### PR TITLE
Use ServiceLoader to seed MiniProfiler's default provider

### DIFF
--- a/core/src/main/java/io/jdev/miniprofiler/MiniProfiler.java
+++ b/core/src/main/java/io/jdev/miniprofiler/MiniProfiler.java
@@ -41,7 +41,7 @@ import java.util.ServiceLoader;
  * might be instrumented code.</p>
  */
 public class MiniProfiler {
-    private static ProfilerProvider profilerProvider;
+    private static volatile ProfilerProvider profilerProvider;
     private static String version;
 
     /**
@@ -82,7 +82,11 @@ public class MiniProfiler {
 
     static ProfilerProvider getOrCreateProfilerProvider() {
         if (profilerProvider == null) {
-            profilerProvider = bootstrapProfilerProvider();
+            synchronized (MiniProfiler.class) {
+                if (profilerProvider == null) {
+                    profilerProvider = bootstrapProfilerProvider();
+                }
+            }
         }
         return profilerProvider;
     }

--- a/core/src/main/java/io/jdev/miniprofiler/MiniProfiler.java
+++ b/core/src/main/java/io/jdev/miniprofiler/MiniProfiler.java
@@ -21,6 +21,8 @@ import io.jdev.miniprofiler.storage.Storage;
 import io.jdev.miniprofiler.util.ResourceHelper;
 
 import java.io.IOException;
+import java.util.Optional;
+import java.util.ServiceLoader;
 
 /**
  * Convenience class for static access to profiling functions.
@@ -80,10 +82,27 @@ public class MiniProfiler {
 
     static ProfilerProvider getOrCreateProfilerProvider() {
         if (profilerProvider == null) {
-            // default to something hopefully sane
-            profilerProvider = new DefaultProfilerProvider();
+            profilerProvider = bootstrapProfilerProvider();
         }
         return profilerProvider;
+    }
+
+    private static ProfilerProvider bootstrapProfilerProvider() {
+        ProfilerProviderLocator best = null;
+        for (ProfilerProviderLocator locator : ServiceLoader.load(ProfilerProviderLocator.class)) {
+            if (locator.getOrder() < ProfilerProviderLocator.MINIPROFILER_STATIC_LOCATOR_ORDER) {
+                if (best == null || locator.getOrder() < best.getOrder()) {
+                    best = locator;
+                }
+            }
+        }
+        if (best != null) {
+            Optional<ProfilerProvider> provider = best.locate();
+            if (provider.isPresent()) {
+                return provider.get();
+            }
+        }
+        return new DefaultProfilerProvider();
     }
 
     /**

--- a/core/src/main/java/io/jdev/miniprofiler/ProfilerProviderLocator.java
+++ b/core/src/main/java/io/jdev/miniprofiler/ProfilerProviderLocator.java
@@ -35,6 +35,13 @@ import java.util.ServiceLoader;
 public interface ProfilerProviderLocator {
 
     /**
+     * Sentinel order value reserved for {@link StaticProfilerProviderLocator}.
+     * Any locator returning this value (or higher) is excluded from
+     * {@link MiniProfiler}'s own bootstrap scan to avoid a bootstrap cycle.
+     */
+    int MINIPROFILER_STATIC_LOCATOR_ORDER = Integer.MAX_VALUE;
+
+    /**
      * Returns the order of this locator. Lower values are consulted first.
      */
     int getOrder();

--- a/core/src/main/java/io/jdev/miniprofiler/StaticProfilerProviderLocator.java
+++ b/core/src/main/java/io/jdev/miniprofiler/StaticProfilerProviderLocator.java
@@ -27,7 +27,7 @@ public class StaticProfilerProviderLocator implements ProfilerProviderLocator {
 
     @Override
     public int getOrder() {
-        return 100;
+        return MINIPROFILER_STATIC_LOCATOR_ORDER;
     }
 
     @Override

--- a/core/src/test/groovy/io/jdev/miniprofiler/ProfilerProviderLocatorSpec.groovy
+++ b/core/src/test/groovy/io/jdev/miniprofiler/ProfilerProviderLocatorSpec.groovy
@@ -20,9 +20,9 @@ import spock.lang.Specification
 
 class ProfilerProviderLocatorSpec extends Specification {
 
-    void "StaticProfilerProviderLocator has order 100"() {
+    void "StaticProfilerProviderLocator has order MINIPROFILER_STATIC_LOCATOR_ORDER"() {
         expect:
-        new StaticProfilerProviderLocator().order == 100
+        new StaticProfilerProviderLocator().order == ProfilerProviderLocator.MINIPROFILER_STATIC_LOCATOR_ORDER
     }
 
     void "StaticProfilerProviderLocator returns a StaticProfilerProvider"() {


### PR DESCRIPTION
`MiniProfiler.getOrCreateProfilerProvider()` previously hardcoded `new DefaultProfilerProvider()` as its fallback. This branch wires it up to the `ProfilerProviderLocator` SPI instead, so that integrations (CDI, etc.) discovered on the classpath automatically become the static default without any manual `setProfilerProvider()` call.

## Bootstrap cycle fix

`StaticProfilerProviderLocator` — which reads back from `MiniProfiler.profilerProvider` — is also registered as a `ProfilerProviderLocator` service, creating a cycle if it were included in the bootstrap scan. The fix introduces a sentinel constant `ProfilerProviderLocator.MINIPROFILER_STATIC_LOCATOR_ORDER = Integer.MAX_VALUE`, assigned as the order of `StaticProfilerProviderLocator`. The bootstrap scan in `MiniProfiler` filters out any locator at or above that value, so `StaticProfilerProviderLocator` is skipped during seeding but remains fully functional for external consumers via `ProfilerProviderLocator.findProvider()`.

## Thread safety

`profilerProvider` is now `volatile` and `getOrCreateProfilerProvider()` uses double-checked locking, ensuring the ServiceLoader scan runs at most once regardless of how many threads race to initialise the provider.