### PR TITLE
Add build.groovy-module plugin with Groovydoc in published javadoc jar

### DIFF
--- a/gradle/plugins/src/main/kotlin/build.groovy-module.gradle.kts
+++ b/gradle/plugins/src/main/kotlin/build.groovy-module.gradle.kts
@@ -1,0 +1,25 @@
+/*
+ * Copyright 2026 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+plugins {
+    id("build.java-module")
+}
+
+plugins.withId("build.publish") {
+    tasks.named<Jar>("javadocJar") {
+        from(tasks.named("groovydoc"))
+    }
+}

--- a/test-geb-groovy3/test-geb-groovy3.gradle.kts
+++ b/test-geb-groovy3/test-geb-groovy3.gradle.kts
@@ -17,7 +17,7 @@
 plugins {
     id("build.base")
     id("build.build-parameters")
-    id("build.java-module")
+    id("build.groovy-module")
     id("build.publish")
 }
 

--- a/test-geb-groovy4/test-geb-groovy4.gradle.kts
+++ b/test-geb-groovy4/test-geb-groovy4.gradle.kts
@@ -16,7 +16,7 @@
 
 plugins {
     id("build.browser-test")
-    id("build.java-module")
+    id("build.groovy-module")
     id("build.publish")
 }
 


### PR DESCRIPTION
The two Geb test support modules (`test-geb-groovy3`, `test-geb-groovy4`) publish their APIs as Groovy source. The standard `javadoc` task produces empty output for Groovy files, so the published `-javadoc.jar` was effectively useless for consumers.

This PR introduces a `build.groovy-module` convention plugin for Groovy-centric modules. It composes `build.java-module` (inheriting all standard compilation, quality checks, and test wiring) and additionally includes the output of the `groovydoc` task in the published javadoc jar when `build.publish` is also applied.

Both Geb modules are updated to apply `build.groovy-module` in place of `build.java-module`.