### PR TITLE
Publish viewer fat jar to Maven Central instead of thin jar

### DIFF
--- a/miniprofiler-viewer/miniprofiler-viewer.gradle.kts
+++ b/miniprofiler-viewer/miniprofiler-viewer.gradle.kts
@@ -41,7 +41,13 @@ tasks.withType<Test>().configureEach {
     systemProperty("miniprofiler.viewer.testFixturesDir", testFixturesResourceDir)
 }
 
-val shadowJarTask = tasks.named<ShadowJar>("shadowJar")
+val shadowJarTask = tasks.named<ShadowJar>("shadowJar") {
+    archiveClassifier.set("")
+}
+
+tasks.named<Jar>("jar") {
+    archiveClassifier.set("original")
+}
 
 tasks.named<Test>("integrationTest") {
     dependsOn(shadowJarTask)
@@ -50,7 +56,9 @@ tasks.named<Test>("integrationTest") {
 
 publishing {
     publications.named<MavenPublication>("maven") {
-        from(components["java"])
+        artifact(shadowJarTask)
+        artifact(tasks.named("sourcesJar"))
+        artifact(tasks.named("javadocJar"))
         pom {
             name = "MiniProfiler Standalone Viewer"
             description = "Standalone app to allow viewing saved profiles."


### PR DESCRIPTION
## Summary

- The `publishing` block in `miniprofiler-viewer` was using `from(components["java"])`, which published the regular thin jar (~8KB) rather than the fat jar (~222KB) containing all bundled dependencies
- Switched to explicitly publishing the shadow jar as the primary artifact (empty classifier), with the regular jar given an `"original"` classifier to avoid filename conflicts
- Sources and javadoc jars are added explicitly to the publication since they're no longer pulled in via the java component
- The POM correctly has no runtime dependencies listed, since they're all bundled inside the fat jar

## Test plan

- [x] `miniprofiler-viewer:check` passes (15/15 tests)
- [x] `publishToMavenLocal` produces the fat jar as the primary artifact (verified by file size: 222KB vs 8KB for the thin jar)
- [x] Full project `check` passes