### PR TITLE
Add automated release workflows

### DIFF
--- a/.github/workflows/gradle-release.yml
+++ b/.github/workflows/gradle-release.yml
@@ -1,0 +1,79 @@
+name: "Release"
+on:
+  workflow_dispatch:
+    inputs:
+      releaseVersion:
+        description: "Release version (default: strip -SNAPSHOT from current)"
+        required: false
+        default: ""
+
+permissions:
+  contents: write
+
+jobs:
+  release:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+          token: ${{ secrets.RELEASE_PAT || secrets.GITHUB_TOKEN }}
+
+      - uses: actions/setup-java@v5
+        with:
+          distribution: temurin
+          java-version: |
+            8
+            11
+            17
+
+      - name: Setup Gradle
+        uses: gradle/actions/setup-gradle@v5
+
+      - name: Configure git
+        run: |
+          git config user.name "${{ github.actor }}"
+          git config user.email "${{ github.actor_id }}+${{ github.actor }}@users.noreply.github.com"
+
+      - name: Compute release version
+        id: versions
+        run: |
+          SNAPSHOT_VERSION=$(grep -oP '(?<=version = ")[^"]+' miniprofiler-jvm.gradle.kts)
+          if [ -n "${{ github.event.inputs.releaseVersion }}" ]; then
+            RELEASE_VERSION="${{ github.event.inputs.releaseVersion }}"
+          else
+            RELEASE_VERSION="${SNAPSHOT_VERSION%-SNAPSHOT}"
+          fi
+          echo "release_version=$RELEASE_VERSION" >> "$GITHUB_OUTPUT"
+
+      - name: Stamp release version
+        run: |
+          RELEASE_VERSION="${{ steps.versions.outputs.release_version }}"
+          sed -i "s/version = \".*-SNAPSHOT\"/version = \"${RELEASE_VERSION}\"/" miniprofiler-jvm.gradle.kts
+          sed -i "s/    version: .*/    version: ${RELEASE_VERSION}/" README.md
+
+      - name: Run checks
+        env:
+          CI: true
+        run: ./gradlew check -x integrationTest
+
+      - name: Commit release version
+        run: |
+          RELEASE_VERSION="${{ steps.versions.outputs.release_version }}"
+          git add miniprofiler-jvm.gradle.kts README.md
+          git diff --cached --quiet || git commit -m "Release ${RELEASE_VERSION}"
+
+      - name: Publish to Maven Central
+        env:
+          ORG_GRADLE_PROJECT_sonatypeUsername: ${{ secrets.SONATYPE_USERNAME }}
+          ORG_GRADLE_PROJECT_sonatypePassword: ${{ secrets.SONATYPE_PASSWORD }}
+          ORG_GRADLE_PROJECT_signingKey: ${{ secrets.SIGNING_KEY }}
+          ORG_GRADLE_PROJECT_signingPassword: ${{ secrets.SIGNING_PASSWORD }}
+        run: ./gradlew publishToSonatype closeAndReleaseSonatypeStagingRepository --no-parallel
+
+      - name: Tag release and push
+        run: |
+          RELEASE_VERSION="${{ steps.versions.outputs.release_version }}"
+          git tag "v${RELEASE_VERSION}"
+          git push origin main
+          git push origin "v${RELEASE_VERSION}"

--- a/.github/workflows/gradle-validate-release-artifacts.yml
+++ b/.github/workflows/gradle-validate-release-artifacts.yml
@@ -1,0 +1,56 @@
+name: "Validate release artifacts"
+on:
+  workflow_run:
+    workflows: ["Release"]
+    types: [completed]
+  workflow_dispatch:
+
+jobs:
+  validate:
+    runs-on: ubuntu-latest
+    if: ${{ github.event_name == 'workflow_dispatch' || github.event.workflow_run.conclusion == 'success' }}
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Read version
+        id: version
+        run: |
+          VERSION=$(grep -oP '(?<=version = ")[^"]+' miniprofiler-jvm.gradle.kts)
+          echo "version=$VERSION" >> "$GITHUB_OUTPUT"
+
+      - name: Check artifacts on Maven Central
+        run: |
+          VERSION="${{ steps.version.outputs.version }}"
+          BASE_URL="https://repo1.maven.org/maven2/io/jdev/miniprofiler"
+          ARTIFACTS=(
+            miniprofiler-core
+            miniprofiler-servlet
+            miniprofiler-javaee
+            miniprofiler-jooq
+            miniprofiler-ratpack
+            miniprofiler-grails
+            miniprofiler-viewer
+            miniprofiler-test-support
+            miniprofiler-manual
+          )
+          MAX_WAIT=600
+          INTERVAL=30
+          for ARTIFACT in "${ARTIFACTS[@]}"; do
+            URL="${BASE_URL}/${ARTIFACT}/${VERSION}/${ARTIFACT}-${VERSION}.pom"
+            echo "Checking $URL"
+            ELAPSED=0
+            while true; do
+              STATUS=$(curl -s -o /dev/null -w "%{http_code}" "$URL")
+              if [ "$STATUS" = "200" ]; then
+                echo "  OK"
+                break
+              fi
+              if [ $ELAPSED -ge $MAX_WAIT ]; then
+                echo "  Not available after ${MAX_WAIT}s (HTTP $STATUS)"
+                exit 1
+              fi
+              echo "  HTTP $STATUS, retrying in ${INTERVAL}s..."
+              sleep $INTERVAL
+              ELAPSED=$((ELAPSED + INTERVAL))
+            done
+          done

