### PR TITLE
Add ProfilerProviderLocator SPI and cross-version ORM integration tests

### DIFF
--- a/core/src/main/java/io/jdev/miniprofiler/ProfilerProviderLocator.java
+++ b/core/src/main/java/io/jdev/miniprofiler/ProfilerProviderLocator.java
@@ -1,0 +1,70 @@
+/*
+ * Copyright 2026 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.jdev.miniprofiler;
+
+import java.util.ArrayList;
+import java.util.Comparator;
+import java.util.List;
+import java.util.Optional;
+import java.util.ServiceLoader;
+
+/**
+ * SPI for locating the current {@link ProfilerProvider}. Implementations are
+ * discovered via {@link ServiceLoader} and consulted in ascending {@link #getOrder()}
+ * order. The first implementation that returns a non-empty {@link Optional} wins.
+ *
+ * <p>A {@link StaticProfilerProviderLocator} is registered by default in
+ * {@code miniprofiler-core} at order 100 as a fallback. CDI-aware implementations
+ * in {@code miniprofiler-javax-ee} (order 20) and {@code miniprofiler-jakarta-ee}
+ * (order 10) take precedence when present on the classpath.</p>
+ */
+public interface ProfilerProviderLocator {
+
+    /**
+     * Returns the order of this locator. Lower values are consulted first.
+     */
+    int getOrder();
+
+    /**
+     * Attempts to locate a {@link ProfilerProvider}. Returns an empty
+     * {@link Optional} if this locator is not applicable in the current environment.
+     */
+    Optional<ProfilerProvider> locate();
+
+    /**
+     * Discovers all registered {@link ProfilerProviderLocator} implementations via
+     * {@link ServiceLoader}, sorts them by {@link #getOrder()}, and returns the
+     * result of the first one that returns a non-empty {@link Optional}.
+     *
+     * <p>Falls back to a new {@link StaticProfilerProvider} if no locator succeeds,
+     * though in practice the {@link StaticProfilerProviderLocator} always succeeds.</p>
+     */
+    static ProfilerProvider findProvider() {
+        List<ProfilerProviderLocator> locators = new ArrayList<>();
+        for (ProfilerProviderLocator locator : ServiceLoader.load(ProfilerProviderLocator.class)) {
+            locators.add(locator);
+        }
+        locators.sort(Comparator.comparingInt(ProfilerProviderLocator::getOrder));
+        for (ProfilerProviderLocator locator : locators) {
+            Optional<ProfilerProvider> provider = locator.locate();
+            if (provider.isPresent()) {
+                return provider.get();
+            }
+        }
+        throw new IllegalStateException("No ProfilerProviderLocator returned a provider. Ensure miniprofiler-core is on the classpath.");
+    }
+}

--- a/core/src/main/java/io/jdev/miniprofiler/StaticProfilerProviderLocator.java
+++ b/core/src/main/java/io/jdev/miniprofiler/StaticProfilerProviderLocator.java
@@ -14,14 +14,24 @@
  * limitations under the License.
  */
 
-package io.jdev.miniprofiler.jakarta.ee;
+package io.jdev.miniprofiler;
 
-import io.jdev.miniprofiler.DefaultProfilerProvider;
+import java.util.Optional;
 
