### PR TITLE
Add build.base plugin with sanityCheck lifecycle task

### DIFF
--- a/doc/manual/manual.gradle.kts
+++ b/doc/manual/manual.gradle.kts
@@ -17,8 +17,9 @@ import java.awt.Desktop.getDesktop
  */
 
 plugins {
-    alias(libs.plugins.asciidoctor)
+    id("build.base")
     id("build.publish")
+    alias(libs.plugins.asciidoctor)
 }
 
 repositories {
@@ -27,6 +28,10 @@ repositories {
 
 tasks.asciidoctor.configure {
     baseDirFollowsSourceDir()
+}
+
+tasks.named("sanityCheck") {
+    dependsOn(tasks.named("asciidoctor"))
 }
 
 val api by tasks.registering(Javadoc::class) {

--- a/gradle/plugins/src/main/kotlin/build.base.gradle.kts
+++ b/gradle/plugins/src/main/kotlin/build.base.gradle.kts
@@ -1,0 +1,20 @@
+/*
+ * Copyright 2026 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+tasks.register("sanityCheck") {
+    group = "verification"
+    description = "Lifecycle task: compiles all code, runs quality checks and generates documentation"
+}

--- a/gradle/plugins/src/main/kotlin/build.java-module.gradle.kts
+++ b/gradle/plugins/src/main/kotlin/build.java-module.gradle.kts
@@ -18,6 +18,7 @@ import org.gradle.accessors.dm.LibrariesForLibs
 import org.gradle.api.tasks.testing.logging.TestExceptionFormat
 
 plugins {
+    id("build.base")
     id("build.checkstyle")
     id("build.codenarc")
     id("groovy")
@@ -69,4 +70,11 @@ if (!project.path.startsWith(":integration-test:")) {
             runtimeClasspath += sourceSets.main.get().compileClasspath
         }
     }
+}
+
+tasks.named("sanityCheck") {
+    dependsOn(tasks.withType<AbstractCompile>())
+    dependsOn(tasks.withType<Checkstyle>())
+    dependsOn(tasks.withType<CodeNarc>())
+    dependsOn(tasks.withType<Javadoc>())
 }


### PR DESCRIPTION
## Summary

- Adds a new `build.base` convention plugin that registers a `sanityCheck` lifecycle task in the `verification` group
- `build.java-module` applies `build.base` and wires `sanityCheck` to depend on all compile tasks (`AbstractCompile`), Checkstyle, CodeNarc, and Javadoc tasks
- `doc/manual` applies `build.base` and wires `sanityCheck` to depend on the `asciidoctor` task; also reorders plugin declarations with `id()` entries before `alias()`

## Test plan

- [ ] Run `~/.gain/bin/gain :miniprofiler-core:sanityCheck` and verify compile, Checkstyle, CodeNarc, and Javadoc tasks execute
- [ ] Run `~/.gain/bin/gain :doc:manual:sanityCheck` and verify the `asciidoctor` task executes
- [ ] Run `~/.gain/bin/gain sanityCheck` to verify all modules pick up the task without errors