--- a/.github/workflows/gradle-version-bump.yml
+++ b/.github/workflows/gradle-version-bump.yml
@@ -1,0 +1,53 @@
+name: "Version bump"
+on:
+  workflow_run:
+    workflows: ["Validate release artifacts"]
+    types: [completed]
+  workflow_dispatch:
+    inputs:
+      nextVersion:
+        description: "Next dev version (default: auto-increment patch or minor)"
+        required: false
+        default: ""
+
+permissions:
+  contents: write
+
+jobs:
+  version-bump:
+    runs-on: ubuntu-latest
+    if: ${{ github.event_name == 'workflow_dispatch' || github.event.workflow_run.conclusion == 'success' }}
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          token: ${{ secrets.RELEASE_PAT || secrets.GITHUB_TOKEN }}
+
+      - name: Configure git
+        run: |
+          git config user.name "${{ github.actor }}"
+          git config user.email "${{ github.actor_id }}+${{ github.actor }}@users.noreply.github.com"
+
+      - name: Compute next version
+        id: versions
+        run: |
+          CURRENT_VERSION=$(grep -oP '(?<=version = ")[^"]+' miniprofiler-jvm.gradle.kts)
+          RELEASE_VERSION="${CURRENT_VERSION%-SNAPSHOT}"
+          if [ -n "${{ github.event.inputs.nextVersion }}" ]; then
+            NEXT_VERSION="${{ github.event.inputs.nextVersion }}"
+          else
+            IFS='.' read -r MAJOR MINOR PATCH <<< "$RELEASE_VERSION"
+            if [ "$PATCH" != "0" ]; then
+              NEXT_VERSION="${MAJOR}.${MINOR}.$((PATCH + 1))-SNAPSHOT"
+            else
+              NEXT_VERSION="${MAJOR}.$((MINOR + 1)).0-SNAPSHOT"
+            fi
+          fi
+          echo "next_version=$NEXT_VERSION" >> "$GITHUB_OUTPUT"
+
+      - name: Stamp next snapshot version
+        run: |
+          NEXT_VERSION="${{ steps.versions.outputs.next_version }}"
+          sed -i "s/version = \"[^\"]*\"/version = \"${NEXT_VERSION}\"/" miniprofiler-jvm.gradle.kts
+          git add miniprofiler-jvm.gradle.kts
+          git commit -m "Begin development of ${NEXT_VERSION}"
+          git push origin main

--- a/gradle/plugins/src/main/kotlin/build.publish.gradle.kts
+++ b/gradle/plugins/src/main/kotlin/build.publish.gradle.kts
@@ -58,6 +58,11 @@ publishing {
 val isSnapshot = (project.version as String).endsWith("-SNAPSHOT")
 
 signing {
+    val signingKey: String? = findProperty("signingKey") as String?
+    val signingPassword: String? = findProperty("signingPassword") as String?
+    if (signingKey != null && signingPassword != null) {
+        useInMemoryPgpKeys(signingKey, signingPassword)
+    }
     sign(publishing.publications["maven"])
     setRequired(project.provider {
         val publishingToStaging = !isSnapshot && gradle.taskGraph.hasTask("${project.path}:publishToSonatype")


### PR DESCRIPTION
## Summary

- Adds `gradle-release` workflow: manually triggered via `workflow_dispatch`, stamps the release version, runs checks (excluding integration tests), publishes to Maven Central via Sonatype, tags and pushes
- Adds `gradle-validate-release-artifacts` workflow: triggered on release completion, polls `repo1.maven.org` until all published artifacts are available (up to 10 minutes)
- Adds `gradle-version-bump` workflow: triggered on successful artifact validation, bumps `miniprofiler-jvm.gradle.kts` to the next snapshot version and pushes
- Updates `build.publish` to support in-memory PGP signing via `ORG_GRADLE_PROJECT_signingKey` / `ORG_GRADLE_PROJECT_signingPassword` env vars (falls back to keyring-based signing locally)

## New secrets required

| Secret | Content |
|--------|---------|
| `SIGNING_KEY` | ASCII-armored GPG private key (`gpg --armor --export-secret-keys <KEY_ID>`) |
| `SIGNING_PASSWORD` | Passphrase for the GPG key |
| `RELEASE_PAT` | GitHub PAT with `repo` scope (only needed if branch protection blocks `GITHUB_TOKEN` pushes) |

`SONATYPE_USERNAME` and `SONATYPE_PASSWORD` already exist.

## Test plan

- [ ] Verify new secrets are configured in GitHub repository settings
- [ ] Trigger `gradle-release` workflow manually on a snapshot branch and confirm it publishes successfully
- [ ] Confirm `gradle-validate-release-artifacts` runs automatically and passes
- [ ] Confirm `gradle-version-bump` runs automatically and pushes the next snapshot commit