### PR TITLE
Disable Javadoc for non-published projects and vendored code in core

### DIFF
--- a/core/core.gradle.kts
+++ b/core/core.gradle.kts
@@ -55,6 +55,13 @@ tasks.named<ProcessResources>("processResources") {
 }
 
 
+// exclude vendored log4jdbc and hibernate SQL formatter from Javadoc - these are
+// third-party code included for implementation purposes, not part of the public API
+tasks.named<Javadoc>("javadoc") {
+    exclude("io/jdev/miniprofiler/sql/log4jdbc/**")
+    exclude("io/jdev/miniprofiler/sql/hibernate/**")
+}
+
 // include hibernate builder source, since it's LGPL and we don't want to add any
 // extra burden on people who might be bundling this library in
 tasks.named<Jar>("jar").configure {

--- a/gradle/plugins/src/main/kotlin/build.java-module.gradle.kts
+++ b/gradle/plugins/src/main/kotlin/build.java-module.gradle.kts
@@ -90,7 +90,6 @@ tasks.named("sanityCheck") {
     dependsOn(tasks.withType<AbstractCompile>())
     dependsOn(tasks.withType<Checkstyle>())
     dependsOn(tasks.withType<CodeNarc>())
-    dependsOn(tasks.withType<Javadoc>())
 }
 
 tasks.withType<JavaCompile>().configureEach {
@@ -101,8 +100,21 @@ tasks.withType<GroovyCompile>().configureEach {
     options.compilerArgs.add("-Werror")
 }
 
-tasks.withType<Javadoc>().configureEach {
-    (options as StandardJavadocDocletOptions).addStringOption("Xdoclint:all,-missing/private")
+plugins.withId("build.publish") {
+    tasks.withType<Javadoc>().configureEach {
+        (options as StandardJavadocDocletOptions).addStringOption("Xdoclint:all,-missing/private")
+    }
+    tasks.named("sanityCheck") {
+        dependsOn(tasks.withType<Javadoc>())
+    }
+}
+
+afterEvaluate {
+    if (!plugins.hasPlugin("build.publish")) {
+        tasks.withType<Javadoc>().configureEach {
+            enabled = false
+        }
+    }
 }
 
 tasks.named("fullCheck") {


### PR DESCRIPTION
Non-published projects (testlib-integration, testlib-browser) no longer
generate Javadoc: the task is explicitly disabled and excluded from
sanityCheck. Javadoc doclint configuration and sanityCheck dependency
are now conditional on the build.publish plugin being present.

The core module's Javadoc now excludes the vendored log4jdbc and
hibernate SQL formatter packages, which are third-party licensed code
not intended for public API documentation.