### PR TITLE
Add cross-version integration tests for jOOQ

### DIFF
--- a/.github/workflows/gradle-build.yml
+++ b/.github/workflows/gradle-build.yml
@@ -15,6 +15,7 @@ jobs:
               8
               11
               17
+              21
 
       - name: Setup Gradle
         uses: gradle/actions/setup-gradle@v6

--- a/.github/workflows/gradle-build.yml
+++ b/.github/workflows/gradle-build.yml
@@ -30,10 +30,10 @@ jobs:
         with:
           geckodriver-version: 0.36.0
 
-      - name: Build
-        run: ./gradlew assemble
+      - name: Build and run fast tests
+        run: ./gradlew assemble check --continue
 
-      - name: Run tests
+      - name: Run slow tests
         uses: GabrielBB/xvfb-action@v1.7
         with:
           run: ./gradlew fullCheck --continue

--- a/eclipselink/eclipselink.gradle.kts
+++ b/eclipselink/eclipselink.gradle.kts
@@ -15,6 +15,7 @@
  */
 
 plugins {
+    id("build.cross-version-test")
     id("build.java-module")
     id("build.publish")
 }
@@ -45,42 +46,32 @@ dependencies {
     }
 }
 
-addCrossVersionTestSuite("crossVersionTestEclipseLink2", 8) {
-    dependencies {
+crossVersionTests {
+    configureEach {
+        implementation(libs.bundles.testing.groovy4)
+        runtimeOnly(libs.bundles.testing.runtime)
+        implementation(projects.test)
+        implementation(libs.h2)
+    }
+    register("crossVersionTestEclipseLink2") {
+        minJavaVersion = 8
         implementation(libs.eclipselink.v2)
-        implementation(libs.h2)
     }
-}
-addCrossVersionTestSuite("crossVersionTestEclipseLink3", 11) {
-    dependencies {
+    register("crossVersionTestEclipseLink3") {
+        minJavaVersion = 11
         implementation(libs.eclipselink.v3)
-        implementation(libs.h2)
     }
-}
-val crossVersionTestEclipseLink4 = addCrossVersionTestSuite("crossVersionTestEclipseLink4", 11) {
-    dependencies {
+    register("crossVersionTestEclipseLink4") {
+        minJavaVersion = 11
         implementation(libs.eclipselink.v4)
-        implementation(libs.h2)
     }
-}
-addCrossVersionTestSuite("crossVersionTestEclipseLink5", 17) {
-    dependencies {
+    register("crossVersionTestEclipseLink5") {
+        minJavaVersion = 17
         implementation(libs.eclipselink.v5)
-        implementation(libs.h2)
     }
 }
 
-tasks.named("check") { dependsOn(crossVersionTestEclipseLink4) }
-
-// Force older EclipseLink versions in suites where the inherited v4 would otherwise win
-listOf("CompileClasspath", "RuntimeClasspath").forEach { suffix ->
-    configurations.named("crossVersionTestEclipseLink2$suffix") {
-        resolutionStrategy.force("org.eclipse.persistence:eclipselink:2.7.12")
-    }
-    configurations.named("crossVersionTestEclipseLink3$suffix") {
-        resolutionStrategy.force("org.eclipse.persistence:eclipselink:3.0.4")
-    }
-}
+tasks.named("check") { dependsOn("crossVersionTestEclipseLink4") }
 
 publishing {
     publications.named<MavenPublication>("maven") {

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -42,9 +42,6 @@ javax-servlet-api-v2 = "2.3"
 javax-servlet-api-v4 = "4.0.1"
 jetty9 = "9.4.57.v20241219"
 jetty12 = "12.0.21"
-jooq-compile = "3.0.0"
-# jOOQ 3.15+ requires Java 11, so we stay on 3.14.x for Java 8 compatibility
-jooq-test = "3.14.16"
 # Cross-version test versions — one per supported JDK generation
 jooq-v300 = "3.0.0"   # Compile target: minimum supported version (Java 8)
 jooq-v314 = "3.14.16" # Last Java 8 version
@@ -102,8 +99,6 @@ jetty9-server        = { module = "org.eclipse.jetty:jetty-server",            v
 jetty9-servlet       = { module = "org.eclipse.jetty:jetty-servlet",           version.ref = "jetty9"  }
 jetty12-server       = { module = "org.eclipse.jetty:jetty-server",            version.ref = "jetty12" }
 jetty12-ee10-servlet = { module = "org.eclipse.jetty.ee10:jetty-ee10-servlet", version.ref = "jetty12" }
-jooq-compile = { module = "org.jooq:jooq", version.ref = "jooq-compile" }
-jooq-test = { module = "org.jooq:jooq", version.ref = "jooq-test" }
 jooq-v300 = { module = "org.jooq:jooq", version.ref = "jooq-v300" }
 jooq-v314 = { module = "org.jooq:jooq", version.ref = "jooq-v314" }
 jooq-v316 = { module = "org.jooq:jooq", version.ref = "jooq-v316" }
@@ -137,6 +132,11 @@ testcontainers-core   = { module = "org.testcontainers:testcontainers",   versio
 testcontainers-junit5 = { module = "org.testcontainers:testcontainers-junit-jupiter", version.ref = "testcontainers" }
 weld-se-v3 = { module = "org.jboss.weld.se:weld-se-core", version.ref = "weld-se-v3" }
 weld-se-v5 = { module = "org.jboss.weld.se:weld-se-core", version.ref = "weld-se-v5" }
+
+[bundles]
+testing-groovy3 = ["groovy-v3", "spock-groovy3", "junit-jupiter", "awaitility"]
+testing-groovy4 = ["groovy-v4", "spock-groovy4", "junit-jupiter", "awaitility"]
+testing-runtime = ["byte-buddy", "logback"]
 
 [plugins]
 asciidoctor = { id = "org.asciidoctor.jvm.convert", version.ref = "asciidoctor" }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -45,6 +45,12 @@ jetty12 = "12.0.21"
 jooq-compile = "3.0.0"
 # jOOQ 3.15+ requires Java 11, so we stay on 3.14.x for Java 8 compatibility
 jooq-test = "3.14.16"
+# Cross-version test versions — one per supported JDK generation
+jooq-v300 = "3.0.0"   # Compile target: minimum supported version (Java 8)
+jooq-v314 = "3.14.16" # Last Java 8 version
+jooq-v316 = "3.16.10" # Last Java 11 version
+jooq-v319 = "3.19.31" # Last Java 17 version (last open-source before Java 21 was required)
+jooq-v321 = "3.21.1"  # Latest version (Java 21)
 json-simple = "1.1.1"
 junit = "5.14.3"
 junit-platform = "1.14.3"
@@ -98,6 +104,11 @@ jetty12-server       = { module = "org.eclipse.jetty:jetty-server",            v
 jetty12-ee10-servlet = { module = "org.eclipse.jetty.ee10:jetty-ee10-servlet", version.ref = "jetty12" }
 jooq-compile = { module = "org.jooq:jooq", version.ref = "jooq-compile" }
 jooq-test = { module = "org.jooq:jooq", version.ref = "jooq-test" }
+jooq-v300 = { module = "org.jooq:jooq", version.ref = "jooq-v300" }
+jooq-v314 = { module = "org.jooq:jooq", version.ref = "jooq-v314" }
+jooq-v316 = { module = "org.jooq:jooq", version.ref = "jooq-v316" }
+jooq-v319 = { module = "org.jooq:jooq", version.ref = "jooq-v319" }
+jooq-v321 = { module = "org.jooq:jooq", version.ref = "jooq-v321" }
 json-simple = { module = "com.googlecode.json-simple:json-simple", version.ref = "json-simple" }
 junit-jupiter = { module = "org.junit.jupiter:junit-jupiter", version.ref = "junit" }
 junit-platform-launcher = { module = "org.junit.platform:junit-platform-launcher", version.ref = "junit-platform" }

--- a/gradle/plugins/src/main/kotlin/CrossVersionTestSuiteSpec.kt
+++ b/gradle/plugins/src/main/kotlin/CrossVersionTestSuiteSpec.kt
@@ -1,0 +1,60 @@
+/*
+ * Copyright 2026 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import org.gradle.api.Named
+import org.gradle.api.artifacts.ExternalModuleDependencyBundle
+import org.gradle.api.artifacts.MinimalExternalModuleDependency
+import org.gradle.api.provider.Property
+import org.gradle.api.provider.Provider
+import javax.inject.Inject
+
+abstract class CrossVersionTestSuiteSpec @Inject constructor(private val _name: String) : Named {
+    override fun getName(): String = _name
+    abstract val minJavaVersion: Property<Int>
+
+    internal val implementationDependencies = mutableListOf<Any>()
+    internal val runtimeOnlyDependencies = mutableListOf<Any>()
+
+    fun implementation(notation: Any) {
+        addDep(notation, implementationDependencies)
+    }
+
+    fun runtimeOnly(notation: Any) {
+        addDep(notation, runtimeOnlyDependencies)
+    }
+
+    // DependencyHandler.add(String, Object) does not support Provider<MinimalExternalModuleDependency>
+    // or MinimalExternalModuleDependency directly. Resolve providers eagerly and convert catalog
+    // entries to "group:name:version" coordinate strings which are universally supported.
+    private fun addDep(notation: Any, target: MutableList<Any>) {
+        if (notation is Provider<*>) {
+            @Suppress("UNCHECKED_CAST")
+            addDep((notation as Provider<Any>).get(), target)
+            return
+        }
+        when (notation) {
+            is MinimalExternalModuleDependency -> target.add(notation.toCoordinates())
+            is ExternalModuleDependencyBundle -> notation.forEach { target.add(it.toCoordinates()) }
+            else -> target.add(notation)
+        }
+    }
+
+    private fun MinimalExternalModuleDependency.toCoordinates(): String {
+        val version = versionConstraint.requiredVersion
+        return if (version.isNotEmpty()) "${module.group}:${module.name}:$version"
+        else "${module.group}:${module.name}"
+    }
+}

--- a/gradle/plugins/src/main/kotlin/build.cross-version-test.gradle.kts
+++ b/gradle/plugins/src/main/kotlin/build.cross-version-test.gradle.kts
@@ -1,0 +1,62 @@
+/*
+ * Copyright 2026 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+plugins {
+    id("build.java-module")
+}
+
+val crossVersionTests = project.objects.domainObjectContainer(CrossVersionTestSuiteSpec::class.java)
+extensions.add("crossVersionTests", crossVersionTests)
+
+val crossVersionTest = tasks.register("crossVersionTest") {
+    group = "verification"
+    description = "Runs all cross-version test suites."
+}
+
+tasks.named("fullCheck") { dependsOn(crossVersionTest) }
+
+// all{} fires on a freshly-created spec before register{} and configureEach{} configure actions
+// have run (Gradle fires whenObjectAdded at creation time). Defer all spec-reading to afterEvaluate,
+// by which point the spec's dep lists and minJavaVersion have been fully populated.
+crossVersionTests.all {
+    val spec = this
+    project.afterEvaluate {
+        val suite = addTestSuite(spec.name, spec.minJavaVersion.getOrElse(8)) { }
+
+        // Set source dirs to the shared crossVersionTest source tree
+        sourceSets.named(spec.name) {
+            java.setSrcDirs(emptyList<String>())
+            extensions.getByType(org.gradle.api.tasks.GroovySourceDirectorySet::class.java)
+                .setSrcDirs(listOf("src/crossVersionTest/groovy"))
+            resources.setSrcDirs(listOf("src/crossVersionTest/resources"))
+        }
+
+        // Cut all ties to testImplementation/testRuntimeOnly
+        configurations.named("${spec.name}Implementation") { setExtendsFrom(emptyList()) }
+        configurations.named("${spec.name}RuntimeOnly") { setExtendsFrom(emptyList()) }
+
+        // Apply deps from the spec. Catalog entries have been eagerly converted to coordinate
+        // strings in CrossVersionTestSuiteSpec.addDep(), so DependencyHandler.add(String, Object)
+        // handles them correctly.
+        dependencies {
+            "${spec.name}Implementation"(sourceSets.named("main").get().output)
+            spec.implementationDependencies.forEach { dep -> "${spec.name}Implementation"(dep) }
+            spec.runtimeOnlyDependencies.forEach { dep -> "${spec.name}RuntimeOnly"(dep) }
+        }
+
+        crossVersionTest { dependsOn(suite) }
+    }
+}

--- a/hibernate/hibernate.gradle.kts
+++ b/hibernate/hibernate.gradle.kts
@@ -15,6 +15,7 @@
  */
 
 plugins {
+    id("build.cross-version-test")
     id("build.java-module")
     id("build.publish")
 }
@@ -28,37 +29,28 @@ dependencies {
     testImplementation(libs.hibernate.v5)
 }
 
-val crossVersionTestHibernate5 = addCrossVersionTestSuite("crossVersionTestHibernate5", 8) {
-    dependencies {
+crossVersionTests {
+    configureEach {
+        implementation(libs.bundles.testing.groovy4)
+        runtimeOnly(libs.bundles.testing.runtime)
+        implementation(projects.test)
+        implementation(libs.h2)
+    }
+    register("crossVersionTestHibernate5") {
+        minJavaVersion = 8
         implementation(libs.hibernate.v5)
-        implementation(libs.h2)
     }
-}
-addCrossVersionTestSuite("crossVersionTestHibernate6", 11) {
-    dependencies {
+    register("crossVersionTestHibernate6") {
+        minJavaVersion = 11
         implementation(libs.hibernate.v6)
-        implementation(libs.h2)
     }
-}
-addCrossVersionTestSuite("crossVersionTestHibernate7", 17) {
-    dependencies {
+    register("crossVersionTestHibernate7") {
+        minJavaVersion = 17
         implementation(libs.hibernate.v7)
-        implementation(libs.h2)
     }
 }
 
-tasks.named("check") { dependsOn(crossVersionTestHibernate5) }
-
-configurations {
-    // Exclude the compile-time Hibernate (org.hibernate:hibernate-core) from suites that use
-    // Hibernate 6+, which changed groupId to org.hibernate.orm
-    "crossVersionTestHibernate6Implementation" {
-        exclude(group = "org.hibernate", module = "hibernate-core")
-    }
-    "crossVersionTestHibernate7Implementation" {
-        exclude(group = "org.hibernate", module = "hibernate-core")
-    }
-}
+tasks.named("check") { dependsOn("crossVersionTestHibernate5") }
 
 publishing {
     publications.named<MavenPublication>("maven") {

--- a/jooq/jooq.gradle.kts
+++ b/jooq/jooq.gradle.kts
@@ -28,6 +28,65 @@ dependencies {
     testImplementation(libs.h2)
 }
 
+val crossVersionTestJooqV3_0 = addCrossVersionTestSuite("crossVersionTestJooqV3_0", 8) {
+    // jOOQ 3.0.0: compile target, minimum supported version (Java 8)
+    dependencies {
+        implementation(libs.jooq.v300)
+        implementation(libs.h2)
+    }
+}
+addCrossVersionTestSuite("crossVersionTestJooqV3_14", 8) {
+    // jOOQ 3.14.16: last Java 8 version
+    dependencies {
+        implementation(libs.jooq.v314)
+        implementation(libs.h2)
+    }
+}
+addCrossVersionTestSuite("crossVersionTestJooqV3_16", 11) {
+    // jOOQ 3.16.10: last Java 11 version
+    dependencies {
+        implementation(libs.jooq.v316)
+        implementation(libs.h2)
+    }
+}
+addCrossVersionTestSuite("crossVersionTestJooqV3_19", 17) {
+    // jOOQ 3.19.31: last Java 17 version (last open-source before Java 21 was required)
+    dependencies {
+        implementation(libs.jooq.v319)
+        implementation(libs.h2)
+    }
+}
+addCrossVersionTestSuite("crossVersionTestJooqV3_21", 21) {
+    // jOOQ 3.21.1: latest version (Java 21)
+    dependencies {
+        implementation(libs.jooq.v321)
+        implementation(libs.h2)
+    }
+}
+
+// The v3_0 suite tests the minimum supported version and runs as part of regular check
+tasks.named("check") { dependsOn(crossVersionTestJooqV3_0) }
+
+// Force each suite to use its specific jOOQ version, overriding the 3.14.16 inherited
+// from testImplementation and the 3.0.0 compile-only dependency
+listOf("CompileClasspath", "RuntimeClasspath").forEach { suffix ->
+    configurations.named("crossVersionTestJooqV3_0$suffix") {
+        resolutionStrategy.force("org.jooq:jooq:3.0.0")
+    }
+    configurations.named("crossVersionTestJooqV3_14$suffix") {
+        resolutionStrategy.force("org.jooq:jooq:3.14.16")
+    }
+    configurations.named("crossVersionTestJooqV3_16$suffix") {
+        resolutionStrategy.force("org.jooq:jooq:3.16.10")
+    }
+    configurations.named("crossVersionTestJooqV3_19$suffix") {
+        resolutionStrategy.force("org.jooq:jooq:3.19.31")
+    }
+    configurations.named("crossVersionTestJooqV3_21$suffix") {
+        resolutionStrategy.force("org.jooq:jooq:3.21.1")
+    }
+}
+
 publishing {
     publications.named<MavenPublication>("maven") {
         from(components["java"])

--- a/jooq/jooq.gradle.kts
+++ b/jooq/jooq.gradle.kts
@@ -15,77 +15,56 @@
  */
 
 plugins {
+    id("build.cross-version-test")
     id("build.java-module")
     id("build.publish")
 }
 
 dependencies {
 	api(projects.core)
-	compileOnly(libs.jooq.compile)
+	compileOnly(libs.jooq.v300)
 
     testImplementation(projects.test)
-    testImplementation(libs.jooq.test)
+    testImplementation(libs.jooq.v314)
     testImplementation(libs.h2)
 }
 
-val crossVersionTestJooqV3_0 = addCrossVersionTestSuite("crossVersionTestJooqV3_0", 8) {
-    // jOOQ 3.0.0: compile target, minimum supported version (Java 8)
-    dependencies {
+crossVersionTests {
+    configureEach {
+        implementation(libs.bundles.testing.groovy4)
+        runtimeOnly(libs.bundles.testing.runtime)
+        implementation(projects.test)
+        implementation(libs.h2)
+    }
+    register("crossVersionTestJooqV3_0") {
+        // jOOQ 3.0.0: compile target, minimum supported version (Java 8)
+        minJavaVersion = 8
         implementation(libs.jooq.v300)
-        implementation(libs.h2)
     }
-}
-addCrossVersionTestSuite("crossVersionTestJooqV3_14", 8) {
-    // jOOQ 3.14.16: last Java 8 version
-    dependencies {
+    register("crossVersionTestJooqV3_14") {
+        // jOOQ 3.14.16: last Java 8 version
+        minJavaVersion = 8
         implementation(libs.jooq.v314)
-        implementation(libs.h2)
     }
-}
-addCrossVersionTestSuite("crossVersionTestJooqV3_16", 11) {
-    // jOOQ 3.16.10: last Java 11 version
-    dependencies {
+    register("crossVersionTestJooqV3_16") {
+        // jOOQ 3.16.10: last Java 11 version
+        minJavaVersion = 11
         implementation(libs.jooq.v316)
-        implementation(libs.h2)
     }
-}
-addCrossVersionTestSuite("crossVersionTestJooqV3_19", 17) {
-    // jOOQ 3.19.31: last Java 17 version (last open-source before Java 21 was required)
-    dependencies {
+    register("crossVersionTestJooqV3_19") {
+        // jOOQ 3.19.31: last Java 17 version (last open-source before Java 21 was required)
+        minJavaVersion = 17
         implementation(libs.jooq.v319)
-        implementation(libs.h2)
     }
-}
-addCrossVersionTestSuite("crossVersionTestJooqV3_21", 21) {
-    // jOOQ 3.21.1: latest version (Java 21)
-    dependencies {
+    register("crossVersionTestJooqV3_21") {
+        // jOOQ 3.21.1: latest version (Java 21)
+        minJavaVersion = 21
         implementation(libs.jooq.v321)
-        implementation(libs.h2)
     }
 }
 
 // The v3_0 suite tests the minimum supported version and runs as part of regular check
-tasks.named("check") { dependsOn(crossVersionTestJooqV3_0) }
-
-// Force each suite to use its specific jOOQ version, overriding the 3.14.16 inherited
-// from testImplementation and the 3.0.0 compile-only dependency
-listOf("CompileClasspath", "RuntimeClasspath").forEach { suffix ->
-    configurations.named("crossVersionTestJooqV3_0$suffix") {
-        resolutionStrategy.force("org.jooq:jooq:3.0.0")
-    }
-    configurations.named("crossVersionTestJooqV3_14$suffix") {
-        resolutionStrategy.force("org.jooq:jooq:3.14.16")
-    }
-    configurations.named("crossVersionTestJooqV3_16$suffix") {
-        resolutionStrategy.force("org.jooq:jooq:3.16.10")
-    }
-    configurations.named("crossVersionTestJooqV3_19$suffix") {
-        resolutionStrategy.force("org.jooq:jooq:3.19.31")
-    }
-    configurations.named("crossVersionTestJooqV3_21$suffix") {
-        resolutionStrategy.force("org.jooq:jooq:3.21.1")
-    }
-}
+tasks.named("check") { dependsOn("crossVersionTestJooqV3_0") }
 
 publishing {
     publications.named<MavenPublication>("maven") {

--- a/jooq/src/crossVersionTest/groovy/io/jdev/miniprofiler/jooq/JooqCrossVersionSpec.groovy
+++ b/jooq/src/crossVersionTest/groovy/io/jdev/miniprofiler/jooq/JooqCrossVersionSpec.groovy
@@ -1,0 +1,104 @@
+/*
+ * Copyright 2026 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.jdev.miniprofiler.jooq
+
+import groovy.sql.Sql
+import io.jdev.miniprofiler.Profiler
+import io.jdev.miniprofiler.test.TestProfilerProvider
+import org.h2.jdbcx.JdbcDataSource
+import org.jooq.DSLContext
+import org.jooq.SQLDialect
+import org.jooq.impl.DSL
+import spock.lang.Specification
+
+class JooqCrossVersionSpec extends Specification {
+
+    TestProfilerProvider profilerProvider
+    JdbcDataSource ds
+    DSLContext db
+
+    void setup() {
+        profilerProvider = new TestProfilerProvider()
+
+        ds = new JdbcDataSource()
+        ds.URL = "jdbc:h2:mem:jooq_cross_version_test;DB_CLOSE_DELAY=-1"
+        ds.user = "sa"
+        ds.password = "sa"
+
+        // DefaultConfiguration.set(DataSource) was added after 3.0, so we use
+        // DSL.using(DataSource, SQLDialect) and then set the listener on the live config.
+        db = DSL.using(ds, SQLDialect.H2)
+        db.configuration().set(new MiniProfilerExecuteListenerProvider(profilerProvider))
+
+        new Sql(ds).execute("create table if not exists foo (id int, name varchar(50))")
+    }
+
+    void "profiles SELECT queries and inlines parameters"() {
+        given:
+        new Sql(ds).execute("delete from foo")
+        new Sql(ds).execute("insert into foo values (1, 'test')")
+        def profiler = profilerProvider.start("select-test")
+
+        when:
+        db.resultQuery("select * from foo where id = ?", 1).fetch()
+
+        then:
+        hasProfiledSql(profiler, "select * from foo where id = 1")
+
+        cleanup:
+        profiler?.stop()
+    }
+
+    void "profiles INSERT queries and inlines parameters"() {
+        given:
+        def profiler = profilerProvider.start("insert-test")
+
+        when:
+        db.query("insert into foo values (?, ?)", 2, "bar").execute()
+
+        then:
+        hasProfiledSql(profiler, "insert into foo values (2, 'bar')")
+
+        cleanup:
+        profiler?.stop()
+    }
+
+    void "profiles batch queries"() {
+        given:
+        def profiler = profilerProvider.start("batch-test")
+
+        when:
+        db.batch(
+            db.query("insert into foo values (?, ?)", 10, "alpha"),
+            db.query("insert into foo values (?, ?)", 11, "beta")
+        ).execute()
+
+        then:
+        def sqlTimings = profiler.root.customTimings["sql"]
+        sqlTimings != null && sqlTimings.size() == 1
+        sqlTimings[0].commandString.contains("insert into foo values (10, 'alpha')")
+        sqlTimings[0].commandString.contains("insert into foo values (11, 'beta')")
+
+        cleanup:
+        profiler?.stop()
+    }
+
+    private static boolean hasProfiledSql(Profiler profiler, String expectedSql) {
+        def sqlTimings = profiler.root.customTimings["sql"]
+        return sqlTimings != null && sqlTimings.any { it.commandString == expectedSql }
+    }
+}

--- a/test-geb-groovy3/test-geb-groovy3.gradle.kts
+++ b/test-geb-groovy3/test-geb-groovy3.gradle.kts
@@ -54,8 +54,7 @@ sourceSets.named("browserTest") {
 
 dependencies {
     "browserTestImplementation"(projects.core)
-    "browserTestImplementation"(libs.groovy.v3)
-    "browserTestImplementation"(libs.spock.groovy3)
+    "browserTestImplementation"(libs.bundles.testing.groovy3)
 }
 
 // build.java-module adds org.apache.groovy (groovy.v4) — exclude all of it so only groovy.v3 is on the browserTest classpath


### PR DESCRIPTION
## Summary

- Adds cross-version integration tests for jOOQ, covering versions 3.0.0 (minimum
  supported, Java 8), 3.14.16 (last Java 8), 3.16.10 (last Java 11), 3.19.31 (last
  Java 17 / last open-source), and 3.21.1 (latest, Java 21)
- Refactors the cross-version test infrastructure introduced for Hibernate and
  EclipseLink into a `build.cross-version-test` convention plugin with a
  `crossVersionTests` container DSL, eliminating boilerplate and the need for manual
  `resolutionStrategy.force()` calls
- Adds a `crossVersionTest` lifecycle task per module aggregating all suites, wired
  to `fullCheck`
- Updates CI so `check` (unit + minimum cross-version suite) runs in the build step,
  and `fullCheck` (browser/scenario tests + all cross-version suites) runs under xvfb