### PR TITLE
Fix all build warnings and enable -Werror for Java/Groovy compilation

### DIFF
--- a/core/core.gradle.kts
+++ b/core/core.gradle.kts
@@ -45,9 +45,10 @@ dependencies {
 }
 
 tasks.named<ProcessResources>("processResources") {
+    val projectVersion = version.toString()
 	filesMatching("**/miniprofiler-version.txt") {
 		filter(mapOf("tokens" to mapOf(
-            "version" to project.version
+            "version" to projectVersion
         )), ReplaceTokens::class.java)
 	}
     inputs.property("version", version)

--- a/core/src/main/java/io/jdev/miniprofiler/ProfilerProviderLocator.java
+++ b/core/src/main/java/io/jdev/miniprofiler/ProfilerProviderLocator.java
@@ -43,12 +43,16 @@ public interface ProfilerProviderLocator {
 
     /**
      * Returns the order of this locator. Lower values are consulted first.
+     *
+     * @return the order value; lower values are consulted first
      */
     int getOrder();
 
     /**
      * Attempts to locate a {@link ProfilerProvider}. Returns an empty
      * {@link Optional} if this locator is not applicable in the current environment.
+     *
+     * @return an {@link Optional} containing the provider, or empty if not applicable
      */
     Optional<ProfilerProvider> locate();
 
@@ -59,6 +63,8 @@ public interface ProfilerProviderLocator {
      *
      * <p>Falls back to a new {@link StaticProfilerProvider} if no locator succeeds,
      * though in practice the {@link StaticProfilerProviderLocator} always succeeds.</p>
+     *
+     * @return the located {@link ProfilerProvider}
      */
     static ProfilerProvider findProvider() {
         List<ProfilerProviderLocator> locators = new ArrayList<>();

--- a/core/src/main/java/io/jdev/miniprofiler/server/MiniProfilerServer.java
+++ b/core/src/main/java/io/jdev/miniprofiler/server/MiniProfilerServer.java
@@ -127,13 +127,19 @@ public class MiniProfilerServer implements AutoCloseable {
         httpServer.start();
     }
 
-    /** Returns the TCP port this server is listening on. */
+    /**
+     * Returns the TCP port this server is listening on.
+     *
+     * @return the TCP port this server is listening on
+     */
     public int getPort() {
         return httpServer.getAddress().getPort();
     }
 
     /**
      * Returns the base URL for this server, e.g. {@code http://127.0.0.1:12345/}.
+     *
+     * @return the base URL, e.g. {@code "http://127.0.0.1:12345/"}
      */
     public String getBaseUrl() {
         return "http://127.0.0.1:" + getPort() + "/";
@@ -286,6 +292,8 @@ public class MiniProfilerServer implements AutoCloseable {
 
     /**
      * Returns the underlying {@link ProfilerProvider}.
+     *
+     * @return the underlying {@link ProfilerProvider}
      */
     public ProfilerProvider getProvider() {
         return provider;

--- a/core/src/main/java/io/jdev/miniprofiler/sql/log4jdbc/CallableStatementSpy.java
+++ b/core/src/main/java/io/jdev/miniprofiler/sql/log4jdbc/CallableStatementSpy.java
@@ -1013,7 +1013,7 @@ public class CallableStatementSpy extends PreparedStatementSpy implements Callab
     }
   }
 
-  public Object getObject(int i, Map map) throws SQLException
+  public Object getObject(int i, Map<String, Class<?>> map) throws SQLException
   {
     String methodCall = "getObject(" + i + ", " + map + ")";
     try
@@ -1666,6 +1666,7 @@ public class CallableStatementSpy extends PreparedStatementSpy implements Callab
     reportReturn(methodCall);
   }
 
+  @SuppressWarnings("unchecked")
   public <T> T unwrap(Class<T> iface) throws SQLException {
     String methodCall = "unwrap(" + (iface==null?"null":iface.getName()) + ")";
     try

--- a/core/src/main/java/io/jdev/miniprofiler/sql/log4jdbc/ConnectionSpy.java
+++ b/core/src/main/java/io/jdev/miniprofiler/sql/log4jdbc/ConnectionSpy.java
@@ -69,7 +69,7 @@ public class ConnectionSpy implements Connection, Spy
    * Contains a Mapping of connectionNumber to currently open ConnectionSpy
    * objects.
    */
-  private static final Map connectionTracker = new HashMap();
+  private static final Map<Integer, ConnectionSpy> connectionTracker = new HashMap<>();
 
   /**
    * Get a dump of how many connections are open, and which connection numbers
@@ -89,7 +89,7 @@ public class ConnectionSpy implements Connection, Spy
       {
         return "open connections:  none";
       }
-      Set keys = connectionTracker.keySet();
+      Set<Integer> keys = connectionTracker.keySet();
       keysArr = (Integer[]) keys.toArray(new Integer[keys.size()]);
     }
 
@@ -742,6 +742,7 @@ public class ConnectionSpy implements Connection, Spy
     }
   }
 
+  @SuppressWarnings("unchecked")
   public Map<String,Class<?>> getTypeMap() throws SQLException
   {
     String methodCall = "getTypeMap()";
@@ -911,6 +912,7 @@ public class ConnectionSpy implements Connection, Spy
     reportReturn(methodCall);
   }
 
+  @SuppressWarnings("unchecked")
   public <T> T unwrap(Class<T> iface) throws SQLException {
     String methodCall = "unwrap(" + (iface==null?"null":iface.getName()) + ")";
     try

--- a/core/src/main/java/io/jdev/miniprofiler/sql/log4jdbc/DriverSpy.java
+++ b/core/src/main/java/io/jdev/miniprofiler/sql/log4jdbc/DriverSpy.java
@@ -104,7 +104,7 @@ public class DriverSpy implements Driver
    * Maps driver class names to RdbmsSpecifics objects for each kind of
    * database.
    */
-  private static Map rdbmsSpecifics;
+  private static Map<String, RdbmsSpecifics> rdbmsSpecifics;
 
   static final SpyLogDelegator log = SpyLogFactory.getSpyLogDelegator();
 
@@ -455,7 +455,7 @@ public class DriverSpy implements Driver
     // time.  The driver can spy on any driver type, it's just a little bit
     // easier to configure log4jdbc if it's one of these types!
 
-    Set subDrivers = new TreeSet();
+    Set<String> subDrivers = new TreeSet<>();
 
     if (AutoLoadPopularDrivers)
     {
@@ -509,9 +509,9 @@ public class DriverSpy implements Driver
     // instantiate all the supported drivers and remove
     // those not found
     String driverClass;
-    for (Iterator i = subDrivers.iterator(); i.hasNext();)
+    for (Iterator<String> i = subDrivers.iterator(); i.hasNext();)
     {
-      driverClass = (String) i.next();
+      driverClass = i.next();
       try
       {
         Class.forName(driverClass);
@@ -534,7 +534,7 @@ public class DriverSpy implements Driver
     MySqlRdbmsSpecifics mySql = new MySqlRdbmsSpecifics();
 
     /** create lookup Map for specific rdbms formatters */
-    rdbmsSpecifics = new HashMap();
+    rdbmsSpecifics = new HashMap<>();
     rdbmsSpecifics.put("oracle.jdbc.driver.OracleDriver", oracle);
     rdbmsSpecifics.put("oracle.jdbc.OracleDriver", oracle);
     rdbmsSpecifics.put("net.sourceforge.jtds.jdbc.Driver", sqlServer);
@@ -569,7 +569,7 @@ public class DriverSpy implements Driver
 
     log.debug("driver name is " + driverName);
 
-    RdbmsSpecifics r = (RdbmsSpecifics) rdbmsSpecifics.get(driverName);
+    RdbmsSpecifics r = rdbmsSpecifics.get(driverName);
 
     if (r == null)
     {
@@ -741,7 +741,7 @@ public class DriverSpy implements Driver
       String dclass = d.getClass().getName();
       if (dclass != null && dclass.length() > 0)
       {
-        r = (RdbmsSpecifics) rdbmsSpecifics.get(dclass);
+        r = rdbmsSpecifics.get(dclass);
       }
 
       if (r == null)

--- a/core/src/main/java/io/jdev/miniprofiler/sql/log4jdbc/PostLogProfilerProcessor.java
+++ b/core/src/main/java/io/jdev/miniprofiler/sql/log4jdbc/PostLogProfilerProcessor.java
@@ -91,7 +91,7 @@ public class PostLogProfilerProcessor {
   /**
    * Collection of all sql that took longer than "threshold" msec to run.
    */
-  private List flaggedSql = new LinkedList();
+  private List<ProfiledSql> flaggedSql = new LinkedList<>();
 
   /**
    * Process given filename, and produce sql profiling report to given PrintStream.

--- a/core/src/main/java/io/jdev/miniprofiler/sql/log4jdbc/PreparedStatementSpy.java
+++ b/core/src/main/java/io/jdev/miniprofiler/sql/log4jdbc/PreparedStatementSpy.java
@@ -50,7 +50,7 @@ public class PreparedStatementSpy extends StatementSpy implements PreparedStatem
   /**
    * holds list of bind variables for tracing
    */
-  protected final List argTrace = new ArrayList();
+  protected final List<String> argTrace = new ArrayList<>();
 
   // a way to turn on and off type help...
   // todo:  make this a configurable parameter
@@ -119,7 +119,7 @@ public class PreparedStatementSpy extends StatementSpy implements PreparedStatem
       {
         try
         {
-          arg = (String) argTrace.get(argIdx);
+          arg = argTrace.get(argIdx);
         }
         catch (IndexOutOfBoundsException e)
         {
@@ -1115,6 +1115,7 @@ public class PreparedStatementSpy extends StatementSpy implements PreparedStatem
     reportReturn(methodCall);
   }
 
+  @SuppressWarnings("unchecked")
   public <T> T unwrap(Class<T> iface) throws SQLException {
     String methodCall = "unwrap(" + (iface==null?"null":iface.getName()) + ")";
     try

--- a/core/src/main/java/io/jdev/miniprofiler/sql/log4jdbc/ResultSetSpy.java
+++ b/core/src/main/java/io/jdev/miniprofiler/sql/log4jdbc/ResultSetSpy.java
@@ -1860,7 +1860,7 @@ public class ResultSetSpy implements ResultSet, Spy
     }
   }
 
-  public Object getObject(String colName, Map map) throws SQLException
+  public Object getObject(String colName, Map<String, Class<?>> map) throws SQLException
   {
     String methodCall = "getObject(" + colName + ", " + map + ")";
     try
@@ -2914,6 +2914,7 @@ public class ResultSetSpy implements ResultSet, Spy
     }
   }
 
+  @SuppressWarnings("unchecked")
   public <T> T unwrap(Class<T> iface) throws SQLException {
     String methodCall = "unwrap(" + (iface==null?"null":iface.getName()) + ")";
     try

--- a/core/src/main/java/io/jdev/miniprofiler/sql/log4jdbc/StatementSpy.java
+++ b/core/src/main/java/io/jdev/miniprofiler/sql/log4jdbc/StatementSpy.java
@@ -433,7 +433,7 @@ public class StatementSpy implements Statement, Spy
    * Tracking of current batch (see addBatch, clearBatch and executeBatch)
    * //todo: should access to this List be synchronized?
    */
-  protected List currentBatch = new ArrayList();
+  protected List<String> currentBatch = new ArrayList<>();
 
   public void addBatch(String sql) throws SQLException
   {
@@ -509,7 +509,7 @@ public class StatementSpy implements Statement, Spy
     String sql;
     for (int i=0; i < j;)
     {
-      sql = (String) currentBatch.get(i);
+      sql = currentBatch.get(i);
       batchReport.append("\n");
       batchReport.append(Utilities.rightJustify(fieldSize,""+(++i)));
       batchReport.append(":  ");
@@ -987,6 +987,7 @@ public class StatementSpy implements Statement, Spy
     }
   }
 
+  @SuppressWarnings("unchecked")
   public <T> T unwrap(Class<T> iface) throws SQLException {
     String methodCall = "unwrap(" + (iface==null?"null":iface.getName()) + ")";
     try

--- a/doc/manual/manual.gradle.kts
+++ b/doc/manual/manual.gradle.kts
@@ -38,7 +38,7 @@ val api by tasks.registering(Javadoc::class) {
     group = "manual"
     description = "Generate combined Javadoc for all published modules"
 
-    destinationDir = file("$buildDir/api")
+    destinationDir = layout.buildDirectory.dir("api").get().asFile
 
     val javadocTasks = rootProject.subprojects
         .filter { it.plugins.hasPlugin("java") && it.plugins.hasPlugin("build.publish") }
@@ -59,7 +59,7 @@ val packageManual by tasks.registering(Sync::class) {
     group = "manual"
     description = "Brings together manual and API reference"
 
-    into("$buildDir/manual")
+    into(layout.buildDirectory.dir("manual"))
     from(tasks.asciidoctor)
 
     into("api") {
@@ -91,13 +91,10 @@ val manualZip by tasks.registering(Zip::class) {
     from(packageManual)
 }
 
-artifacts {
-    archives(manualZip)
-}
-
 publishing {
     publications.named<MavenPublication>("maven") {
         artifactId = "miniprofiler-manual"
+        artifact(manualZip)
         pom {
             name = "MiniProfiler Manual"
             description = "The manual for MiniProfiler JVM"

--- a/eclipselink/src/main/java/io/jdev/miniprofiler/eclipselink/LegacyProfilingSessionCustomizer.java
+++ b/eclipselink/src/main/java/io/jdev/miniprofiler/eclipselink/LegacyProfilingSessionCustomizer.java
@@ -30,7 +30,7 @@ import org.eclipse.persistence.sessions.Session;
  *
  * @see ProfilingSessionCustomizer
  */
-@SuppressWarnings("deprecation")
+@SuppressWarnings({"deprecation", "removal"})
 public class LegacyProfilingSessionCustomizer implements org.eclipse.persistence.config.SessionCustomizer {
 
     private final ProfilerProvider profilerProvider;

--- a/gradle/plugins/settings.gradle.kts
+++ b/gradle/plugins/settings.gradle.kts
@@ -24,4 +24,6 @@ dependencyResolutionManagement {
 
 include("build-parameters")
 
+rootProject.name = "plugins"
+
 enableFeaturePreview("TYPESAFE_PROJECT_ACCESSORS")

--- a/gradle/plugins/src/main/kotlin/build.java-module.gradle.kts
+++ b/gradle/plugins/src/main/kotlin/build.java-module.gradle.kts
@@ -93,6 +93,10 @@ tasks.named("sanityCheck") {
     dependsOn(tasks.withType<Javadoc>())
 }
 
+tasks.withType<Javadoc>().configureEach {
+    (options as StandardJavadocDocletOptions).addStringOption("Xdoclint:all,-missing/private")
+}
+
 tasks.named("fullCheck") {
     dependsOn(tasks.named("check"))
 }

--- a/gradle/plugins/src/main/kotlin/build.java-module.gradle.kts
+++ b/gradle/plugins/src/main/kotlin/build.java-module.gradle.kts
@@ -93,6 +93,14 @@ tasks.named("sanityCheck") {
     dependsOn(tasks.withType<Javadoc>())
 }
 
+tasks.withType<JavaCompile>().configureEach {
+    options.compilerArgs.add("-Werror")
+}
+
+tasks.withType<GroovyCompile>().configureEach {
+    options.compilerArgs.add("-Werror")
+}
+
 tasks.withType<Javadoc>().configureEach {
     (options as StandardJavadocDocletOptions).addStringOption("Xdoclint:all,-missing/private")
 }

--- a/gradle/plugins/src/main/kotlin/build.ratpack.gradle.kts
+++ b/gradle/plugins/src/main/kotlin/build.ratpack.gradle.kts
@@ -1,0 +1,27 @@
+/*
+ * Copyright 2026 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import org.gradle.process.CommandLineArgumentProvider
+
+// Guice 4.x (a transitive dependency of ratpack) uses ClassLoader.defineClass via reflection,
+// which is illegal on Java 9+ without an explicit open. The argument is a no-op on Java 8.
+project.tasks.withType<Test>().configureEach {
+    jvmArgumentProviders.add(CommandLineArgumentProvider {
+        val version = javaLauncher.orNull?.metadata?.languageVersion?.asInt()
+            ?: JavaVersion.current().majorVersion.toInt()
+        if (version >= 9) listOf("--add-opens=java.base/java.lang=ALL-UNNAMED") else emptyList()
+    })
+}

--- a/jakarta-ee/src/main/java/io/jdev/miniprofiler/jakarta/ee/CdiProfilerProviderLocator.java
+++ b/jakarta-ee/src/main/java/io/jdev/miniprofiler/jakarta/ee/CdiProfilerProviderLocator.java
@@ -39,6 +39,7 @@ public class CdiProfilerProviderLocator implements ProfilerProviderLocator {
     }
 
     @Override
+    @SuppressWarnings("unchecked")
     public Optional<ProfilerProvider> locate() {
         try {
             Object lookedUp = lookupBeanManagerFromJndi();

--- a/jakarta-ee/src/main/java/io/jdev/miniprofiler/jakarta/ee/DefaultCDIProfilerProvider.java
+++ b/jakarta-ee/src/main/java/io/jdev/miniprofiler/jakarta/ee/DefaultCDIProfilerProvider.java
@@ -21,6 +21,10 @@ import io.jdev.miniprofiler.DefaultProfilerProvider;
 import jakarta.enterprise.context.ApplicationScoped;
 import jakarta.enterprise.inject.Default;
 
+/**
+ * CDI {@link jakarta.enterprise.context.ApplicationScoped} implementation of
+ * {@link io.jdev.miniprofiler.DefaultProfilerProvider} for use in Jakarta EE applications.
+ */
 @ApplicationScoped
 @Default
 public class DefaultCDIProfilerProvider extends DefaultProfilerProvider {

--- a/jakarta-ee/src/main/java/io/jdev/miniprofiler/jakarta/ee/Profiled.java
+++ b/jakarta-ee/src/main/java/io/jdev/miniprofiler/jakarta/ee/Profiled.java
@@ -24,6 +24,10 @@ import static java.lang.annotation.ElementType.METHOD;
 import static java.lang.annotation.ElementType.TYPE;
 import static java.lang.annotation.RetentionPolicy.RUNTIME;
 
+/**
+ * Marks a method or class for MiniProfiler step profiling via
+ * {@link ProfilingEJBInterceptor}.
+ */
 @InterceptorBinding
 @Target({METHOD, TYPE})
 @Retention(RUNTIME)

--- a/jakarta-ee/src/main/java/io/jdev/miniprofiler/jakarta/ee/ProfilingEJBInterceptor.java
+++ b/jakarta-ee/src/main/java/io/jdev/miniprofiler/jakarta/ee/ProfilingEJBInterceptor.java
@@ -25,6 +25,10 @@ import jakarta.interceptor.AroundInvoke;
 import jakarta.interceptor.Interceptor;
 import jakarta.interceptor.InvocationContext;
 
+/**
+ * CDI interceptor that wraps EJB method invocations in a MiniProfiler timing step.
+ * Apply {@link Profiled} to a class or method to enable profiling.
+ */
 @Interceptor
 @Profiled
 public class ProfilingEJBInterceptor {
@@ -32,6 +36,13 @@ public class ProfilingEJBInterceptor {
     @Inject
     private ProfilerProvider profilerProvider;
 
+    /**
+     * Wraps the intercepted method in a MiniProfiler {@link io.jdev.miniprofiler.Timing} step.
+     *
+     * @param ctx the invocation context
+     * @return the result of {@link jakarta.interceptor.InvocationContext#proceed()}
+     * @throws Exception if the intercepted method throws
+     */
     @AroundInvoke
     public Object profile(InvocationContext ctx) throws Exception {
         Profiler profiler = profilerProvider.current();

--- a/jakarta-servlet/src/main/java/io/jdev/miniprofiler/jakarta/servlet/ProfilingFilter.java
+++ b/jakarta-servlet/src/main/java/io/jdev/miniprofiler/jakarta/servlet/ProfilingFilter.java
@@ -61,10 +61,15 @@ public class ProfilingFilter implements Filter {
     private static final String CONTENT_TYPE_JSON = "application/json";
     private static final String ID_PARAM = "id";
 
+    /** The profiler provider used to start and retrieve profiling sessions. */
     protected ProfilerProvider profilerProvider = new StaticProfilerProvider();
+    /** The URL path prefix for MiniProfiler resources, e.g. {@code "/miniprofiler"}. */
     protected String profilerPath = DEFAULT_PROFILER_PATH;
+    /** Allowed {@code Origin} for CORS, or {@code null} to disallow cross-origin requests. */
     protected String allowedOrigin;
+    /** Helper for serving MiniProfiler static resources. */
     protected ResourceHelper resourceHelper = new ResourceHelper();
+    /** The servlet context this filter is registered in. */
     protected ServletContext servletContext;
 
     @Override
@@ -268,6 +273,13 @@ public class ProfilingFilter implements Filter {
         }
     }
 
+    /**
+     * Starts a new profiling session for the given request.
+     *
+     * @param id      the profiler session ID
+     * @param request the current HTTP request
+     * @return the started {@link Profiler}
+     */
     protected Profiler startProfiling(UUID id, HttpServletRequest request) {
         return profilerProvider.start(id, request.getRequestURI());
     }

--- a/jakarta-servlet/src/main/java/io/jdev/miniprofiler/jakarta/servlet/jsp/ScriptTag.java
+++ b/jakarta-servlet/src/main/java/io/jdev/miniprofiler/jakarta/servlet/jsp/ScriptTag.java
@@ -49,6 +49,7 @@ public class ScriptTag extends TagSupport {
     private Boolean authorized;
     private Boolean startHidden;
 
+    /** Creates a new instance backed by the current global {@link io.jdev.miniprofiler.ProfilerProvider}. */
     public ScriptTag() {
         setProfilerProvider(MiniProfiler.getProfilerProvider());
     }
@@ -114,51 +115,63 @@ public class ScriptTag extends TagSupport {
         return config;
     }
 
+    /** Sets the {@link ProfilerProvider} that supplies the current profiler. */
     public void setProfilerProvider(ProfilerProvider profilerProvider) {
         this.profilerProvider = profilerProvider;
         this.scriptTagWriter = new ScriptTagWriter(profilerProvider);
     }
 
+    /** Sets an explicit path override for MiniProfiler resources; if {@code null}, the provider's configured path is used. */
     public void setPath(String path) {
         this.path = path;
     }
 
+    /** Sets the UI display position; value is matched case-insensitively to {@link io.jdev.miniprofiler.ProfilerUiConfig.Position}. */
     public void setPosition(String position) {
         this.position = position == null ? null : ConfigHelper.findEnum(ProfilerUiConfig.Position.class, position);
     }
 
+    /** Sets the UI color scheme; value is matched case-insensitively to {@link io.jdev.miniprofiler.ProfilerUiConfig.ColorScheme}. */
     public void setColorScheme(String scheme) {
         this.colorScheme = scheme == null ? null : ConfigHelper.findEnum(ProfilerUiConfig.ColorScheme.class, scheme);
     }
 
+    /** Sets the keyboard shortcut for toggling the MiniProfiler popup. */
     public void setToggleShortcut(String toggleShortcut) {
         this.toggleShortcut = toggleShortcut;
     }
 
+    /** Sets the maximum number of trace entries to display in the popup. */
     public void setMaxTraces(Integer maxTraces) {
         this.maxTraces = maxTraces;
     }
 
+    /** Sets the threshold in milliseconds below which timings are considered trivial. */
     public void setTrivialMilliseconds(Integer trivialMilliseconds) {
         this.trivialMilliseconds = trivialMilliseconds;
     }
 
+    /** Sets whether trivial timings are shown by default. */
     public void setTrivial(boolean trivial) {
         this.trivial = trivial;
     }
 
+    /** Sets whether child timings are expanded by default. */
     public void setChildren(boolean children) {
         this.children = children;
     }
 
+    /** Sets whether control buttons are shown in the popup. */
     public void setControls(boolean controls) {
         this.controls = controls;
     }
 
+    /** Sets whether the current user is authorized to view profiling results. */
     public void setAuthorized(boolean authorized) {
         this.authorized = authorized;
     }
 
+    /** Sets whether the MiniProfiler popup starts in the hidden state. */
     public void setStartHidden(boolean startHidden) {
         this.startHidden = startHidden;
     }

--- a/javax-ee/src/main/java/io/jdev/miniprofiler/javax/ee/CdiProfilerProviderLocator.java
+++ b/javax-ee/src/main/java/io/jdev/miniprofiler/javax/ee/CdiProfilerProviderLocator.java
@@ -39,6 +39,7 @@ public class CdiProfilerProviderLocator implements ProfilerProviderLocator {
     }
 
     @Override
+    @SuppressWarnings("unchecked")
     public Optional<ProfilerProvider> locate() {
         try {
             Object lookedUp = lookupBeanManagerFromJndi();

--- a/ratpack/ratpack.gradle.kts
+++ b/ratpack/ratpack.gradle.kts
@@ -18,6 +18,7 @@ plugins {
     id("build.browser-test")
     id("build.java-module")
     id("build.publish")
+    id("build.ratpack")
     id("java-test-fixtures")
 }
 

--- a/ratpack/src/main/java/io/jdev/miniprofiler/ratpack/AsyncStorage.java
+++ b/ratpack/src/main/java/io/jdev/miniprofiler/ratpack/AsyncStorage.java
@@ -51,6 +51,7 @@ public interface AsyncStorage extends Storage {
      * Stores the given profiling information
      *
      * @param profiler the profiling information to store
+     * @return an operation that performs the save
      */
     default Operation saveAsync(ProfilerImpl profiler) {
         return Blocking.op(() -> save(profiler));
@@ -71,6 +72,7 @@ public interface AsyncStorage extends Storage {
      *
      * @param user the user
      * @param id   the id of the session
+     * @return an operation that marks the session as un-viewed
      */
     default Operation setUnviewedAsync(String user, UUID id) {
         return Blocking.op(() -> setUnviewed(user, id));
@@ -81,6 +83,7 @@ public interface AsyncStorage extends Storage {
      *
      * @param user the user
      * @param id   the id of the session
+     * @return an operation that marks the session as viewed
      */
     default Operation setViewedAsync(String user, UUID id) {
         return Blocking.op(() -> setViewed(user, id));

--- a/scenario-test/glassfish7/src/main/java/io/jdev/miniprofiler/glassfish7/funtest/IndexServlet.java
+++ b/scenario-test/glassfish7/src/main/java/io/jdev/miniprofiler/glassfish7/funtest/IndexServlet.java
@@ -24,12 +24,21 @@ import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 import java.io.IOException;
 
+/** Servlet that renders the index page listing all people, for the GlassFish 7 functional test application. */
 @WebServlet("")
 public class IndexServlet extends HttpServlet {
 
     @EJB
     private PersonService personService;
 
+    /**
+     * Handles GET requests by loading all people and forwarding to the index JSP.
+     *
+     * @param req  the HTTP request
+     * @param resp the HTTP response
+     * @throws ServletException if the request cannot be handled
+     * @throws IOException      on I/O error
+     */
     @Override
     protected void doGet(HttpServletRequest req, HttpServletResponse resp) throws ServletException, IOException {
         req.setAttribute("people", personService.getAllPeople());

--- a/scenario-test/glassfish7/src/main/java/io/jdev/miniprofiler/glassfish7/funtest/Person.java
+++ b/scenario-test/glassfish7/src/main/java/io/jdev/miniprofiler/glassfish7/funtest/Person.java
@@ -18,6 +18,7 @@ package io.jdev.miniprofiler.glassfish7.funtest;
 
 import jakarta.persistence.*;
 
+/** JPA entity representing a person in the GlassFish 7 functional test application. */
 @Entity
 public class Person {
 
@@ -31,26 +32,32 @@ public class Person {
     @Column(nullable = false)
     private String lastName;
 
+    /** Returns the person's ID. */
     public Long getId() {
         return id;
     }
 
+    /** Sets the person's ID. */
     public void setId(Long id) {
         this.id = id;
     }
 
+    /** Returns the person's first name. */
     public String getFirstName() {
         return firstName;
     }
 
+    /** Sets the person's first name. */
     public void setFirstName(String firstName) {
         this.firstName = firstName;
     }
 
+    /** Returns the person's last name. */
     public String getLastName() {
         return lastName;
     }
 
+    /** Sets the person's last name. */
     public void setLastName(String lastName) {
         this.lastName = lastName;
     }

--- a/scenario-test/glassfish7/src/main/java/io/jdev/miniprofiler/glassfish7/funtest/PersonService.java
+++ b/scenario-test/glassfish7/src/main/java/io/jdev/miniprofiler/glassfish7/funtest/PersonService.java
@@ -18,8 +18,11 @@ package io.jdev.miniprofiler.glassfish7.funtest;
 
 import java.util.List;
 
+/** Service interface for managing {@link Person} entities in the GlassFish 7 test application. */
 public interface PersonService {
+    /** Returns all people in the database. */
     List<Person> getAllPeople();
 
+    /** Creates and persists a new person with the given name. */
     Person createPerson(String firstName, String lastName);
 }

--- a/scenario-test/glassfish7/src/main/java/io/jdev/miniprofiler/glassfish7/funtest/PersonServiceImpl.java
+++ b/scenario-test/glassfish7/src/main/java/io/jdev/miniprofiler/glassfish7/funtest/PersonServiceImpl.java
@@ -26,6 +26,7 @@ import jakarta.persistence.EntityManager;
 import jakarta.persistence.PersistenceContext;
 import java.util.List;
 
+/** EJB implementation of {@link PersonService} for the GlassFish 7 functional test application. */
 @Stateless
 @Profiled
 public class PersonServiceImpl implements PersonService {

--- a/scenario-test/glassfish7/src/main/java/io/jdev/miniprofiler/glassfish7/funtest/Startup.java
+++ b/scenario-test/glassfish7/src/main/java/io/jdev/miniprofiler/glassfish7/funtest/Startup.java
@@ -21,6 +21,7 @@ import jakarta.servlet.ServletContextEvent;
 import jakarta.servlet.ServletContextListener;
 import jakarta.servlet.annotation.WebListener;
 
+/** Populates initial test data on application startup for the GlassFish 7 functional test application. */
 @WebListener
 public class Startup implements ServletContextListener {
 

--- a/scenario-test/jetty12-servlet/src/main/java/io/jdev/miniprofiler/servlettest/Startup.java
+++ b/scenario-test/jetty12-servlet/src/main/java/io/jdev/miniprofiler/servlettest/Startup.java
@@ -26,6 +26,7 @@ import java.sql.Connection;
 import java.sql.SQLException;
 import java.sql.Statement;
 
+/** Sets up the in-memory H2 database and registers a {@link ProfilingDataSource} on application startup. */
 public class Startup implements ServletContextListener {
 
     @Override

--- a/scenario-test/ratpack1/ratpack1.gradle.kts
+++ b/scenario-test/ratpack1/ratpack1.gradle.kts
@@ -17,6 +17,7 @@
 plugins {
     id("build.scenario-test")
     id("build.java-module")
+    id("build.ratpack")
     id("application")
 }
 

--- a/scenario-test/ratpack1/src/main/java/io/jdev/miniprofiler/ratpack/funtest/Main.java
+++ b/scenario-test/ratpack1/src/main/java/io/jdev/miniprofiler/ratpack/funtest/Main.java
@@ -24,6 +24,8 @@ import io.jdev.miniprofiler.ratpack.MiniProfilerStartProfilingHandlers;
 import ratpack.guice.Guice;
 import ratpack.handlebars.HandlebarsModule;
 import ratpack.server.*;
+import ratpack.service.Service;
+import ratpack.service.StartEvent;
 
 import javax.sql.DataSource;
 import java.sql.Connection;

--- a/scenario-test/wildfly27/src/main/java/io/jdev/miniprofiler/wildfly27/funtest/IndexServlet.java
+++ b/scenario-test/wildfly27/src/main/java/io/jdev/miniprofiler/wildfly27/funtest/IndexServlet.java
@@ -24,12 +24,21 @@ import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 import java.io.IOException;
 
+/** Servlet that renders the index page listing all people, for the WildFly 27 functional test application. */
 @WebServlet("")
 public class IndexServlet extends HttpServlet {
 
     @EJB
     private PersonService personService;
 
+    /**
+     * Handles GET requests by loading all people and forwarding to the index JSP.
+     *
+     * @param req  the HTTP request
+     * @param resp the HTTP response
+     * @throws ServletException if the request cannot be handled
+     * @throws IOException      on I/O error
+     */
     @Override
     protected void doGet(HttpServletRequest req, HttpServletResponse resp) throws ServletException, IOException {
         req.setAttribute("people", personService.getAllPeople());

--- a/scenario-test/wildfly27/src/main/java/io/jdev/miniprofiler/wildfly27/funtest/Person.java
+++ b/scenario-test/wildfly27/src/main/java/io/jdev/miniprofiler/wildfly27/funtest/Person.java
@@ -18,6 +18,7 @@ package io.jdev.miniprofiler.wildfly27.funtest;
 
 import jakarta.persistence.*;
 
+/** JPA entity representing a person in the WildFly 27 functional test application. */
 @Entity
 public class Person {
 
@@ -31,26 +32,32 @@ public class Person {
     @Column(nullable = false)
     private String lastName;
 
+    /** Returns the person's ID. */
     public Long getId() {
         return id;
     }
 
+    /** Sets the person's ID. */
     public void setId(Long id) {
         this.id = id;
     }
 
+    /** Returns the person's first name. */
     public String getFirstName() {
         return firstName;
     }
 
+    /** Sets the person's first name. */
     public void setFirstName(String firstName) {
         this.firstName = firstName;
     }
 
+    /** Returns the person's last name. */
     public String getLastName() {
         return lastName;
     }
 
+    /** Sets the person's last name. */
     public void setLastName(String lastName) {
         this.lastName = lastName;
     }

--- a/scenario-test/wildfly27/src/main/java/io/jdev/miniprofiler/wildfly27/funtest/PersonService.java
+++ b/scenario-test/wildfly27/src/main/java/io/jdev/miniprofiler/wildfly27/funtest/PersonService.java
@@ -18,8 +18,11 @@ package io.jdev.miniprofiler.wildfly27.funtest;
 
 import java.util.List;
 
+/** Service interface for managing {@link Person} entities in the WildFly 27 test application. */
 public interface PersonService {
+    /** Returns all people in the database. */
     List<Person> getAllPeople();
 
+    /** Creates and persists a new person with the given name. */
     Person createPerson(String firstName, String lastName);
 }

--- a/scenario-test/wildfly27/src/main/java/io/jdev/miniprofiler/wildfly27/funtest/PersonServiceImpl.java
+++ b/scenario-test/wildfly27/src/main/java/io/jdev/miniprofiler/wildfly27/funtest/PersonServiceImpl.java
@@ -26,6 +26,7 @@ import jakarta.persistence.EntityManager;
 import jakarta.persistence.PersistenceContext;
 import java.util.List;
 
+/** EJB implementation of {@link PersonService} for the WildFly 27 functional test application. */
 @Stateless
 @Profiled
 public class PersonServiceImpl implements PersonService {

--- a/scenario-test/wildfly27/src/main/java/io/jdev/miniprofiler/wildfly27/funtest/Startup.java
+++ b/scenario-test/wildfly27/src/main/java/io/jdev/miniprofiler/wildfly27/funtest/Startup.java
@@ -21,6 +21,7 @@ import jakarta.servlet.ServletContextEvent;
 import jakarta.servlet.ServletContextListener;
 import jakarta.servlet.annotation.WebListener;
 
+/** Populates initial test data on application startup for the WildFly 27 functional test application. */
 @WebListener
 public class Startup implements ServletContextListener {
 

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -8,6 +8,7 @@ plugins {
     id("build.build-parameters")
     id("com.gradle.develocity") version "4.4.0"
     id("com.gradle.common-custom-user-data-gradle-plugin") version "2.5.0"
+    id("org.gradle.toolchains.foojay-resolver-convention") version "1.0.0"
 }
 
 includeBuild("gradle/plugins")

--- a/test/src/main/java/io/jdev/miniprofiler/test/ExpectedTiming.java
+++ b/test/src/main/java/io/jdev/miniprofiler/test/ExpectedTiming.java
@@ -48,7 +48,11 @@ public final class ExpectedTiming {
         return minDurationMs;
     }
 
-    /** Child timings in order. Never null; may be empty. */
+    /**
+     * Child timings in order. Never null; may be empty.
+     *
+     * @return child timings in order; never null, may be empty
+     */
     public List<ExpectedTiming> getChildren() {
         return children;
     }
@@ -56,6 +60,8 @@ public final class ExpectedTiming {
     /**
      * Custom timings keyed by type (e.g. {@code "sql"}).
      * Never null; may be empty.
+     *
+     * @return custom timings keyed by type; never null, may be empty
      */
     public Map<String, List<ExpectedCustomTiming>> getCustomTimings() {
         return customTimings;

--- a/test/src/main/java/io/jdev/miniprofiler/test/ProfilerComparator.java
+++ b/test/src/main/java/io/jdev/miniprofiler/test/ProfilerComparator.java
@@ -49,6 +49,8 @@ public final class ProfilerComparator {
     /**
      * Verifies that {@code actual} matches {@code expected}.
      *
+     * @param actual the profiler to verify
+     * @param expected the expected profiler shape to verify against
      * @throws AssertionError if any aspect of the actual profiler does not match
      */
     public static void verify(ProfilerImpl actual, ExpectedProfiler expected) {

--- a/test/src/main/java/io/jdev/miniprofiler/test/ProfilerDsl.java
+++ b/test/src/main/java/io/jdev/miniprofiler/test/ProfilerDsl.java
@@ -64,6 +64,7 @@ public final class ProfilerDsl {
      * @param name         the expected profiler name
      * @param minDurationMs minimum expected duration in milliseconds
      * @param spec         spec that configures the root timing's children and custom timings
+     * @return the built {@link ExpectedProfiler}
      */
     public static ExpectedProfiler profiler(String name, long minDurationMs, Consumer<TimingBuilder> spec) {
         TimingBuilder rootBuilder = new TimingBuilder(name, minDurationMs);
@@ -74,6 +75,10 @@ public final class ProfilerDsl {
     /**
      * Creates an {@link ExpectedProfiler} with the given name and no minimum duration
      * constraint, configured by the given spec.
+     *
+     * @param name the expected profiler name
+     * @param spec spec that configures the root timing's children and custom timings
+     * @return the built {@link ExpectedProfiler}
      */
     public static ExpectedProfiler profiler(String name, Consumer<TimingBuilder> spec) {
         return profiler(name, 0, spec);
@@ -82,6 +87,10 @@ public final class ProfilerDsl {
     /**
      * Creates an {@link ExpectedProfiler} with the given name and a minimum duration
      * but no children or custom timings.
+     *
+     * @param name the expected profiler name
+     * @param minDurationMs minimum expected duration in milliseconds
+     * @return the built {@link ExpectedProfiler}
      */
     public static ExpectedProfiler profiler(String name, long minDurationMs) {
         return profiler(name, minDurationMs, b -> {
@@ -91,6 +100,9 @@ public final class ProfilerDsl {
     /**
      * Creates an {@link ExpectedProfiler} with the given name and no minimum duration,
      * children, or custom timings.
+     *
+     * @param name the expected profiler name
+     * @return the built {@link ExpectedProfiler}
      */
     public static ExpectedProfiler profiler(String name) {
         return profiler(name, 0, b -> {
@@ -114,6 +126,11 @@ public final class ProfilerDsl {
 
         /**
          * Adds a child timing step with a minimum duration, configured by the given spec.
+         *
+         * @param stepName the name of the timing step
+         * @param stepMinDurationMs minimum expected duration in milliseconds
+         * @param spec spec that configures the step's children and custom timings
+         * @return this builder
          */
         public TimingBuilder step(String stepName, long stepMinDurationMs, Consumer<TimingBuilder> spec) {
             TimingBuilder child = new TimingBuilder(stepName, stepMinDurationMs);
@@ -124,6 +141,10 @@ public final class ProfilerDsl {
 
         /**
          * Adds a child timing step with no minimum duration constraint, configured by the given spec.
+         *
+         * @param stepName the name of the timing step
+         * @param spec spec that configures the step's children and custom timings
+         * @return this builder
          */
         public TimingBuilder step(String stepName, Consumer<TimingBuilder> spec) {
             return step(stepName, 0, spec);
@@ -131,6 +152,9 @@ public final class ProfilerDsl {
 
         /**
          * Adds a child timing step with no minimum duration and no children or custom timings.
+         *
+         * @param stepName the name of the timing step
+         * @return this builder
          */
         public TimingBuilder step(String stepName) {
             return step(stepName, 0, b -> {
@@ -144,6 +168,7 @@ public final class ProfilerDsl {
          * @param executeType   the execute type (e.g. {@code "reader"})
          * @param commandString the command string; whitespace will be normalised during comparison
          * @param minDurationMs minimum expected duration in milliseconds
+         * @return this builder
          */
         public TimingBuilder customTiming(String type, String executeType, String commandString, long minDurationMs) {
             customTimings.computeIfAbsent(type, k -> new ArrayList<>())
@@ -153,6 +178,11 @@ public final class ProfilerDsl {
 
         /**
          * Adds an expected custom timing entry with no minimum duration constraint.
+         *
+         * @param type the custom timing type key (e.g. {@code "sql"})
+         * @param executeType the execute type (e.g. {@code "reader"})
+         * @param commandString the command string; whitespace will be normalised during comparison
+         * @return this builder
          */
         public TimingBuilder customTiming(String type, String executeType, String commandString) {
             return customTiming(type, executeType, commandString, 0);

--- a/testlib-integration/src/main/java/io/jdev/miniprofiler/integtest/InProcessTestedServer.java
+++ b/testlib-integration/src/main/java/io/jdev/miniprofiler/integtest/InProcessTestedServer.java
@@ -34,6 +34,8 @@ public interface InProcessTestedServer extends TestedServer {
     /**
      * Returns the profiler provider used by this server.
      * Cast to {@link io.jdev.miniprofiler.BaseProfilerProvider} to access storage.
+     *
+     * @return the profiler provider
      */
     ProfilerProvider getProfilerProvider();
 
@@ -41,6 +43,8 @@ public interface InProcessTestedServer extends TestedServer {
      * Returns the URL path (relative to serverUrl) of a page that serves an HTML response
      * with the MiniProfiler floating button widget, profiled with a child step and SQL timing.
      * Returns {@code null} for implementations that don't serve application pages (e.g. the viewer).
+     *
+     * @return the URL path, or {@code null} if not applicable
      */
     default String getProfiledPagePath() {
         return null;
@@ -51,6 +55,8 @@ public interface InProcessTestedServer extends TestedServer {
      * the {@code X-MiniProfiler-Ids} response header, suitable for testing AJAX profiling.
      * Returns {@code null} for implementations that don't profile application requests
      * (e.g. core server, viewer).
+     *
+     * @return the URL path, or {@code null} if not applicable
      */
     default String getAjaxEndpointPath() {
         return null;

--- a/testlib-integration/src/main/java/io/jdev/miniprofiler/integtest/TestHttpResponse.java
+++ b/testlib-integration/src/main/java/io/jdev/miniprofiler/integtest/TestHttpResponse.java
@@ -40,12 +40,20 @@ public class TestHttpResponse {
         this.headers = headers;
     }
 
-    /** Returns the HTTP status code. */
+    /**
+     * Returns the HTTP status code.
+     *
+     * @return the HTTP status code
+     */
     public int statusCode() {
         return statusCode;
     }
 
-    /** Returns the response body as a string. */
+    /**
+     * Returns the response body as a string.
+     *
+     * @return the response body as a string
+     */
     public String body() {
         return body;
     }
@@ -53,6 +61,9 @@ public class TestHttpResponse {
     /**
      * Returns the first value of the named response header, or empty if not present.
      * Header name matching is case-insensitive.
+     *
+     * @param name the header name (case-insensitive)
+     * @return the first value, or empty if not present
      */
     public Optional<String> header(String name) {
         String lower = name.toLowerCase(Locale.ROOT);
@@ -70,12 +81,18 @@ public class TestHttpResponse {
     /**
      * Parses the response body as JSON using Groovy's {@code JsonSlurper}.
      * Returns a {@code Map} for JSON objects or a {@code List} for JSON arrays.
+     *
+     * @return the parsed JSON as a {@code Map} or {@code List}
      */
     public Object bodyAsJson() {
         return new JsonSlurper().parseText(body);
     }
 
-    /** Returns the value of the {@code Content-Type} response header, or empty if not present. */
+    /**
+     * Returns the value of the {@code Content-Type} response header, or empty if not present.
+     *
+     * @return the Content-Type header value, or empty if absent
+     */
     public Optional<String> contentType() {
         return header("content-type");
     }
@@ -83,6 +100,8 @@ public class TestHttpResponse {
     /**
      * Parses the {@code X-MiniProfiler-Ids} response header and returns all profiler IDs.
      * Throws {@link AssertionError} if the header is absent or malformed.
+     *
+     * @return all profiler IDs
      */
     public List<String> miniProfilerIds() {
         String headerValue = header("X-MiniProfiler-Ids")
@@ -109,6 +128,8 @@ public class TestHttpResponse {
     /**
      * Returns the single profiler ID from the {@code X-MiniProfiler-Ids} response header.
      * Throws {@link AssertionError} if the header is absent, malformed, or contains more than one ID.
+     *
+     * @return the single profiler ID
      */
     public String miniProfilerId() {
         List<String> ids = miniProfilerIds();

--- a/testlib-integration/src/main/java/io/jdev/miniprofiler/integtest/TestMiniProfilerHttpClient.java
+++ b/testlib-integration/src/main/java/io/jdev/miniprofiler/integtest/TestMiniProfilerHttpClient.java
@@ -62,6 +62,8 @@ public class TestMiniProfilerHttpClient {
      * Sends a GET request to {@code baseUrl + path}.
      *
      * @param path path relative to the base URL, e.g. {@code ""} for the root, {@code "page"} for {@code /page}
+     * @return the response
+     * @throws IOException on network error
      */
     public TestHttpResponse get(String path) throws IOException {
         return get(path, Collections.<String, String>emptyMap());
@@ -69,6 +71,11 @@ public class TestMiniProfilerHttpClient {
 
     /**
      * Sends a GET request to {@code baseUrl + path} with the given request headers.
+     *
+     * @param path path relative to the base URL
+     * @param headers the extra request headers
+     * @return the response
+     * @throws IOException on network error
      */
     public TestHttpResponse get(String path, Map<String, String> headers) throws IOException {
         HttpURLConnection conn = (HttpURLConnection) new URL(baseUrl + path).openConnection();
@@ -87,6 +94,10 @@ public class TestMiniProfilerHttpClient {
     /**
      * Fetches a MiniProfiler result as JSON: {@code GET miniprofiler/results?id=<id>}
      * with {@code Accept: application/json}.
+     *
+     * @param id the profiler result ID
+     * @return the response
+     * @throws IOException on network error
      */
     public TestHttpResponse getResultsJson(String id) throws IOException {
         return get(profilerPath + "/results?id=" + id, Collections.singletonMap("Accept", "application/json"));
@@ -94,6 +105,10 @@ public class TestMiniProfilerHttpClient {
 
     /**
      * Fetches a MiniProfiler result as HTML: {@code GET <profilerPath>/results?id=<id>}.
+     *
+     * @param id the profiler result ID
+     * @return the response
+     * @throws IOException on network error
      */
     public TestHttpResponse getResultsHtml(String id) throws IOException {
         return get(profilerPath + "/results?id=" + id);
@@ -101,6 +116,9 @@ public class TestMiniProfilerHttpClient {
 
     /**
      * Fetches the full results list: {@code GET <profilerPath>/results-list}.
+     *
+     * @return the response
+     * @throws IOException on network error
      */
     public TestHttpResponse getResultsList() throws IOException {
         return get(profilerPath + "/results-list");
@@ -108,6 +126,10 @@ public class TestMiniProfilerHttpClient {
 
     /**
      * Fetches results after a given profile ID: {@code GET <profilerPath>/results-list?last-id=<lastId>}.
+     *
+     * @param lastId the last seen ID for pagination
+     * @return the response
+     * @throws IOException on network error
      */
     public TestHttpResponse getResultsList(String lastId) throws IOException {
         return get(profilerPath + "/results-list?last-id=" + lastId);
@@ -115,6 +137,9 @@ public class TestMiniProfilerHttpClient {
 
     /**
      * Fetches the results index page: {@code GET <profilerPath>/results-index}.
+     *
+     * @return the response
+     * @throws IOException on network error
      */
     public TestHttpResponse getResultsIndex() throws IOException {
         return get(profilerPath + "/results-index");
@@ -122,6 +147,10 @@ public class TestMiniProfilerHttpClient {
 
     /**
      * Fetches a static resource: {@code GET <profilerPath>/<name>}.
+     *
+     * @param name the resource file name
+     * @return the response
+     * @throws IOException on network error
      */
     public TestHttpResponse getStaticResource(String name) throws IOException {
         return get(profilerPath + "/" + name);

--- a/testlib-integration/src/main/java/io/jdev/miniprofiler/integtest/TestedServer.java
+++ b/testlib-integration/src/main/java/io/jdev/miniprofiler/integtest/TestedServer.java
@@ -26,6 +26,8 @@ public interface TestedServer extends Closeable {
 
     /**
      * Returns the base URL of this server, e.g. {@code "http://127.0.0.1:12345/"}.
+     *
+     * @return the base URL, e.g. {@code "http://127.0.0.1:12345/"}
      */
     String getServerUrl();
 


### PR DESCRIPTION
## Summary
- Fix build warnings across Java sources and Gradle build scripts (unchecked casts, raw types, deprecations, unused imports, missing `@Override`, redundant config in build scripts)
- Suppress illegal reflective access warning from Guice 4.x in ratpack test JVMs via `--add-opens` in a shared `build.ratpack` convention plugin
- Fix all javadoc doclint warnings across 9 modules (missing `@param`, `@return`, `@throws` tags, malformed HTML)
- Enable `-Werror` on Java and Groovy compile tasks so warnings become build failures going forward