-import jakarta.enterprise.context.ApplicationScoped;
-import jakarta.enterprise.inject.Default;
+/**
+ * Fallback {@link ProfilerProviderLocator} that always returns a
+ * {@link StaticProfilerProvider}, delegating to whatever has been configured
+ * on {@link MiniProfiler}.
+ */
+public class StaticProfilerProviderLocator implements ProfilerProviderLocator {
 
-@ApplicationScoped
-@Default
-public class DefaultCDIProfilerProvider extends DefaultProfilerProvider {
+    @Override
+    public int getOrder() {
+        return 100;
+    }
+
+    @Override
+    public Optional<ProfilerProvider> locate() {
+        return Optional.of(new StaticProfilerProvider());
+    }
 }

--- a/core/src/main/resources/META-INF/services/io.jdev.miniprofiler.ProfilerProviderLocator
+++ b/core/src/main/resources/META-INF/services/io.jdev.miniprofiler.ProfilerProviderLocator
@@ -1,0 +1,1 @@
+io.jdev.miniprofiler.StaticProfilerProviderLocator

--- a/core/src/test/groovy/io/jdev/miniprofiler/ProfilerProviderLocatorSpec.groovy
+++ b/core/src/test/groovy/io/jdev/miniprofiler/ProfilerProviderLocatorSpec.groovy
@@ -1,0 +1,84 @@
+/*
+ * Copyright 2026 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.jdev.miniprofiler
+
+import spock.lang.Specification
+
+class ProfilerProviderLocatorSpec extends Specification {
+
+    void "StaticProfilerProviderLocator has order 100"() {
+        expect:
+        new StaticProfilerProviderLocator().order == 100
+    }
+
+    void "StaticProfilerProviderLocator returns a StaticProfilerProvider"() {
+        when:
+        def result = new StaticProfilerProviderLocator().locate()
+
+        then:
+        result.present
+        result.get() instanceof StaticProfilerProvider
+    }
+
+    void "findProvider returns a provider via ServiceLoader"() {
+        when:
+        def provider = ProfilerProviderLocator.findProvider()
+
+        then:
+        provider != null
+    }
+
+    void "findProvider returns provider from lowest-order locator"() {
+        given: 'a low-order locator returning a specific provider'
+        def expectedProvider = Mock(ProfilerProvider)
+        def lowOrderLocator = new ProfilerProviderLocator() {
+            int getOrder() { return 1 }
+            Optional<ProfilerProvider> locate() { Optional.of(expectedProvider) }
+        }
+        def highOrderLocator = new ProfilerProviderLocator() {
+            int getOrder() { return 99 }
+            Optional<ProfilerProvider> locate() { throw new AssertionError("should not be called") }
+        }
+
+        when:
+        def locators = [highOrderLocator, lowOrderLocator].sort { it.order }
+        def result = locators.findResult { it.locate().orElse(null) }
+
+        then:
+        result == expectedProvider
+    }
+
+    void "findProvider skips locators returning empty optional"() {
+        given:
+        def expectedProvider = Mock(ProfilerProvider)
+        def emptyLocator = new ProfilerProviderLocator() {
+            int getOrder() { return 1 }
+            Optional<ProfilerProvider> locate() { Optional.empty() }
+        }
+        def successLocator = new ProfilerProviderLocator() {
+            int getOrder() { return 2 }
+            Optional<ProfilerProvider> locate() { Optional.of(expectedProvider) }
+        }
+
+        when:
+        def locators = [emptyLocator, successLocator].sort { it.order }
+        def result = locators.findResult { it.locate().orElse(null) }
+
+        then:
+        result == expectedProvider
+    }
+}

--- a/eclipselink/eclipselink.gradle.kts
+++ b/eclipselink/eclipselink.gradle.kts
@@ -19,14 +19,66 @@ plugins {
     id("build.publish")
 }
 
+java {
+    toolchain {
+        // EclipseLink 4+ class files require a Java 11 compiler to read
+        languageVersion = JavaLanguageVersion.of(11)
+    }
+}
+
+tasks.withType<JavaCompile>().matching { it.name == "compileJava" }.configureEach {
+    // Output Java 8 bytecode so the module can deploy to Java 8 containers (e.g. GlassFish 4)
+    options.release = 8
+}
+
+// Compiled against EclipseLink 4.x which has both the legacy config.SessionCustomizer and
+// the current sessions.SessionCustomizer, allowing ProfilingSessionCustomizer and
+// LegacyProfilingSessionCustomizer to coexist in the same compilation unit.
 dependencies {
     api(projects.core)
-    compileOnly(libs.eclipselink) {
+    compileOnly(libs.eclipselink.v4) {
         isTransitive = false
     }
     testImplementation(projects.test)
-    testImplementation(libs.eclipselink) {
+    testImplementation(libs.eclipselink.v4) {
         isTransitive = false
+    }
+}
+
+addCrossVersionTestSuite("crossVersionTestEclipseLink2", 8) {
+    dependencies {
+        implementation(libs.eclipselink.v2)
+        implementation(libs.h2)
+    }
+}
+addCrossVersionTestSuite("crossVersionTestEclipseLink3", 11) {
+    dependencies {
+        implementation(libs.eclipselink.v3)
+        implementation(libs.h2)
+    }
+}
+val crossVersionTestEclipseLink4 = addCrossVersionTestSuite("crossVersionTestEclipseLink4", 11) {
+    dependencies {
+        implementation(libs.eclipselink.v4)
+        implementation(libs.h2)
+    }
+}
+addCrossVersionTestSuite("crossVersionTestEclipseLink5", 17) {
+    dependencies {
+        implementation(libs.eclipselink.v5)
+        implementation(libs.h2)
+    }
+}
+
+tasks.named("check") { dependsOn(crossVersionTestEclipseLink4) }
+
+// Force older EclipseLink versions in suites where the inherited v4 would otherwise win
+listOf("CompileClasspath", "RuntimeClasspath").forEach { suffix ->
+    configurations.named("crossVersionTestEclipseLink2$suffix") {
+        resolutionStrategy.force("org.eclipse.persistence:eclipselink:2.7.12")
+    }
+    configurations.named("crossVersionTestEclipseLink3$suffix") {
+        resolutionStrategy.force("org.eclipse.persistence:eclipselink:3.0.4")
     }
 }
 

--- a/eclipselink/eclipselink.gradle.kts
+++ b/eclipselink/eclipselink.gradle.kts
@@ -24,6 +24,10 @@ dependencies {
     compileOnly(libs.eclipselink) {
         isTransitive = false
     }
+    testImplementation(projects.test)
+    testImplementation(libs.eclipselink) {
+        isTransitive = false
+    }
 }
 
 publishing {

--- a/eclipselink/src/crossVersionTest/groovy/io/jdev/miniprofiler/eclipselink/EclipseLinkCrossVersionSpec.groovy
+++ b/eclipselink/src/crossVersionTest/groovy/io/jdev/miniprofiler/eclipselink/EclipseLinkCrossVersionSpec.groovy
@@ -1,0 +1,120 @@
+/*
+ * Copyright 2026 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.jdev.miniprofiler.eclipselink
+
+import io.jdev.miniprofiler.MiniProfiler
+import io.jdev.miniprofiler.Profiler
+import io.jdev.miniprofiler.test.TestProfilerProvider
+import io.jdev.miniprofiler.test.TestProfilerProviderLocator
+import org.eclipse.persistence.sessions.DatabaseLogin
+import org.eclipse.persistence.sessions.Project
+import spock.lang.Requires
+import spock.lang.Specification
+
+/**
+ * Tests {@link ProfilingSessionCustomizer} which implements
+ * {@code org.eclipse.persistence.sessions.SessionCustomizer} (EclipseLink 4+).
+ */
+@Requires({ classExists('org.eclipse.persistence.sessions.SessionCustomizer') })
+class EclipseLinkCrossVersionSpec extends Specification {
+
+    TestProfilerProvider profilerProvider = new TestProfilerProvider()
+
+    void cleanup() {
+        TestProfilerProviderLocator.deactivate()
+        MiniProfiler.profilerProvider = null
+    }
+
+    void "DI mode: constructor-injected provider captures SQL"() {
+        given:
+        def profiler = profilerProvider.start("di-test")
+        def dbSession = createSession("eclipselink_di_test")
+
+        def customizer = new ProfilingSessionCustomizer(profilerProvider)
+        customizer.customize(dbSession)
+        dbSession.login()
+
+        when:
+        dbSession.executeSQL("SELECT 1")
+
+        then:
+        hasProfiledSql(profiler, "SELECT 1")
+
+        cleanup:
+        dbSession?.logout()
+        profiler?.stop()
+    }
+
+    void "ServiceLoader mode: profiler provider discovered via locator captures SQL"() {
+        given:
+        TestProfilerProviderLocator.activate(profilerProvider)
+        def profiler = profilerProvider.start("serviceloader-test")
+        def dbSession = createSession("eclipselink_sl_test")
+
+        def customizer = new ProfilingSessionCustomizer()
+        customizer.customize(dbSession)
+        dbSession.login()
+
+        when:
+        dbSession.executeSQL("SELECT 1")
+
+        then:
+        hasProfiledSql(profiler, "SELECT 1")
+
+        cleanup:
+        dbSession?.logout()
+        profiler?.stop()
+    }
+
+    void "Static fallback mode: falls through to MiniProfiler static provider"() {
+        given:
+        TestProfilerProviderLocator.deactivate()
+        MiniProfiler.profilerProvider = profilerProvider
+        def profiler = profilerProvider.start("static-test")
+        def dbSession = createSession("eclipselink_static_test")
+
+        def customizer = new ProfilingSessionCustomizer()
+        customizer.customize(dbSession)
+        dbSession.login()
+
+        when:
+        dbSession.executeSQL("SELECT 1")
+
+        then:
+        hasProfiledSql(profiler, "SELECT 1")
+
+        cleanup:
+        dbSession?.logout()
+        profiler?.stop()
+    }
+
+    private static createSession(String dbName) {
+        def login = new DatabaseLogin()
+        login.setDriverClassName("org.h2.Driver")
+        login.setConnectionString("jdbc:h2:mem:${dbName};DB_CLOSE_DELAY=-1")
+        new Project(login).createDatabaseSession()
+    }
+
+    private static boolean hasProfiledSql(Profiler profiler, String expectedFragment) {
+        def sqlTimings = profiler.root.customTimings["sql"]
+        return sqlTimings != null && sqlTimings.any { it.commandString.contains(expectedFragment) }
+    }
+
+    private static boolean classExists(String name) {
+        try { Class.forName(name); true } catch (ClassNotFoundException e) { false }
+    }
+}

--- a/eclipselink/src/crossVersionTest/groovy/io/jdev/miniprofiler/eclipselink/LegacyEclipseLinkCrossVersionSpec.groovy
+++ b/eclipselink/src/crossVersionTest/groovy/io/jdev/miniprofiler/eclipselink/LegacyEclipseLinkCrossVersionSpec.groovy
@@ -1,0 +1,120 @@
+/*
+ * Copyright 2026 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.jdev.miniprofiler.eclipselink
+
+import io.jdev.miniprofiler.MiniProfiler
+import io.jdev.miniprofiler.Profiler
+import io.jdev.miniprofiler.test.TestProfilerProvider
+import io.jdev.miniprofiler.test.TestProfilerProviderLocator
+import org.eclipse.persistence.sessions.DatabaseLogin
+import org.eclipse.persistence.sessions.Project
+import spock.lang.Requires
+import spock.lang.Specification
+
+/**
+ * Tests {@link LegacyProfilingSessionCustomizer} which implements
+ * {@code org.eclipse.persistence.config.SessionCustomizer} (EclipseLink 2.x/3.x).
+ */
+@Requires({ classExists('org.eclipse.persistence.config.SessionCustomizer') })
+class LegacyEclipseLinkCrossVersionSpec extends Specification {
+
+    TestProfilerProvider profilerProvider = new TestProfilerProvider()
+
+    void cleanup() {
+        TestProfilerProviderLocator.deactivate()
+        MiniProfiler.profilerProvider = null
+    }
+
+    void "DI mode: constructor-injected provider captures SQL"() {
+        given:
+        def profiler = profilerProvider.start("legacy-di-test")
+        def dbSession = createSession("eclipselink_legacy_di_test")
+
+        def customizer = new LegacyProfilingSessionCustomizer(profilerProvider)
+        customizer.customize(dbSession)
+        dbSession.login()
+
+        when:
+        dbSession.executeSQL("SELECT 1")
+
+        then:
+        hasProfiledSql(profiler, "SELECT 1")
+
+        cleanup:
+        dbSession?.logout()
+        profiler?.stop()
+    }
+
+    void "ServiceLoader mode: profiler provider discovered via locator captures SQL"() {
+        given:
+        TestProfilerProviderLocator.activate(profilerProvider)
+        def profiler = profilerProvider.start("legacy-serviceloader-test")
+        def dbSession = createSession("eclipselink_legacy_sl_test")
+
+        def customizer = new LegacyProfilingSessionCustomizer()
+        customizer.customize(dbSession)
+        dbSession.login()
+
+        when:
+        dbSession.executeSQL("SELECT 1")
+
+        then:
+        hasProfiledSql(profiler, "SELECT 1")
+
+        cleanup:
+        dbSession?.logout()
+        profiler?.stop()
+    }
+
+    void "Static fallback mode: falls through to MiniProfiler static provider"() {
+        given:
+        TestProfilerProviderLocator.deactivate()
+        MiniProfiler.profilerProvider = profilerProvider
+        def profiler = profilerProvider.start("legacy-static-test")
+        def dbSession = createSession("eclipselink_legacy_static_test")
+
+        def customizer = new LegacyProfilingSessionCustomizer()
+        customizer.customize(dbSession)
+        dbSession.login()
+
+        when:
+        dbSession.executeSQL("SELECT 1")
+
+        then:
+        hasProfiledSql(profiler, "SELECT 1")
+
+        cleanup:
+        dbSession?.logout()
+        profiler?.stop()
+    }
+
+    private static createSession(String dbName) {
+        def login = new DatabaseLogin()
+        login.setDriverClassName("org.h2.Driver")
+        login.setConnectionString("jdbc:h2:mem:${dbName};DB_CLOSE_DELAY=-1")
+        new Project(login).createDatabaseSession()
+    }
+
+    private static boolean hasProfiledSql(Profiler profiler, String expectedFragment) {
+        def sqlTimings = profiler.root.customTimings["sql"]
+        return sqlTimings != null && sqlTimings.any { it.commandString.contains(expectedFragment) }
+    }
+
+    private static boolean classExists(String name) {
+        try { Class.forName(name); true } catch (ClassNotFoundException e) { false }
+    }
+}

--- a/eclipselink/src/crossVersionTest/resources/META-INF/services/io.jdev.miniprofiler.ProfilerProviderLocator
+++ b/eclipselink/src/crossVersionTest/resources/META-INF/services/io.jdev.miniprofiler.ProfilerProviderLocator
@@ -1,0 +1,1 @@
+io.jdev.miniprofiler.test.TestProfilerProviderLocator

--- a/eclipselink/src/main/java/io/jdev/miniprofiler/eclipselink/LegacyProfilingSessionCustomizer.java
+++ b/eclipselink/src/main/java/io/jdev/miniprofiler/eclipselink/LegacyProfilingSessionCustomizer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014 the original author or authors.
+ * Copyright 2026 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -18,26 +18,28 @@ package io.jdev.miniprofiler.eclipselink;
 
 import io.jdev.miniprofiler.ProfilerProvider;
 import org.eclipse.persistence.sessions.Session;
-import org.eclipse.persistence.sessions.SessionCustomizer;
 
 /**
- * An EclipseLink SessionCustomizer that installs a
- * {@link ProfilingConnector} onto EclipseLink's read and write pools.
+ * A {@link org.eclipse.persistence.config.SessionCustomizer} for EclipseLink 2.x
+ * and 3.x, where the {@code org.eclipse.persistence.config.SessionCustomizer}
+ * interface is the primary customizer contract.
  *
- * <p>The customizer can be installed by setting the
- * <code>eclipselink.session.customizer</code> property to this class name
- * <code>io.jdev.miniprofiler.eclipselink.ProfilingSessionCustomizer</code>
- * </p>
+ * <p>For EclipseLink 4.x and later, use {@link ProfilingSessionCustomizer} which
+ * implements the newer {@code org.eclipse.persistence.sessions.SessionCustomizer}
+ * interface.</p>
+ *
+ * @see ProfilingSessionCustomizer
  */
-public class ProfilingSessionCustomizer implements SessionCustomizer {
+@SuppressWarnings("deprecation")
+public class LegacyProfilingSessionCustomizer implements org.eclipse.persistence.config.SessionCustomizer {
 
     private final ProfilerProvider profilerProvider;
 
-    public ProfilingSessionCustomizer() {
+    public LegacyProfilingSessionCustomizer() {
         this.profilerProvider = null;
     }
 
-    public ProfilingSessionCustomizer(ProfilerProvider profilerProvider) {
+    public LegacyProfilingSessionCustomizer(ProfilerProvider profilerProvider) {
         this.profilerProvider = profilerProvider;
     }
 

--- a/eclipselink/src/main/java/io/jdev/miniprofiler/eclipselink/ProfilingSessionCustomizer.java
+++ b/eclipselink/src/main/java/io/jdev/miniprofiler/eclipselink/ProfilingSessionCustomizer.java
@@ -17,7 +17,7 @@
 package io.jdev.miniprofiler.eclipselink;
 
 import io.jdev.miniprofiler.ProfilerProvider;
-import io.jdev.miniprofiler.StaticProfilerProvider;
+import io.jdev.miniprofiler.ProfilerProviderLocator;
 import io.jdev.miniprofiler.sql.ProfilingSpyLogDelegator;
 import io.jdev.miniprofiler.sql.log4jdbc.SpyLogFactory;
 import org.eclipse.persistence.config.SessionCustomizer;
@@ -38,16 +38,21 @@ import org.eclipse.persistence.sessions.server.ServerSession;
  */
 public class ProfilingSessionCustomizer implements SessionCustomizer {
 
+    private final ProfilerProvider profilerProvider;
+
     public ProfilingSessionCustomizer() {
-        this(new StaticProfilerProvider());
+        this.profilerProvider = null;
     }
 
     public ProfilingSessionCustomizer(ProfilerProvider profilerProvider) {
-        SpyLogFactory.setSpyLogDelegator(new ProfilingSpyLogDelegator(profilerProvider));
+        this.profilerProvider = profilerProvider;
     }
 
     @Override
     public void customize(Session session) throws Exception {
+        ProfilerProvider provider = profilerProvider != null ? profilerProvider : ProfilerProviderLocator.findProvider();
+        SpyLogFactory.setSpyLogDelegator(new ProfilingSpyLogDelegator(provider));
+
         DatasourceLogin login = session.getLogin();
         login.setConnector(new ProfilingConnector(login.getConnector()));
         if (session instanceof ServerSession) {

--- a/eclipselink/src/main/java/io/jdev/miniprofiler/eclipselink/SessionCustomizerSupport.java
+++ b/eclipselink/src/main/java/io/jdev/miniprofiler/eclipselink/SessionCustomizerSupport.java
@@ -1,0 +1,53 @@
+/*
+ * Copyright 2026 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.jdev.miniprofiler.eclipselink;
+
+import io.jdev.miniprofiler.ProfilerProvider;
+import io.jdev.miniprofiler.ProfilerProviderLocator;
+import io.jdev.miniprofiler.sql.ProfilingSpyLogDelegator;
+import io.jdev.miniprofiler.sql.log4jdbc.SpyLogFactory;
+import org.eclipse.persistence.sessions.DatasourceLogin;
+import org.eclipse.persistence.sessions.Login;
+import org.eclipse.persistence.sessions.Session;
+import org.eclipse.persistence.sessions.server.ConnectionPool;
+import org.eclipse.persistence.sessions.server.ServerSession;
+
+/**
+ * Shared session customization logic used by both {@link ProfilingSessionCustomizer}
+ * and {@link LegacyProfilingSessionCustomizer}.
+ */
+class SessionCustomizerSupport {
+
+    static void customize(ProfilerProvider explicitProvider, Session session) {
+        ProfilerProvider provider = explicitProvider != null ? explicitProvider : ProfilerProviderLocator.findProvider();
+        SpyLogFactory.setSpyLogDelegator(new ProfilingSpyLogDelegator(provider));
+
+        DatasourceLogin login = session.getLogin();
+        login.setConnector(new ProfilingConnector(login.getConnector()));
+        if (session instanceof ServerSession) {
+            ServerSession serverSession = (ServerSession) session;
+            ConnectionPool pool = serverSession.getReadConnectionPool();
+            if (pool != null) {
+                Login poolLogin = pool.getLogin();
+                if (poolLogin instanceof DatasourceLogin) {
+                    login = (DatasourceLogin) poolLogin;
+                    login.setConnector(new ProfilingConnector(login.getConnector()));
+                }
+            }
+        }
+    }
+}

--- a/eclipselink/src/test/groovy/io/jdev/miniprofiler/eclipselink/ProfilingSessionCustomizerSpec.groovy
+++ b/eclipselink/src/test/groovy/io/jdev/miniprofiler/eclipselink/ProfilingSessionCustomizerSpec.groovy
@@ -1,0 +1,112 @@
+/*
+ * Copyright 2026 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.jdev.miniprofiler.eclipselink
+
+import io.jdev.miniprofiler.MiniProfiler
+import io.jdev.miniprofiler.ProfilerProvider
+import io.jdev.miniprofiler.sql.ProfilingSpyLogDelegator
+import io.jdev.miniprofiler.sql.log4jdbc.SpyLogFactory
+import io.jdev.miniprofiler.test.TestProfilerProvider
+import org.eclipse.persistence.sessions.Connector
+import org.eclipse.persistence.sessions.DatabaseLogin
+import org.eclipse.persistence.sessions.DatasourceLogin
+import org.eclipse.persistence.sessions.Session
+import spock.lang.Specification
+
+class ProfilingSessionCustomizerSpec extends Specification {
+
+    Session session = Mock()
+    DatabaseLogin login = Mock()
+    Connector originalConnector = Mock()
+
+    void setup() {
+        session.getLogin() >> login
+        login.getConnector() >> originalConnector
+    }
+
+    void cleanup() {
+        MiniProfiler.profilerProvider = null
+    }
+
+    void "constructor with provider stores it for use in customize"() {
+        given:
+        def profilerProvider = new TestProfilerProvider()
+        def customizer = new ProfilingSessionCustomizer(profilerProvider)
+
+        when:
+        customizer.customize(session)
+
+        then:
+        SpyLogFactory.spyLogDelegator instanceof ProfilingSpyLogDelegator
+        SpyLogFactory.spyLogDelegator.@profilerProvider == profilerProvider
+    }
+
+    void "no-arg constructor uses ProfilerProviderLocator in customize"() {
+        given:
+        def testProvider = new TestProfilerProvider()
+        MiniProfiler.profilerProvider = testProvider
+        def customizer = new ProfilingSessionCustomizer()
+
+        when:
+        customizer.customize(session)
+
+        then:
+        SpyLogFactory.spyLogDelegator instanceof ProfilingSpyLogDelegator
+
+        and: 'uses the provider resolved via the locator (StaticProfilerProvider -> MiniProfiler)'
+        def profiler = MiniProfiler.start("test")
+        SpyLogFactory.spyLogDelegator.@profilerProvider.current() == profiler
+
+        cleanup:
+        MiniProfiler.profilerProvider?.stopCurrentSession(true)
+    }
+
+    void "customize wraps the session login connector with a ProfilingConnector"() {
+        given:
+        def customizer = new ProfilingSessionCustomizer(Mock(ProfilerProvider))
+
+        when:
+        customizer.customize(session)
+
+        then:
+        1 * login.setConnector({ it instanceof ProfilingConnector && it.@target == originalConnector })
+    }
+
+    void "customize wraps the read pool connector on a ServerSession"() {
+        given:
+        def readPoolLogin = Mock(DatasourceLogin)
+        def readConnector = Mock(Connector)
+        readPoolLogin.getConnector() >> readConnector
+
+        def readPool = Mock(org.eclipse.persistence.sessions.server.ConnectionPool)
+        readPool.getLogin() >> readPoolLogin
+
+        def serverSession = Mock(org.eclipse.persistence.sessions.server.ServerSession)
+        serverSession.getLogin() >> login
+        login.getConnector() >> originalConnector
+        serverSession.getReadConnectionPool() >> readPool
+
+        def customizer = new ProfilingSessionCustomizer(Mock(ProfilerProvider))
+
+        when:
+        customizer.customize(serverSession)
+
+        then:
+        1 * login.setConnector({ it instanceof ProfilingConnector })
+        1 * readPoolLogin.setConnector({ it instanceof ProfilingConnector && it.@target == readConnector })
+    }
+}

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -20,13 +20,18 @@ byte-buddy = "1.18.8"
 checkstyle = "12.3.1"
 codenarc = "3.7.0-groovy-4.0"
 develocity-plugin = "4.3.2"
-eclipselink = "2.7.16"
+eclipselink-v2 = "2.7.12"
+eclipselink-v3 = "3.0.4"
+eclipselink-v4 = "4.0.5"
+eclipselink-v5 = "5.0.0"
 geb-groovy3 = "6.0"
 geb-groovy4 = "8.0.1"
 groovy-v3 = "3.0.25"
 groovy-v4 = "4.0.31"
 h2 = "1.4.200"
-hibernate = "4.3.11.Final"
+hibernate-v5 = "5.6.15.Final"
+hibernate-v6 = "6.6.15.Final"
+hibernate-v7 = "7.0.10.Final"
 jackson = "2.21.2"
 jakarta-ee-api = "9.1.0"
 jakarta-jsp-api = "3.1.1"
@@ -65,7 +70,10 @@ byte-buddy = { module = "net.bytebuddy:byte-buddy", version.ref = "byte-buddy" }
 checkstyle = { module = "com.puppycrawl.tools:checkstyle", version.ref = "checkstyle" }
 codenarc = { module = "org.codenarc:CodeNarc", version.ref = "codenarc" }
 develocity-plugin = { module = "com.gradle:develocity-gradle-plugin", version.ref = "develocity-plugin" }
-eclipselink = { module = "org.eclipse.persistence:eclipselink", version.ref = "eclipselink" }
+eclipselink-v2 = { module = "org.eclipse.persistence:eclipselink", version.ref = "eclipselink-v2" }
+eclipselink-v3 = { module = "org.eclipse.persistence:eclipselink", version.ref = "eclipselink-v3" }
+eclipselink-v4 = { module = "org.eclipse.persistence:eclipselink", version.ref = "eclipselink-v4" }
+eclipselink-v5 = { module = "org.eclipse.persistence:eclipselink", version.ref = "eclipselink-v5" }
 geb-core-groovy3 = { module = "org.gebish:geb-core", version.ref = "geb-groovy3" }
 geb-core-groovy4 = { module = "org.apache.groovy.geb:geb-core", version.ref = "geb-groovy4" }
 geb-spock-groovy3 = { module = "org.gebish:geb-spock", version.ref = "geb-groovy3" }
@@ -73,7 +81,9 @@ geb-spock-groovy4 = { module = "org.apache.groovy.geb:geb-spock", version.ref = 
 groovy-v3 = { module = "org.codehaus.groovy:groovy-all", version.ref = "groovy-v3" }
 groovy-v4 = { module = "org.apache.groovy:groovy-all", version.ref = "groovy-v4" }
 h2 = { module = "com.h2database:h2", version.ref = "h2" }
-hibernate = { module = "org.hibernate:hibernate-core", version.ref = "hibernate" }
+hibernate-v5 = { module = "org.hibernate:hibernate-core",     version.ref = "hibernate-v5" }
+hibernate-v6 = { module = "org.hibernate.orm:hibernate-core", version.ref = "hibernate-v6" }
+hibernate-v7 = { module = "org.hibernate.orm:hibernate-core", version.ref = "hibernate-v7" }
 jackson-databind = { module = "com.fasterxml.jackson.core:jackson-databind", version.ref = "jackson" }
 jakarta-ee-api = { module = "jakarta.platform:jakarta.jakartaee-api", version.ref = "jakarta-ee-api" }
 jakarta-jsp-api = { module = "jakarta.servlet.jsp:jakarta.servlet.jsp-api", version.ref = "jakarta-jsp-api" }

--- a/gradle/plugins/src/main/kotlin/Tests.kt
+++ b/gradle/plugins/src/main/kotlin/Tests.kt
@@ -8,8 +8,10 @@ import org.gradle.api.artifacts.ProjectDependency
 import org.gradle.api.artifacts.VersionCatalogsExtension
 import org.gradle.api.plugins.JavaPluginExtension
 import org.gradle.api.plugins.jvm.JvmTestSuite
+import org.gradle.api.tasks.SourceSetContainer
 import org.gradle.api.provider.Provider
 import org.gradle.api.reporting.ReportingExtension
+import org.gradle.api.tasks.GroovySourceDirectorySet
 import org.gradle.api.tasks.compile.GroovyCompile
 import org.gradle.api.tasks.compile.JavaCompile
 import org.gradle.jvm.toolchain.JavaLanguageVersion
@@ -113,6 +115,26 @@ fun Project.addTestSuite(suiteName: String, minJavaVersion: Int, configure: Acti
     }
 
     return suite!!
+}
+
+fun Project.addCrossVersionTestSuite(
+    suiteName: String, minJavaVersion: Int, configure: Action<JvmTestSuite> = Action {}
+): Provider<JvmTestSuite> {
+    val sourceSets = extensions.getByType(SourceSetContainer::class.java)
+    val suite = addTestSuite(suiteName, minJavaVersion) {
+        dependencies {
+            implementation(sourceSets.named("main").get().output)
+        }
+        configure.execute(this)
+    }
+    sourceSets.named(suiteName) {
+        java.setSrcDirs(emptyList<String>())
+        extensions.getByType(GroovySourceDirectorySet::class.java)
+            .setSrcDirs(listOf("src/crossVersionTest/groovy"))
+        resources.setSrcDirs(listOf("src/crossVersionTest/resources"))
+    }
+    tasks.named("fullCheck") { dependsOn(suite) }
+    return suite
 }
 
 fun DependencyHandlerScope.scenarioTestFixtures(dependency: ProjectDependency): ProjectDependency {

--- a/hibernate/hibernate.gradle.kts
+++ b/hibernate/hibernate.gradle.kts
@@ -24,6 +24,10 @@ dependencies {
     compileOnly(libs.hibernate) {
         isTransitive = false
     }
+    testImplementation(projects.test)
+    testImplementation(libs.hibernate) {
+        isTransitive = false
+    }
 }
 
 publishing {

--- a/hibernate/hibernate.gradle.kts
+++ b/hibernate/hibernate.gradle.kts
@@ -21,12 +21,42 @@ plugins {
 
 dependencies {
     api(projects.core)
-    compileOnly(libs.hibernate) {
+    compileOnly(libs.hibernate.v5) {
         isTransitive = false
     }
     testImplementation(projects.test)
-    testImplementation(libs.hibernate) {
-        isTransitive = false
+    testImplementation(libs.hibernate.v5)
+}
+
+val crossVersionTestHibernate5 = addCrossVersionTestSuite("crossVersionTestHibernate5", 8) {
+    dependencies {
+        implementation(libs.hibernate.v5)
+        implementation(libs.h2)
+    }
+}
+addCrossVersionTestSuite("crossVersionTestHibernate6", 11) {
+    dependencies {
+        implementation(libs.hibernate.v6)
+        implementation(libs.h2)
+    }
+}
+addCrossVersionTestSuite("crossVersionTestHibernate7", 17) {
+    dependencies {
+        implementation(libs.hibernate.v7)
+        implementation(libs.h2)
+    }
+}
+
+tasks.named("check") { dependsOn(crossVersionTestHibernate5) }
+
+configurations {
+    // Exclude the compile-time Hibernate (org.hibernate:hibernate-core) from suites that use
+    // Hibernate 6+, which changed groupId to org.hibernate.orm
+    "crossVersionTestHibernate6Implementation" {
+        exclude(group = "org.hibernate", module = "hibernate-core")
+    }
+    "crossVersionTestHibernate7Implementation" {
+        exclude(group = "org.hibernate", module = "hibernate-core")
     }
 }
 

--- a/hibernate/src/crossVersionTest/groovy/io/jdev/miniprofiler/hibernate/HibernateCrossVersionSpec.groovy
+++ b/hibernate/src/crossVersionTest/groovy/io/jdev/miniprofiler/hibernate/HibernateCrossVersionSpec.groovy
@@ -1,0 +1,116 @@
+/*
+ * Copyright 2026 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.jdev.miniprofiler.hibernate
+
+import io.jdev.miniprofiler.MiniProfiler
+import io.jdev.miniprofiler.Profiler
+import io.jdev.miniprofiler.test.TestProfilerProvider
+import io.jdev.miniprofiler.test.TestProfilerProviderLocator
+import org.h2.jdbcx.JdbcDataSource
+import spock.lang.Specification
+
+class HibernateCrossVersionSpec extends Specification {
+
+    TestProfilerProvider profilerProvider = new TestProfilerProvider()
+
+    void cleanup() {
+        TestProfilerProviderLocator.deactivate()
+        MiniProfiler.profilerProvider = null
+    }
+
+    void "DI mode: constructor-injected provider captures SQL"() {
+        given:
+        def profiler = profilerProvider.start("di-test")
+
+        def ds = new JdbcDataSource()
+        ds.setURL("jdbc:h2:mem:hibernate_di_test;DB_CLOSE_DELAY=-1")
+
+        def connectionProvider = new ProfilingDatasourceConnectionProvider(profilerProvider)
+        connectionProvider.configure(["hibernate.connection.datasource": ds])
+
+        when:
+        def conn = connectionProvider.getConnection()
+        conn.createStatement().execute("SELECT 1")
+        conn.close()
+
+        then:
+        hasProfiledSql(profiler, "SELECT 1")
+
+        cleanup:
+        profiler?.stop()
+    }
+
+    void "ServiceLoader mode: profiler provider discovered via locator captures SQL"() {
+        given:
+        TestProfilerProviderLocator.activate(profilerProvider)
+        def profiler = profilerProvider.start("serviceloader-test")
+
+        def ds = new JdbcDataSource()
+        ds.setURL("jdbc:h2:mem:hibernate_sl_test;DB_CLOSE_DELAY=-1")
+
+        def cfg = new org.hibernate.cfg.Configuration()
+        cfg.getProperties().put("hibernate.connection.datasource", ds)
+        cfg.setProperty("hibernate.connection.provider_class",
+            "io.jdev.miniprofiler.hibernate.ProfilingDatasourceConnectionProvider")
+
+        when:
+        def sf = cfg.buildSessionFactory()
+        def session = sf.openSession()
+        session.doWork { conn -> conn.createStatement().execute("SELECT 1") }
+        session.close()
+        sf.close()
+
+        then:
+        hasProfiledSql(profiler, "SELECT 1")
+
+        cleanup:
+        profiler?.stop()
+    }
+
+    void "Static fallback mode: falls through to MiniProfiler static provider"() {
+        given:
+        TestProfilerProviderLocator.deactivate()
+        MiniProfiler.profilerProvider = profilerProvider
+        def profiler = profilerProvider.start("static-test")
+
+        def ds = new JdbcDataSource()
+        ds.setURL("jdbc:h2:mem:hibernate_static_test;DB_CLOSE_DELAY=-1")
+
+        def cfg = new org.hibernate.cfg.Configuration()
+        cfg.getProperties().put("hibernate.connection.datasource", ds)
+        cfg.setProperty("hibernate.connection.provider_class",
+            "io.jdev.miniprofiler.hibernate.ProfilingDatasourceConnectionProvider")
+
+        when:
+        def sf = cfg.buildSessionFactory()
+        def session = sf.openSession()
+        session.doWork { conn -> conn.createStatement().execute("SELECT 1") }
+        session.close()
+        sf.close()
+
+        then:
+        hasProfiledSql(profiler, "SELECT 1")
+
+        cleanup:
+        profiler?.stop()
+    }
+
+    private static boolean hasProfiledSql(Profiler profiler, String expectedFragment) {
+        def sqlTimings = profiler.root.customTimings["sql"]
+        return sqlTimings != null && sqlTimings.any { it.commandString.contains(expectedFragment) }
+    }
+}

--- a/hibernate/src/crossVersionTest/resources/META-INF/services/io.jdev.miniprofiler.ProfilerProviderLocator
+++ b/hibernate/src/crossVersionTest/resources/META-INF/services/io.jdev.miniprofiler.ProfilerProviderLocator
@@ -1,0 +1,1 @@
+io.jdev.miniprofiler.test.TestProfilerProviderLocator

--- a/hibernate/src/main/java/io/jdev/miniprofiler/hibernate/ProfilingDatasourceConnectionProvider.java
+++ b/hibernate/src/main/java/io/jdev/miniprofiler/hibernate/ProfilingDatasourceConnectionProvider.java
@@ -17,7 +17,7 @@
 package io.jdev.miniprofiler.hibernate;
 
 import io.jdev.miniprofiler.ProfilerProvider;
-import io.jdev.miniprofiler.StaticProfilerProvider;
+import io.jdev.miniprofiler.ProfilerProviderLocator;
 import io.jdev.miniprofiler.sql.ProfilingSpyLogDelegator;
 import io.jdev.miniprofiler.sql.log4jdbc.ConnectionSpy;
 import io.jdev.miniprofiler.sql.log4jdbc.SpyLogFactory;
@@ -25,18 +25,31 @@ import org.hibernate.engine.jdbc.connections.internal.DatasourceConnectionProvid
 
 import java.sql.Connection;
 import java.sql.SQLException;
+import java.util.Map;
 
 public class ProfilingDatasourceConnectionProvider extends DatasourceConnectionProviderImpl {
 
-    private final ProfilerProvider profilerProvider;
+    private boolean profilingConfigured;
 
     public ProfilingDatasourceConnectionProvider() {
-        this(new StaticProfilerProvider());
     }
 
     public ProfilingDatasourceConnectionProvider(ProfilerProvider profilerProvider) {
-        this.profilerProvider = profilerProvider;
+        setupProfiling(profilerProvider);
+    }
+
+    @Override
+    @SuppressWarnings("rawtypes")
+    public void configure(Map configValues) {
+        if (!profilingConfigured) {
+            setupProfiling(ProfilerProviderLocator.findProvider());
+        }
+        super.configure(configValues);
+    }
+
+    private void setupProfiling(ProfilerProvider profilerProvider) {
         SpyLogFactory.setSpyLogDelegator(new ProfilingSpyLogDelegator(profilerProvider));
+        profilingConfigured = true;
     }
 
     @Override

--- a/hibernate/src/test/groovy/io/jdev/miniprofiler/hibernate/ProfilingDatasourceConnectionProviderSpec.groovy
+++ b/hibernate/src/test/groovy/io/jdev/miniprofiler/hibernate/ProfilingDatasourceConnectionProviderSpec.groovy
@@ -1,0 +1,93 @@
+/*
+ * Copyright 2026 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.jdev.miniprofiler.hibernate
+
+import io.jdev.miniprofiler.MiniProfiler
+import io.jdev.miniprofiler.ProfilerProvider
+import io.jdev.miniprofiler.sql.ProfilingSpyLogDelegator
+import io.jdev.miniprofiler.sql.log4jdbc.SpyLogFactory
+import io.jdev.miniprofiler.test.TestProfilerProvider
+import spock.lang.Specification
+
+class ProfilingDatasourceConnectionProviderSpec extends Specification {
+
+    void cleanup() {
+        MiniProfiler.profilerProvider = null
+    }
+
+    void "constructor with provider immediately configures SpyLogFactory"() {
+        given:
+        def profilerProvider = new TestProfilerProvider()
+
+        when:
+        new ProfilingDatasourceConnectionProvider(profilerProvider)
+
+        then:
+        SpyLogFactory.spyLogDelegator instanceof ProfilingSpyLogDelegator
+        SpyLogFactory.spyLogDelegator.@profilerProvider == profilerProvider
+    }
+
+    void "no-arg constructor does not configure SpyLogFactory"() {
+        given: 'a sentinel delegator set before construction'
+        def originalDelegator = SpyLogFactory.spyLogDelegator
+
+        when:
+        new ProfilingDatasourceConnectionProvider()
+
+        then: 'SpyLogFactory was not changed by construction'
+        SpyLogFactory.spyLogDelegator == originalDelegator
+    }
+
+    void "configure sets up SpyLogFactory using ProfilerProviderLocator"() {
+        given:
+        def testProvider = new TestProfilerProvider()
+        MiniProfiler.profilerProvider = testProvider
+        def connectionProvider = new ProfilingDatasourceConnectionProvider()
+
+        when: 'configure is called; profiling setup runs before super, which throws without a DataSource'
+        connectionProvider.configure([:])
+
+        then: 'Hibernate throws because no DataSource was provided'
+        thrown(Exception)
+
+        and: 'SpyLogFactory was configured before the exception'
+        SpyLogFactory.spyLogDelegator instanceof ProfilingSpyLogDelegator
+
+        and: 'the delegator uses the provider resolved via the locator (StaticProfilerProvider -> MiniProfiler)'
+        def profiler = MiniProfiler.start("test")
+        SpyLogFactory.spyLogDelegator.@profilerProvider.current() == profiler
+
+        cleanup:
+        MiniProfiler.profilerProvider?.stopCurrentSession(true)
+    }
+
+    void "configure does not reconfigure SpyLogFactory when provider was set via constructor"() {
+        given:
+        def constructorProvider = Mock(ProfilerProvider)
+        def connectionProvider = new ProfilingDatasourceConnectionProvider(constructorProvider)
+        def delegatorAfterConstruction = SpyLogFactory.spyLogDelegator
+
+        when: 'configure is called; profilingConfigured flag prevents re-setup, then super throws without a DataSource'
+        connectionProvider.configure([:])
+
+        then:
+        thrown(Exception)
+
+        and: 'delegator is still the one set by the constructor'
+        SpyLogFactory.spyLogDelegator == delegatorAfterConstruction
+    }
+}

--- a/jakarta-ee/src/integrationTest/groovy/io/jdev/miniprofiler/jakarta/ee/CdiProfilerProviderLocatorIntegrationSpec.groovy
+++ b/jakarta-ee/src/integrationTest/groovy/io/jdev/miniprofiler/jakarta/ee/CdiProfilerProviderLocatorIntegrationSpec.groovy
@@ -1,0 +1,71 @@
+/*
+ * Copyright 2026 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.jdev.miniprofiler.jakarta.ee
+
+import io.jdev.miniprofiler.ProfilerProvider
+import spock.lang.Shared
+import spock.lang.Specification
+
+import jakarta.enterprise.inject.se.SeContainer
+import jakarta.enterprise.inject.se.SeContainerInitializer
+
+class CdiProfilerProviderLocatorIntegrationSpec extends Specification {
+
+    @Shared SeContainer container
+
+    void setupSpec() {
+        container = SeContainerInitializer.newInstance()
+            .addBeanClasses(DefaultCDIProfilerProvider)
+            .initialize()
+    }
+
+    void cleanupSpec() {
+        container?.close()
+    }
+
+    CdiProfilerProviderLocator locatorWithContainerBeanManager() {
+        def beanManager = container.beanManager
+        return new CdiProfilerProviderLocator() {
+            @Override
+            Object lookupBeanManagerFromJndi() { return beanManager }
+        }
+    }
+
+    void "locator finds ProfilerProvider from CDI container"() {
+        when:
+        def result = locatorWithContainerBeanManager().locate()
+
+        then:
+        result.present
+        result.get() instanceof ProfilerProvider
+    }
+
+    void "locator returns the CDI-managed singleton ProfilerProvider"() {
+        given:
+        def locatorProvider = locatorWithContainerBeanManager().locate().get()
+        def containerProvider = container.select(ProfilerProvider).get()
+
+        when:
+        def profiler = locatorProvider.start("test")
+
+        then: 'both references share the same underlying CDI bean'
+        containerProvider.current() == profiler
+
+        cleanup:
+        locatorProvider.stopCurrentSession(true)
+    }
+}

--- a/jakarta-ee/src/main/java/io/jdev/miniprofiler/jakarta/ee/CdiProfilerProviderLocator.java
+++ b/jakarta-ee/src/main/java/io/jdev/miniprofiler/jakarta/ee/CdiProfilerProviderLocator.java
@@ -1,0 +1,68 @@
+/*
+ * Copyright 2026 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.jdev.miniprofiler.jakarta.ee;
+
+import io.jdev.miniprofiler.ProfilerProvider;
+import io.jdev.miniprofiler.ProfilerProviderLocator;
+
+import jakarta.enterprise.context.spi.CreationalContext;
+import jakarta.enterprise.inject.spi.Bean;
+import jakarta.enterprise.inject.spi.BeanManager;
+import javax.naming.InitialContext;
+import java.util.Optional;
+import java.util.Set;
+
+/**
+ * {@link ProfilerProviderLocator} that looks up a {@link ProfilerProvider} from the
+ * Jakarta CDI container via JNDI. Returns an empty {@link Optional} if the Jakarta CDI
+ * API is not available or no {@link ProfilerProvider} bean is registered.
+ */
+public class CdiProfilerProviderLocator implements ProfilerProviderLocator {
+
+    @Override
+    public int getOrder() {
+        return 10;
+    }
+
+    @Override
+    public Optional<ProfilerProvider> locate() {
+        try {
+            Object lookedUp = lookupBeanManagerFromJndi();
+            if (!(lookedUp instanceof BeanManager)) {
+                return Optional.empty();
+            }
+            BeanManager bm = (BeanManager) lookedUp;
+            Set<Bean<?>> beans = bm.getBeans(ProfilerProvider.class);
+            if (beans.isEmpty()) {
+                return Optional.empty();
+            }
+            Bean<ProfilerProvider> bean = (Bean<ProfilerProvider>) bm.resolve(beans);
+            CreationalContext<ProfilerProvider> ctx = bm.createCreationalContext(bean);
+            Object reference = bm.getReference(bean, ProfilerProvider.class, ctx);
+            if (!(reference instanceof ProfilerProvider)) {
+                return Optional.empty();
+            }
+            return Optional.of((ProfilerProvider) reference);
+        } catch (Exception | NoClassDefFoundError e) {
+            return Optional.empty();
+        }
+    }
+
+    Object lookupBeanManagerFromJndi() throws Exception {
+        return new InitialContext().lookup("java:comp/BeanManager");
+    }
+}

--- a/jakarta-ee/src/main/resources/META-INF/services/io.jdev.miniprofiler.ProfilerProviderLocator
+++ b/jakarta-ee/src/main/resources/META-INF/services/io.jdev.miniprofiler.ProfilerProviderLocator
@@ -1,0 +1,1 @@
+io.jdev.miniprofiler.jakarta.ee.CdiProfilerProviderLocator

--- a/jakarta-ee/src/test/groovy/io/jdev/miniprofiler/jakarta/ee/CdiProfilerProviderLocatorSpec.groovy
+++ b/jakarta-ee/src/test/groovy/io/jdev/miniprofiler/jakarta/ee/CdiProfilerProviderLocatorSpec.groovy
@@ -1,0 +1,79 @@
+/*
+ * Copyright 2026 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.jdev.miniprofiler.jakarta.ee
+
+import io.jdev.miniprofiler.ProfilerProvider
+import spock.lang.Specification
+
+import jakarta.enterprise.context.spi.CreationalContext
+import jakarta.enterprise.inject.spi.Bean
+import jakarta.enterprise.inject.spi.BeanManager
+
+class CdiProfilerProviderLocatorSpec extends Specification {
+
+    CdiProfilerProviderLocator locator = new CdiProfilerProviderLocator()
+
+    void "locator has order 10"() {
+        expect:
+        locator.order == 10
+    }
+
+    void "locator returns empty optional when CDI is not available"() {
+        // In a plain unit test environment there is no JNDI BeanManager
+        when:
+        def result = locator.locate()
+
+        then:
+        !result.present
+    }
+
+    void "locator returns empty optional when JNDI returns a BeanManager of the wrong type"() {
+        given: 'a locator that simulates finding a javax BeanManager instead of jakarta'
+        def wrongTypeLocator = new CdiProfilerProviderLocator() {
+            @Override
+            Object lookupBeanManagerFromJndi() {
+                return "not a jakarta BeanManager" // simulates javax BeanManager on classpath
+            }
+        }
+
+        when:
+        def result = wrongTypeLocator.locate()
+
+        then:
+        !result.present
+    }
+
+    void "locator returns empty optional when CDI returns wrong ProfilerProvider type"() {
+        given: 'a locator that finds a valid BeanManager but the resolved bean is not a ProfilerProvider'
+        def bm = Mock(BeanManager)
+        def wrongTypeLocator = new CdiProfilerProviderLocator() {
+            @Override
+            Object lookupBeanManagerFromJndi() { return bm }
+        }
+
+        bm.getBeans(ProfilerProvider) >> ([Mock(Bean)] as Set)
+        bm.resolve(_) >> Mock(Bean)
+        bm.createCreationalContext(_) >> Mock(CreationalContext)
+        bm.getReference(_, _, _) >> "not a ProfilerProvider"
+
+        when:
+        def result = wrongTypeLocator.locate()
+
+        then:
+        !result.present
+    }
+}

--- a/javax-ee/src/integrationTest/groovy/io/jdev/miniprofiler/javax/ee/CdiProfilerProviderLocatorIntegrationSpec.groovy
+++ b/javax-ee/src/integrationTest/groovy/io/jdev/miniprofiler/javax/ee/CdiProfilerProviderLocatorIntegrationSpec.groovy
@@ -1,0 +1,71 @@
+/*
+ * Copyright 2026 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.jdev.miniprofiler.javax.ee
+
+import io.jdev.miniprofiler.ProfilerProvider
+import spock.lang.Shared
+import spock.lang.Specification
+
+import javax.enterprise.inject.se.SeContainer
+import javax.enterprise.inject.se.SeContainerInitializer
+
+class CdiProfilerProviderLocatorIntegrationSpec extends Specification {
+
+    @Shared SeContainer container
+
+    void setupSpec() {
+        container = SeContainerInitializer.newInstance()
+            .addBeanClasses(DefaultCDIProfilerProvider)
+            .initialize()
+    }
+
+    void cleanupSpec() {
+        container?.close()
+    }
+
+    CdiProfilerProviderLocator locatorWithContainerBeanManager() {
+        def beanManager = container.beanManager
+        return new CdiProfilerProviderLocator() {
+            @Override
+            Object lookupBeanManagerFromJndi() { return beanManager }
+        }
+    }
+
+    void "locator finds ProfilerProvider from CDI container"() {
+        when:
+        def result = locatorWithContainerBeanManager().locate()
+
+        then:
+        result.present
+        result.get() instanceof ProfilerProvider
+    }
+
+    void "locator returns the CDI-managed singleton ProfilerProvider"() {
+        given:
+        def locatorProvider = locatorWithContainerBeanManager().locate().get()
+        def containerProvider = container.select(ProfilerProvider).get()
+
+        when:
+        def profiler = locatorProvider.start("test")
+
+        then: 'both references share the same underlying CDI bean'
+        containerProvider.current() == profiler
+
+        cleanup:
+        locatorProvider.stopCurrentSession(true)
+    }
+}

--- a/javax-ee/src/main/java/io/jdev/miniprofiler/javax/ee/CdiProfilerProviderLocator.java
+++ b/javax-ee/src/main/java/io/jdev/miniprofiler/javax/ee/CdiProfilerProviderLocator.java
@@ -1,0 +1,68 @@
+/*
+ * Copyright 2026 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.jdev.miniprofiler.javax.ee;
+
+import io.jdev.miniprofiler.ProfilerProvider;
+import io.jdev.miniprofiler.ProfilerProviderLocator;
+
+import javax.enterprise.context.spi.CreationalContext;
+import javax.enterprise.inject.spi.Bean;
+import javax.enterprise.inject.spi.BeanManager;
+import javax.naming.InitialContext;
+import java.util.Optional;
+import java.util.Set;
+
+/**
+ * {@link ProfilerProviderLocator} that looks up a {@link ProfilerProvider} from the
+ * javax CDI container via JNDI. Returns an empty {@link Optional} if the javax CDI
+ * API is not available or no {@link ProfilerProvider} bean is registered.
+ */
+public class CdiProfilerProviderLocator implements ProfilerProviderLocator {
+
+    @Override
+    public int getOrder() {
+        return 20;
+    }
+
+    @Override
+    public Optional<ProfilerProvider> locate() {
+        try {
+            Object lookedUp = lookupBeanManagerFromJndi();
+            if (!(lookedUp instanceof BeanManager)) {
+                return Optional.empty();
+            }
+            BeanManager bm = (BeanManager) lookedUp;
+            Set<Bean<?>> beans = bm.getBeans(ProfilerProvider.class);
+            if (beans.isEmpty()) {
+                return Optional.empty();
+            }
+            Bean<ProfilerProvider> bean = (Bean<ProfilerProvider>) bm.resolve(beans);
+            CreationalContext<ProfilerProvider> ctx = bm.createCreationalContext(bean);
+            Object reference = bm.getReference(bean, ProfilerProvider.class, ctx);
+            if (!(reference instanceof ProfilerProvider)) {
+                return Optional.empty();
+            }
+            return Optional.of((ProfilerProvider) reference);
+        } catch (Exception | NoClassDefFoundError e) {
+            return Optional.empty();
+        }
+    }
+
+    Object lookupBeanManagerFromJndi() throws Exception {
+        return new InitialContext().lookup("java:comp/BeanManager");
+    }
+}

--- a/javax-ee/src/main/java/io/jdev/miniprofiler/javax/ee/DefaultCDIProfilerProvider.java
+++ b/javax-ee/src/main/java/io/jdev/miniprofiler/javax/ee/DefaultCDIProfilerProvider.java
@@ -18,8 +18,10 @@ package io.jdev.miniprofiler.javax.ee;
 
 import io.jdev.miniprofiler.DefaultProfilerProvider;
 
+import javax.enterprise.context.ApplicationScoped;
 import javax.enterprise.inject.Default;
 
+@ApplicationScoped
 @Default
 public class DefaultCDIProfilerProvider extends DefaultProfilerProvider {
 }

--- a/javax-ee/src/main/resources/META-INF/services/io.jdev.miniprofiler.ProfilerProviderLocator
+++ b/javax-ee/src/main/resources/META-INF/services/io.jdev.miniprofiler.ProfilerProviderLocator
@@ -1,0 +1,1 @@
+io.jdev.miniprofiler.javax.ee.CdiProfilerProviderLocator

--- a/javax-ee/src/test/groovy/io/jdev/miniprofiler/javax/ee/CdiProfilerProviderLocatorSpec.groovy
+++ b/javax-ee/src/test/groovy/io/jdev/miniprofiler/javax/ee/CdiProfilerProviderLocatorSpec.groovy
@@ -1,0 +1,79 @@
+/*
+ * Copyright 2026 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.jdev.miniprofiler.javax.ee
+
+import io.jdev.miniprofiler.ProfilerProvider
+import spock.lang.Specification
+
+import javax.enterprise.context.spi.CreationalContext
+import javax.enterprise.inject.spi.Bean
+import javax.enterprise.inject.spi.BeanManager
+
+class CdiProfilerProviderLocatorSpec extends Specification {
+
+    CdiProfilerProviderLocator locator = new CdiProfilerProviderLocator()
+
+    void "locator has order 20"() {
+        expect:
+        locator.order == 20
+    }
+
+    void "locator returns empty optional when CDI is not available"() {
+        // In a plain unit test environment there is no JNDI BeanManager
+        when:
+        def result = locator.locate()
+
+        then:
+        !result.present
+    }
+
+    void "locator returns empty optional when JNDI returns a BeanManager of the wrong type"() {
+        given: 'a locator that simulates finding a jakarta BeanManager instead of javax'
+        def wrongTypeLocator = new CdiProfilerProviderLocator() {
+            @Override
+            Object lookupBeanManagerFromJndi() {
+                return "not a javax BeanManager" // simulates jakarta BeanManager on classpath
+            }
+        }
+
+        when:
+        def result = wrongTypeLocator.locate()
+
+        then:
+        !result.present
+    }
+
+    void "locator returns empty optional when CDI returns wrong ProfilerProvider type"() {
+        given: 'a locator that finds a valid BeanManager but the resolved bean is not a ProfilerProvider'
+        def bm = Mock(BeanManager)
+        def wrongTypeLocator = new CdiProfilerProviderLocator() {
+            @Override
+            Object lookupBeanManagerFromJndi() { return bm }
+        }
+
+        bm.getBeans(ProfilerProvider) >> ([Mock(Bean)] as Set)
+        bm.resolve(_) >> Mock(Bean)
+        bm.createCreationalContext(_) >> Mock(CreationalContext)
+        bm.getReference(_, _, _) >> "not a ProfilerProvider"
+
+        when:
+        def result = wrongTypeLocator.locate()
+
+        then:
+        !result.present
+    }
+}

--- a/scenario-test/glassfish4/src/main/resources/META-INF/persistence.xml
+++ b/scenario-test/glassfish4/src/main/resources/META-INF/persistence.xml
@@ -23,7 +23,7 @@
 		<jta-data-source>jdbc/DataSource</jta-data-source>
 		<exclude-unlisted-classes>false</exclude-unlisted-classes>
 		<properties>
-			<property name="eclipselink.session.customizer" value="io.jdev.miniprofiler.eclipselink.ProfilingSessionCustomizer"/>
+			<property name="eclipselink.session.customizer" value="io.jdev.miniprofiler.eclipselink.LegacyProfilingSessionCustomizer"/>
 			<property name="eclipselink.ddl-generation" value="create-tables"/>
 			<property name="eclipselink.ddl-generation.output-mode" value="database"/>
 		</properties>

--- a/test/src/main/java/io/jdev/miniprofiler/test/TestProfilerProviderLocator.java
+++ b/test/src/main/java/io/jdev/miniprofiler/test/TestProfilerProviderLocator.java
@@ -1,0 +1,61 @@
+/*
+ * Copyright 2026 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.jdev.miniprofiler.test;
+
+import io.jdev.miniprofiler.ProfilerProvider;
+import io.jdev.miniprofiler.ProfilerProviderLocator;
+
+import java.util.Optional;
+
+/**
+ * A controllable {@link ProfilerProviderLocator} for testing. Consumers opt in
+ * by adding a {@code META-INF/services/io.jdev.miniprofiler.ProfilerProviderLocator}
+ * file pointing to this class on their test classpath.
+ *
+ * <p>Call {@link #activate(ProfilerProvider)} to make {@link #locate()} return
+ * the given provider. Call {@link #deactivate()} to make it return empty,
+ * allowing the {@link io.jdev.miniprofiler.StaticProfilerProviderLocator}
+ * fallback to take effect.</p>
+ */
+public class TestProfilerProviderLocator implements ProfilerProviderLocator {
+
+    private static volatile boolean enabled;
+    private static volatile ProfilerProvider provider;
+
+    @Override
+    public int getOrder() {
+        return 1;
+    }
+
+    @Override
+    public Optional<ProfilerProvider> locate() {
+        if (enabled && provider != null) {
+            return Optional.of(provider);
+        }
+        return Optional.empty();
+    }
+
+    public static void activate(ProfilerProvider profilerProvider) {
+        provider = profilerProvider;
+        enabled = true;
+    }
+
+    public static void deactivate() {
+        enabled = false;
+        provider = null;
+    }
+}


### PR DESCRIPTION
## Summary

- Introduce `ProfilerProviderLocator` SPI (ServiceLoader-based) so Hibernate and EclipseLink
  integrations discover the `ProfilerProvider` dynamically instead of requiring static wiring.
  CDI-aware locators in javax-ee and jakarta-ee take precedence; `StaticProfilerProviderLocator`
  provides the existing fallback.
- Add cross-version integration tests for both modules, covering Hibernate 5/6/7 and
  EclipseLink 2/3/4/5. Each version suite creates a real ORM session against H2 and verifies
  SQL profiling across three provider acquisition modes: DI, ServiceLoader, and static fallback.
- Migrate `ProfilingSessionCustomizer` to `sessions.SessionCustomizer` (EclipseLink 4+) and add
  `LegacyProfilingSessionCustomizer` for the deprecated `config.SessionCustomizer` (EclipseLink 2/3).
- Bump compile-time dependencies to Hibernate 5 and EclipseLink 4.

## Test plan

- [ ] `check` passes (includes unit tests + cross-version tests for the compile-time versions)
- [ ] `fullCheck` passes (adds cross-version tests for all supported ORM versions, plus
      browser and scenario tests including GlassFish 4 with `LegacyProfilingSessionCustomizer`)