### PR TITLE
Several fixes to plain text report

### DIFF
--- a/miniprofiler-core/src/main/java/io/jdev/miniprofiler/Timing.java
+++ b/miniprofiler-core/src/main/java/io/jdev/miniprofiler/Timing.java
@@ -124,6 +124,13 @@ public interface Timing extends Closeable {
     List<Timing> getChildren();
 
     /**
+     * Returns all child timings of this timing, including in child profilers.
+     *
+     * @return all children
+     */
+    List<Timing> getAllChildren();
+
+    /**
      * Add a custom timing to this timing.
      * @param type type of timing, e.g. "sql"
      * @param executeType what type of execution, e.g. "query"

--- a/miniprofiler-core/src/main/java/io/jdev/miniprofiler/internal/NullTiming.java
+++ b/miniprofiler-core/src/main/java/io/jdev/miniprofiler/internal/NullTiming.java
@@ -96,6 +96,11 @@ class NullTiming implements Timing {
     }
 
     @Override
+    public List<Timing> getAllChildren() {
+        return null;
+    }
+
+    @Override
     public void addCustomTiming(String type, String executeType, String command, long duration) {
     }
 

--- a/miniprofiler-core/src/main/java/io/jdev/miniprofiler/internal/ProfilerImpl.java
+++ b/miniprofiler-core/src/main/java/io/jdev/miniprofiler/internal/ProfilerImpl.java
@@ -279,7 +279,7 @@ public class ProfilerImpl implements Profiler, Serializable, Jsonable {
         while (!timings.isEmpty()) {
             Timing timing = timings.pop();
             appendTimingPrefix(text, timing);
-            text.append(String.format(" %s = %,dms", timing.getName(), timing.getDurationMilliseconds()));
+            text.append(String.format("%s = %,dms", timing.getName(), timing.getDurationMilliseconds()));
 
             Map<String, List<CustomTiming>> customTimings = timing.getCustomTimings();
 
@@ -293,14 +293,14 @@ public class ProfilerImpl implements Profiler, Serializable, Jsonable {
                     }
                     text.append(String.format(" (%s = %,dms in %d cmd%s)",
                         type,
-                        sum, customTimings.size(),
-                        customTimings.size() == 1 ? "" : "s"));
+                        sum, typeCustomTimings.size(),
+                        typeCustomTimings.size() == 1 ? "" : "s"));
                 }
             }
 
             text.append("\n");
 
-            List<Timing> children = timing.getChildren();
+            List<Timing> children = timing.getAllChildren();
             if (children != null) {
                 for (int i = children.size() - 1; i >= 0; i--) {
                     timings.push(children.get(i));
@@ -315,6 +315,9 @@ public class ProfilerImpl implements Profiler, Serializable, Jsonable {
         int depth = timing.getDepth();
         for (int i = 0; i < depth; i++) {
             sb.append('>');
+        }
+        if (depth > 0) {
+            sb.append(' ');
         }
     }
 

--- a/miniprofiler-core/src/main/java/io/jdev/miniprofiler/internal/TimingImpl.java
+++ b/miniprofiler-core/src/main/java/io/jdev/miniprofiler/internal/TimingImpl.java
@@ -129,14 +129,15 @@ public class TimingImpl implements TimingInternal, Serializable, Jsonable {
         map.put("Name", name);
         map.put("StartMilliseconds", startMilliseconds);
         map.put("DurationMilliseconds", durationMilliseconds);
-        map.put("Children", allChildren());
+        map.put("Children", getAllChildren());
         if (customTimings != null) {
             map.put("CustomTimings", customTimings);
         }
         return map;
     }
 
-    private List<Timing> allChildren() {
+    @Override
+    public List<Timing> getAllChildren() {
         if (children == null && childProfilers == null) {
             return null;
         }


### PR DESCRIPTION
- Include child profilers
- Report number of commands correctly
- Don't indent top-level timings