### PR TITLE
Upgrade javadoc generation to JDK 25 with -Xwerror

### DIFF
--- a/core/src/main/java/io/jdev/miniprofiler/BaseProfilerProvider.java
+++ b/core/src/main/java/io/jdev/miniprofiler/BaseProfilerProvider.java
@@ -32,6 +32,11 @@ import java.util.UUID;
  * the current profiler.
  */
 public abstract class BaseProfilerProvider implements ProfilerProvider {
+
+    /** Creates a new instance. */
+    protected BaseProfilerProvider() {}
+
+    /** Storage used to persist completed profiler sessions. */
     protected Storage storage = new MapStorage();
     private String machineName = getDefaultHostname();
     private UserProvider userProvider;
@@ -183,6 +188,11 @@ public abstract class BaseProfilerProvider implements ProfilerProvider {
         }
     }
 
+    /**
+     * Saves the given profiler session to storage.
+     *
+     * @param currentProfiler the profiler session to save
+     */
     protected void saveProfiler(ProfilerImpl currentProfiler) {
         storage.save(currentProfiler);
     }

--- a/core/src/main/java/io/jdev/miniprofiler/CustomTiming.java
+++ b/core/src/main/java/io/jdev/miniprofiler/CustomTiming.java
@@ -23,14 +23,35 @@ import java.io.Closeable;
  */
 public interface CustomTiming extends Closeable {
 
+    /**
+     * Returns the type of custom timing (e.g. "sql", "memcache").
+     *
+     * @return the execute type string
+     */
     String getExecuteType();
 
+    /**
+     * Returns the command string being timed (e.g. the SQL query).
+     *
+     * @return the command string
+     */
     String getCommandString();
 
+    /**
+     * Returns the start time in milliseconds since the profiler session started.
+     *
+     * @return the start time in milliseconds
+     */
     long getStartMilliseconds();
 
+    /**
+     * Returns the duration in milliseconds, or null if the timing has not yet stopped.
+     *
+     * @return the duration in milliseconds, or null
+     */
     Long getDurationMilliseconds();
 
+    /** Stops this timing and records its duration. */
     void stop();
 
     /**

--- a/core/src/main/java/io/jdev/miniprofiler/DefaultProfilerProvider.java
+++ b/core/src/main/java/io/jdev/miniprofiler/DefaultProfilerProvider.java
@@ -23,6 +23,9 @@ package io.jdev.miniprofiler;
  */
 public class DefaultProfilerProvider extends BaseProfilerProvider {
 
+    /** Creates a new instance. */
+    public DefaultProfilerProvider() {}
+
     private static final ThreadLocal<Profiler> PROFILER_HOLDER = new ThreadLocal<Profiler>();
 
     @Override

--- a/core/src/main/java/io/jdev/miniprofiler/DelegatingProfilerProvider.java
+++ b/core/src/main/java/io/jdev/miniprofiler/DelegatingProfilerProvider.java
@@ -26,6 +26,14 @@ import java.util.UUID;
  */
 public abstract class DelegatingProfilerProvider implements ProfilerProvider {
 
+    /** Creates a new instance. */
+    protected DelegatingProfilerProvider() {}
+
+    /**
+     * Returns the delegate profiler provider to which all calls are forwarded.
+     *
+     * @return the delegate profiler provider
+     */
     protected abstract ProfilerProvider getDelegate();
 
     @Override
@@ -88,6 +96,7 @@ public abstract class DelegatingProfilerProvider implements ProfilerProvider {
         return getDelegate().getUiConfig();
     }
 
+    @Override
     public void setUiConfig(ProfilerUiConfig uiConfig) {
         getDelegate().setUiConfig(uiConfig);
     }

--- a/core/src/main/java/io/jdev/miniprofiler/MiniProfiler.java
+++ b/core/src/main/java/io/jdev/miniprofiler/MiniProfiler.java
@@ -41,6 +41,10 @@ import java.util.ServiceLoader;
  * might be instrumented code.</p>
  */
 public class MiniProfiler {
+
+    /** Use the static methods on this class. */
+    private MiniProfiler() {}
+
     private static volatile ProfilerProvider profilerProvider;
     private static String version;
 

--- a/core/src/main/java/io/jdev/miniprofiler/ProfileLevel.java
+++ b/core/src/main/java/io/jdev/miniprofiler/ProfileLevel.java
@@ -22,5 +22,8 @@ package io.jdev.miniprofiler;
  * @see Profiler#step(String, ProfileLevel)
  */
 public enum ProfileLevel {
-    Info, Verbose
+    /** Normal level of profiling detail. */
+    Info,
+    /** Verbose level of profiling detail. */
+    Verbose
 }

--- a/core/src/main/java/io/jdev/miniprofiler/Profiler.java
+++ b/core/src/main/java/io/jdev/miniprofiler/Profiler.java
@@ -198,7 +198,6 @@ public interface Profiler extends Closeable {
     void stop(boolean discardResults);
 
     /**
-     /**
      * Same as calling {@link #stop()}.
      *
      * <p>

--- a/core/src/main/java/io/jdev/miniprofiler/ProfilerUiConfig.java
+++ b/core/src/main/java/io/jdev/miniprofiler/ProfilerUiConfig.java
@@ -25,14 +25,29 @@ import java.util.Properties;
 import static io.jdev.miniprofiler.internal.ConfigHelper.getProperty;
 import static io.jdev.miniprofiler.internal.ConfigHelper.loadPropertiesFile;
 
+/** Configuration options for the MiniProfiler UI. */
 public class ProfilerUiConfig {
 
+    /** Where the MiniProfiler popup appears on screen. */
     public enum Position {
-        Left, Right, BottomLeft, BottomRight
+        /** Positioned at the top left. */
+        Left,
+        /** Positioned at the top right. */
+        Right,
+        /** Positioned at the bottom left. */
+        BottomLeft,
+        /** Positioned at the bottom right. */
+        BottomRight
     }
 
+    /** The color theme for the MiniProfiler UI. */
     public enum ColorScheme {
-        Light, Dark, Auto
+        /** Light color scheme. */
+        Light,
+        /** Dark color scheme. */
+        Dark,
+        /** Follow the system preference. */
+        Auto
     }
 
     private String path;
@@ -47,10 +62,20 @@ public class ProfilerUiConfig {
     private boolean authorized;
     private boolean startHidden;
 
+    /**
+     * Returns the URL path at which the MiniProfiler UI is served.
+     *
+     * @return the URL path
+     */
     public String getPath() {
         return path;
     }
 
+    /**
+     * Sets the URL path at which the MiniProfiler UI is served.
+     *
+     * @param path the URL path
+     */
     public void setPath(String path) {
         if (path == null) {
             throw new IllegalArgumentException((String) null);
@@ -58,10 +83,20 @@ public class ProfilerUiConfig {
         this.path = path;
     }
 
+    /**
+     * Returns the screen position of the MiniProfiler popup.
+     *
+     * @return the screen position
+     */
     public Position getPosition() {
         return position;
     }
 
+    /**
+     * Sets the screen position of the MiniProfiler popup.
+     *
+     * @param position the screen position
+     */
     public void setPosition(Position position) {
         if (position == null) {
             throw new IllegalArgumentException((String) null);
@@ -69,10 +104,20 @@ public class ProfilerUiConfig {
         this.position = position;
     }
 
+    /**
+     * Returns the color scheme for the MiniProfiler UI.
+     *
+     * @return the color scheme
+     */
     public ColorScheme getColorScheme() {
         return colorScheme;
     }
 
+    /**
+     * Sets the color scheme for the MiniProfiler UI.
+     *
+     * @param colorScheme the color scheme
+     */
     public void setColorScheme(ColorScheme colorScheme) {
         if (colorScheme == null) {
             throw new IllegalArgumentException((String) null);
@@ -80,72 +125,157 @@ public class ProfilerUiConfig {
         this.colorScheme = colorScheme;
     }
 
+    /**
+     * Returns the keyboard shortcut to toggle the MiniProfiler UI, or null if none.
+     *
+     * @return the keyboard shortcut, or null
+     */
     public String getToggleShortcut() {
         return toggleShortcut;
     }
 
+    /**
+     * Sets the keyboard shortcut to toggle the MiniProfiler UI.
+     *
+     * @param toggleShortcut the keyboard shortcut string
+     */
     public void setToggleShortcut(String toggleShortcut) {
         this.toggleShortcut = toggleShortcut;
     }
 
+    /**
+     * Returns the maximum number of traces to show, or null to use the default.
+     *
+     * @return the maximum number of traces, or null
+     */
     public Integer getMaxTraces() {
         return maxTraces;
     }
 
+    /**
+     * Sets the maximum number of traces to show.
+     *
+     * @param maxTraces the maximum number of traces
+     */
     public void setMaxTraces(Integer maxTraces) {
         this.maxTraces = maxTraces;
     }
 
+    /**
+     * Returns the threshold in milliseconds below which a step is considered trivial, or null for the default.
+     *
+     * @return the trivial threshold in milliseconds, or null
+     */
     public Integer getTrivialMilliseconds() {
         return trivialMilliseconds;
     }
 
+    /**
+     * Sets the threshold in milliseconds below which a step is considered trivial.
+     *
+     * @param trivialMilliseconds the trivial threshold in milliseconds
+     */
     public void setTrivialMilliseconds(Integer trivialMilliseconds) {
         this.trivialMilliseconds = trivialMilliseconds;
     }
 
+    /**
+     * Returns whether trivial timings are shown.
+     *
+     * @return true if trivial timings are shown
+     */
     public boolean isTrivial() {
         return trivial;
     }
 
+    /**
+     * Sets whether trivial timings are shown.
+     *
+     * @param trivial true to show trivial timings
+     */
     public void setTrivial(boolean trivial) {
         this.trivial = trivial;
     }
 
+    /**
+     * Returns whether child timings are shown by default.
+     *
+     * @return true if child timings are shown
+     */
     public boolean isChildren() {
         return children;
     }
 
+    /**
+     * Sets whether child timings are shown by default.
+     *
+     * @param children true to show child timings by default
+     */
     public void setChildren(boolean children) {
         this.children = children;
     }
 
+    /**
+     * Returns whether the expand/collapse controls are shown.
+     *
+     * @return true if controls are shown
+     */
     public boolean isControls() {
         return controls;
     }
 
+    /**
+     * Sets whether the expand/collapse controls are shown.
+     *
+     * @param controls true to show the expand/collapse controls
+     */
     public void setControls(boolean controls) {
         this.controls = controls;
     }
 
+    /**
+     * Returns whether the current user is authorized to view profiling data.
+     *
+     * @return true if the current user is authorized
+     */
     public boolean isAuthorized() {
         return authorized;
     }
 
+    /**
+     * Sets whether the current user is authorized to view profiling data.
+     *
+     * @param authorized true if the user is authorized
+     */
     public void setAuthorized(boolean authorized) {
         this.authorized = authorized;
     }
 
+    /**
+     * Returns whether the MiniProfiler popup starts hidden.
+     *
+     * @return true if the popup starts hidden
+     */
     public boolean isStartHidden() {
         return startHidden;
     }
 
+    /**
+     * Sets whether the MiniProfiler popup starts hidden.
+     *
+     * @param startHidden true to start the popup hidden
+     */
     public void setStartHidden(boolean startHidden) {
         this.startHidden = startHidden;
     }
 
     private ProfilerUiConfig() {}
 
+    /**
+     * Returns a {@link ProfilerUiConfig} populated with default values.
+     *
+     * @return a new config with defaults
+     */
     public static ProfilerUiConfig defaults() {
         ProfilerUiConfig config = new ProfilerUiConfig();
         config.path = "/miniprofiler";
@@ -165,6 +295,11 @@ public class ProfilerUiConfig {
     private static final String SYSTEM_PROP_PREFIX = "miniprofiler.";
     private static final String MINIPROFILER_RESOURCE_NAME = "/miniprofiler.properties";
 
+    /**
+     * Creates a {@link ProfilerUiConfig} from system properties and {@code miniprofiler.properties}, falling back to defaults.
+     *
+     * @return a new config populated from system properties and the properties file
+     */
     public static ProfilerUiConfig create() {
         return create(System.getProperties(), loadPropertiesFile(MINIPROFILER_RESOURCE_NAME));
     }

--- a/core/src/main/java/io/jdev/miniprofiler/ScriptTagWriter.java
+++ b/core/src/main/java/io/jdev/miniprofiler/ScriptTagWriter.java
@@ -30,10 +30,18 @@ public class ScriptTagWriter {
 
     private final ProfilerProvider provider;
 
+    /**
+     * Creates a new script tag writer using the given profiler provider.
+     *
+     * @param provider the profiler provider to use
+     */
     public ScriptTagWriter(ProfilerProvider provider) {
         this.provider = provider;
     }
 
+    /**
+     * Creates a new script tag writer using a default {@link StaticProfilerProvider}.
+     */
     public ScriptTagWriter() {
         this(new StaticProfilerProvider());
     }

--- a/core/src/main/java/io/jdev/miniprofiler/StaticProfilerProvider.java
+++ b/core/src/main/java/io/jdev/miniprofiler/StaticProfilerProvider.java
@@ -22,6 +22,10 @@ package io.jdev.miniprofiler;
  */
 public class StaticProfilerProvider extends DelegatingProfilerProvider {
 
+    /** Creates a new static profiler provider. */
+    public StaticProfilerProvider() {
+    }
+
     @Override
     protected ProfilerProvider getDelegate() {
         return MiniProfiler.getOrCreateProfilerProvider();

--- a/core/src/main/java/io/jdev/miniprofiler/StaticProfilerProviderLocator.java
+++ b/core/src/main/java/io/jdev/miniprofiler/StaticProfilerProviderLocator.java
@@ -25,6 +25,10 @@ import java.util.Optional;
  */
 public class StaticProfilerProviderLocator implements ProfilerProviderLocator {
 
+    /** Creates a new static profiler provider locator. */
+    public StaticProfilerProviderLocator() {
+    }
+
     @Override
     public int getOrder() {
         return MINIPROFILER_STATIC_LOCATOR_ORDER;

--- a/core/src/main/java/io/jdev/miniprofiler/internal/ConfigHelper.java
+++ b/core/src/main/java/io/jdev/miniprofiler/internal/ConfigHelper.java
@@ -20,7 +20,11 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.util.*;
 
+/** Internal helper for reading configuration properties. */
 public class ConfigHelper {
+
+    /** Use the static methods on this class. */
+    private ConfigHelper() {}
 
     private static final Set<String> NULL_VALUES = Collections.unmodifiableSet(new HashSet<String>(Arrays.asList(
         "none",
@@ -28,26 +32,68 @@ public class ConfigHelper {
         ""
     )));
 
+    /**
+     * Returns the String property value, or {@code defaultValue} if not set.
+     *
+     * @param props the ordered list of property sources to search
+     * @param key the property key
+     * @param defaultValue the value to return if the property is not found
+     * @return the property value, or {@code defaultValue}
+     */
     public static String getProperty(List<PropertiesWithPrefix> props, String key, String defaultValue) {
         Result r = getProperty(props, key);
         return r != null ? r.value : defaultValue;
     }
 
+    /**
+     * Returns the boolean property value, or {@code defaultValue} if not set.
+     *
+     * @param props the ordered list of property sources to search
+     * @param key the property key
+     * @param defaultValue the value to return if the property is not found
+     * @return the property value, or {@code defaultValue}
+     */
     public static boolean getProperty(List<PropertiesWithPrefix> props, String key, boolean defaultValue) {
         Result r = getProperty(props, key);
         return r != null ? Boolean.parseBoolean(r.value) : defaultValue;
     }
 
+    /**
+     * Returns the Integer property value, or {@code defaultValue} if not set.
+     *
+     * @param props the ordered list of property sources to search
+     * @param key the property key
+     * @param defaultValue the value to return if the property is not found
+     * @return the property value, or {@code defaultValue}
+     */
     public static Integer getProperty(List<PropertiesWithPrefix> props, String key, Integer defaultValue) {
         Result r = getProperty(props, key);
         return r != null ? (r.value == null ? null : Integer.valueOf(r.value)) : defaultValue;
     }
 
+    /**
+     * Returns the enum property value, or {@code defaultValue} if not set.
+     *
+     * @param <T> the enum type
+     * @param props the ordered list of property sources to search
+     * @param key the property key
+     * @param enumClass the enum class to convert the value to
+     * @param defaultValue the value to return if the property is not found
+     * @return the property value, or {@code defaultValue}
+     */
     public static <T extends Enum<T>> T getProperty(List<PropertiesWithPrefix> props, String key, Class<T> enumClass, T defaultValue) {
         Result r = getProperty(props, key);
         return r != null ? (r.value == null ? null : findEnum(enumClass, r.value)) : defaultValue;
     }
 
+    /**
+     * Finds the enum constant matching {@code value}, case-insensitively.
+     *
+     * @param <T> the enum type
+     * @param enumClass the enum class to search
+     * @param value the string to match
+     * @return the matching enum constant
+     */
     public static <T extends Enum<T>> T findEnum(Class<T> enumClass, String value) {
         try {
             return Enum.valueOf(enumClass, value);
@@ -79,16 +125,31 @@ public class ConfigHelper {
         return null;
     }
 
+    /** A {@link Properties} instance paired with a prefix to apply to all key lookups. */
     public static class PropertiesWithPrefix {
+        /** The underlying properties. */
         public final Properties props;
+        /** The key prefix applied to all lookups in this properties instance. */
         public final String prefix;
 
+        /**
+         * Creates a new instance.
+         *
+         * @param properties the underlying properties
+         * @param prefix the key prefix to apply to all lookups
+         */
         public PropertiesWithPrefix(Properties properties, String prefix) {
             this.props = properties;
             this.prefix = prefix;
         }
     }
 
+    /**
+     * Loads a properties file from the classpath, returning null if not found.
+     *
+     * @param resourceName the classpath resource name of the properties file
+     * @return the loaded properties, or null if the resource does not exist
+     */
     public static Properties loadPropertiesFile(String resourceName) {
         InputStream resourceStream = Thread.currentThread().getContextClassLoader().getResourceAsStream(resourceName);
         if (resourceStream == null) {

--- a/core/src/main/java/io/jdev/miniprofiler/internal/NullProfiler.java
+++ b/core/src/main/java/io/jdev/miniprofiler/internal/NullProfiler.java
@@ -41,6 +41,7 @@ import java.util.concurrent.Callable;
  */
 public class NullProfiler implements Profiler {
 
+    /** Shared singleton instance. */
     public static final NullProfiler INSTANCE = new NullProfiler();
 
     private NullProfiler() {

--- a/core/src/main/java/io/jdev/miniprofiler/internal/ProfilerImpl.java
+++ b/core/src/main/java/io/jdev/miniprofiler/internal/ProfilerImpl.java
@@ -310,6 +310,11 @@ public class ProfilerImpl implements Profiler, Serializable, Jsonable {
         return this.toJSONString();
     }
 
+    /**
+     * Returns a JSON representation suitable for the results list endpoint.
+     *
+     * @return a JSON string for the results list
+     */
     public String asListJson() {
         Map<String, Object> map = new LinkedHashMap<>();
         map.put("Id", id.toString());
@@ -391,14 +396,29 @@ public class ProfilerImpl implements Profiler, Serializable, Jsonable {
         return name;
     }
 
+    /**
+     * Returns the name of the machine that produced this profiler session.
+     *
+     * @return the machine name
+     */
     public String getMachineName() {
         return machineName;
     }
 
+    /**
+     * Sets the name of the machine that produced this profiler session.
+     *
+     * @param machineName the machine name
+     */
     public void setMachineName(String machineName) {
         this.machineName = machineName;
     }
 
+    /**
+     * Returns the profiling level for this session.
+     *
+     * @return the profiling level
+     */
     public ProfileLevel getLevel() {
         return level;
     }
@@ -408,6 +428,11 @@ public class ProfilerImpl implements Profiler, Serializable, Jsonable {
         return root;
     }
 
+    /**
+     * Returns whether this profiler session contains any custom query timings.
+     *
+     * @return true if there are custom query timings
+     */
     public boolean hasQueryTimings() {
         return hasQueryTimings;
     }
@@ -421,6 +446,11 @@ public class ProfilerImpl implements Profiler, Serializable, Jsonable {
         this.head = head;
     }
 
+    /**
+     * Returns the epoch millisecond timestamp when this session started.
+     *
+     * @return the start timestamp in milliseconds
+     */
     public long getStarted() {
         return started;
     }
@@ -435,6 +465,11 @@ public class ProfilerImpl implements Profiler, Serializable, Jsonable {
         this.user = user;
     }
 
+    /**
+     * Sets whether this profiler session contains any custom query timings.
+     *
+     * @param hasQueryTimings true if there are custom query timings
+     */
     public void setHasQueryTimings(boolean hasQueryTimings) {
         this.hasQueryTimings = hasQueryTimings;
     }

--- a/core/src/main/java/io/jdev/miniprofiler/server/MiniProfilerServer.java
+++ b/core/src/main/java/io/jdev/miniprofiler/server/MiniProfilerServer.java
@@ -276,6 +276,15 @@ public class MiniProfilerServer implements AutoCloseable {
         return baos.toByteArray();
     }
 
+    /**
+     * Sends an HTTP response with the given status, content type, and body.
+     *
+     * @param exchange the HTTP exchange to respond to
+     * @param status the HTTP status code
+     * @param contentType the value of the {@code Content-Type} response header
+     * @param body the response body bytes
+     * @throws IOException if writing the response fails
+     */
     public static void sendResponse(HttpExchange exchange, int status, String contentType, byte[] body)
             throws IOException {
         exchange.getResponseHeaders().set("Content-Type", contentType);
@@ -285,6 +294,13 @@ public class MiniProfilerServer implements AutoCloseable {
         }
     }
 
+    /**
+     * Sends an HTTP error response with the given status code and no body.
+     *
+     * @param exchange the HTTP exchange to respond to
+     * @param status the HTTP status code
+     * @throws IOException if writing the response fails
+     */
     public static void sendError(HttpExchange exchange, int status) throws IOException {
         exchange.sendResponseHeaders(status, 0);
         exchange.getResponseBody().close();

--- a/core/src/main/java/io/jdev/miniprofiler/server/Pages.java
+++ b/core/src/main/java/io/jdev/miniprofiler/server/Pages.java
@@ -27,8 +27,17 @@ import java.util.Collection;
 import java.util.Optional;
 import java.util.UUID;
 
+/** Utility class for rendering MiniProfiler HTML pages. */
 public final class Pages {
 
+    /**
+     * Renders an HTML page showing the results for a single profiler session.
+     *
+     * @param profiler the profiler session to display
+     * @param provider the profiler provider to use for the script tag
+     * @param path the MiniProfiler resource path, or empty to use the provider's default
+     * @return the HTML page as a string
+     */
     public static String renderSingleResultPage(Profiler profiler, ProfilerProvider provider, Optional<String> path) {
         StringBuilder out = new StringBuilder();
         out.append("<html>");
@@ -46,6 +55,13 @@ public final class Pages {
         return out.toString();
     }
 
+    /**
+     * Renders an HTML page showing the list of recent profiler sessions.
+     *
+     * @param provider the profiler provider to use for the script tag
+     * @param path the MiniProfiler resource path, or empty to use the provider's default
+     * @return the HTML page as a string
+     */
     public static String renderResultListPage(ProfilerProvider provider, Optional<String> path) {
         ProfilerUiConfig config = provider.getUiConfig();
         String resolvedPath = resolvePath(provider, path);
@@ -64,6 +80,13 @@ public final class Pages {
         return out.toString();
     }
 
+    /**
+     * Renders a JSON array of profiler session summaries for the given IDs.
+     *
+     * @param ids the profiler session IDs to include
+     * @param storage the storage to load profiler sessions from
+     * @return the JSON array as a string
+     */
     public static String renderResultListJson(Collection<UUID> ids, Storage storage) {
         StringBuilder sb = new StringBuilder("[");
         boolean first = true;

--- a/core/src/main/java/io/jdev/miniprofiler/server/ResultsRequest.java
+++ b/core/src/main/java/io/jdev/miniprofiler/server/ResultsRequest.java
@@ -22,18 +22,34 @@ import org.json.simple.parser.ParseException;
 
 import java.util.UUID;
 
+/**
+ * Represents a request for profiling results, parsed from a JSON payload.
+ */
 public final class ResultsRequest {
 
+    /** The unique identifier of the requested profiling session. */
     public final UUID id;
 
     private ResultsRequest(UUID id) {
         this.id = id;
     }
 
+    /**
+     * Returns the profiling session id.
+     *
+     * @return the session UUID
+     */
     public UUID getId() {
         return id;
     }
 
+    /**
+     * Parses a JSON request string into a {@code ResultsRequest}.
+     *
+     * @param request the JSON string containing an "Id" property
+     * @return the parsed results request
+     * @throws IllegalArgumentException if the JSON is invalid or missing a valid Id
+     */
     public static ResultsRequest from(String request) {
         Object requestObj;
         try {

--- a/core/src/main/java/io/jdev/miniprofiler/sql/DriverUtil.java
+++ b/core/src/main/java/io/jdev/miniprofiler/sql/DriverUtil.java
@@ -21,12 +21,23 @@ import java.sql.DriverManager;
 import java.sql.SQLException;
 import java.util.Enumeration;
 
+/** Utility class for managing JDBC driver registration. */
 public class DriverUtil {
 
+    /** Use the static methods on this class. */
+    private DriverUtil() {}
+
+    /** Deregisters the MiniProfiler SQL spy driver from the current classloader. */
     public static void deregisterDriverSpy() {
         deregisterDriverFromClassloader("io.jdev.miniprofiler.sql.log4jdbc.DriverSpy", Thread.currentThread().getContextClassLoader());
     }
 
+    /**
+     * Deregisters the named JDBC driver from the given classloader.
+     *
+     * @param driverClassName the fully-qualified class name of the driver to deregister
+     * @param cl the classloader the driver was loaded from
+     */
     public static void deregisterDriverFromClassloader(String driverClassName, ClassLoader cl) {
         // pass a class name through rather than a class so that we don't end up loading it accidentally
 

--- a/core/src/main/java/io/jdev/miniprofiler/sql/NullFormatter.java
+++ b/core/src/main/java/io/jdev/miniprofiler/sql/NullFormatter.java
@@ -16,7 +16,11 @@
 
 package io.jdev.miniprofiler.sql;
 
+/** A no-op {@link SqlFormatter} that returns the SQL unchanged. */
 public class NullFormatter implements SqlFormatter {
+
+    /** Creates a new instance. */
+    public NullFormatter() {}
 
     @Override
     public String format(String sql) {

--- a/core/src/main/java/io/jdev/miniprofiler/sql/ProfilingDataSource.java
+++ b/core/src/main/java/io/jdev/miniprofiler/sql/ProfilingDataSource.java
@@ -32,14 +32,26 @@ import java.sql.SQLException;
 import java.sql.SQLFeatureNotSupportedException;
 import java.util.logging.Logger;
 
+/** A {@link DataSource} wrapper that records SQL query timings in MiniProfiler. */
 public class ProfilingDataSource implements DataSource, Closeable {
 
     private final DataSource targetDataSource;
 
+    /**
+     * Creates a new instance using the static {@link io.jdev.miniprofiler.MiniProfiler} profiler provider.
+     *
+     * @param targetDataSource the data source to wrap
+     */
     public ProfilingDataSource(DataSource targetDataSource) {
         this(targetDataSource, new StaticProfilerProvider());
     }
 
+    /**
+     * Creates a new instance using the given profiler provider.
+     *
+     * @param targetDataSource the data source to wrap
+     * @param profilerProvider the profiler provider to use for recording timings
+     */
     public ProfilingDataSource(DataSource targetDataSource, ProfilerProvider profilerProvider) {
         this.targetDataSource = targetDataSource;
         SpyLogFactory.setSpyLogDelegator(new ProfilingSpyLogDelegator(profilerProvider));

--- a/core/src/main/java/io/jdev/miniprofiler/sql/ProfilingSpyLogDelegator.java
+++ b/core/src/main/java/io/jdev/miniprofiler/sql/ProfilingSpyLogDelegator.java
@@ -21,14 +21,21 @@ import io.jdev.miniprofiler.StaticProfilerProvider;
 import io.jdev.miniprofiler.sql.log4jdbc.Spy;
 import io.jdev.miniprofiler.sql.log4jdbc.SpyLogDelegator;
 
+/** A {@link SpyLogDelegator} that records SQL query timings in MiniProfiler. */
 public class ProfilingSpyLogDelegator implements SpyLogDelegator {
 
     private final ProfilerProvider profilerProvider;
 
+    /** Creates a new instance using the static {@link io.jdev.miniprofiler.MiniProfiler} profiler provider. */
     public ProfilingSpyLogDelegator() {
         this(null);
     }
 
+    /**
+     * Creates a new instance using the given profiler provider.
+     *
+     * @param profilerProvider the profiler provider to use, or null to use the static {@link io.jdev.miniprofiler.MiniProfiler} provider
+     */
     public ProfilingSpyLogDelegator(ProfilerProvider profilerProvider) {
         this.profilerProvider = profilerProvider == null ? new StaticProfilerProvider() : profilerProvider;
     }

--- a/core/src/main/java/io/jdev/miniprofiler/sql/SqlFormatter.java
+++ b/core/src/main/java/io/jdev/miniprofiler/sql/SqlFormatter.java
@@ -16,6 +16,13 @@
 
 package io.jdev.miniprofiler.sql;
 
+/** Formats SQL strings for display in the MiniProfiler UI. */
 public interface SqlFormatter {
+    /**
+     * Returns the formatted version of the given SQL string.
+     *
+     * @param sql the SQL string to format
+     * @return the formatted SQL string
+     */
     String format(String sql);
 }

--- a/core/src/main/java/io/jdev/miniprofiler/sql/SqlFormatterFactory.java
+++ b/core/src/main/java/io/jdev/miniprofiler/sql/SqlFormatterFactory.java
@@ -18,14 +18,31 @@ package io.jdev.miniprofiler.sql;
 
 import io.jdev.miniprofiler.sql.hibernate.BasicFormatterImpl;
 
-public class SqlFormatterFactory {
+/**
+ * Factory for obtaining and configuring the global {@link SqlFormatter} used
+ * to format SQL statements in profiling output.
+ */
+public final class SqlFormatterFactory {
 
     private static SqlFormatter formatter = new BasicFormatterImpl();
 
+    private SqlFormatterFactory() {
+    }
+
+    /**
+     * Returns the current global SQL formatter.
+     *
+     * @return the SQL formatter
+     */
     public static SqlFormatter getFormatter() {
         return formatter;
     }
 
+    /**
+     * Sets the global SQL formatter.
+     *
+     * @param formatter the SQL formatter to use
+     */
     public static void setFormatter(SqlFormatter formatter) {
         SqlFormatterFactory.formatter = formatter;
     }

--- a/core/src/main/java/io/jdev/miniprofiler/sql/hibernate/BasicFormatterImpl.java
+++ b/core/src/main/java/io/jdev/miniprofiler/sql/hibernate/BasicFormatterImpl.java
@@ -87,6 +87,7 @@ public class BasicFormatterImpl implements SqlFormatter {
 	private static final String INDENT_STRING = "    ";
 	private static final String INITIAL = "\n    ";
 
+	@Override
 	public String format(String source) {
 		return new FormatProcess( source ).perform();
 	}

--- a/core/src/main/java/io/jdev/miniprofiler/storage/BaseStorage.java
+++ b/core/src/main/java/io/jdev/miniprofiler/storage/BaseStorage.java
@@ -27,9 +27,13 @@ import java.util.UUID;
  */
 public abstract class BaseStorage implements Storage {
 
+    /** Creates a new instance. */
+    protected BaseStorage() {}
+
     /**
      * Default implementation. Returns no results
      */
+    @Override
     public Collection<UUID> list(int maxResults, Date start, Date finish, ListResultsOrder orderBy) {
         return Collections.emptyList();
     }
@@ -37,18 +41,21 @@ public abstract class BaseStorage implements Storage {
     /**
      * Default implementation. Does nothing.
      */
+    @Override
     public void setUnviewed(String user, UUID id) {
     }
 
     /**
      * Default implementation. Does nothing.
      */
+    @Override
     public void setViewed(String user, UUID id) {
     }
 
     /**
      * Default implementation. Returns no results
      */
+    @Override
     public Collection<UUID> getUnviewedIds(String user) {
         return Collections.emptyList();
     }

--- a/core/src/main/java/io/jdev/miniprofiler/storage/MapStorage.java
+++ b/core/src/main/java/io/jdev/miniprofiler/storage/MapStorage.java
@@ -37,18 +37,26 @@ public class MapStorage extends BaseStorage {
 
     private final Map<UUID, ProfilerImpl> cache;
 
+    /** Creates a new instance with the default maximum size of {@value DEFAULT_MAX_SIZE} entries. */
     public MapStorage() {
         this(DEFAULT_MAX_SIZE);
     }
 
+    /**
+     * Creates a new instance with the given maximum number of cached profiler sessions.
+     *
+     * @param maxSize the maximum number of profiler sessions to retain
+     */
     public MapStorage(int maxSize) {
         cache = Collections.synchronizedMap(new LRUMapCache(maxSize));
     }
 
+    @Override
     public void save(ProfilerImpl profiler) {
         cache.put(profiler.getId(), profiler);
     }
 
+    @Override
     public ProfilerImpl load(UUID id) {
         return cache.get(id);
     }
@@ -74,6 +82,7 @@ public class MapStorage extends BaseStorage {
             .collect(Collectors.toList());
     }
 
+    /** Removes all cached profiler sessions. */
     public void clear() {
         cache.clear();
     }

--- a/core/src/main/java/io/jdev/miniprofiler/storage/Storage.java
+++ b/core/src/main/java/io/jdev/miniprofiler/storage/Storage.java
@@ -34,7 +34,10 @@ public interface Storage {
      * Which order to list results in.
      */
     public static enum ListResultsOrder {
-        Ascending, Descending
+        /** Results listed in ascending chronological order. */
+        Ascending,
+        /** Results listed in descending chronological order. */
+        Descending
     }
 
     /**

--- a/core/src/main/java/io/jdev/miniprofiler/util/ResourceHelper.java
+++ b/core/src/main/java/io/jdev/miniprofiler/util/ResourceHelper.java
@@ -30,21 +30,42 @@ public class ResourceHelper {
     private final String resourceBasePath;
     private final ClassLoader classLoader;
 
+    /** Creates a new instance using the default resource base path. */
     public ResourceHelper() {
         this(RESOURCE_BASE_PATH);
     }
 
+    /**
+     * Creates a new instance using the given resource base path.
+     *
+     * @param resourceBasePath the classpath prefix under which static resources are located
+     */
     public ResourceHelper(String resourceBasePath) {
         resourceBasePath = resourceBasePath.endsWith("/") ? resourceBasePath : resourceBasePath + "/";
         this.resourceBasePath = resourceBasePath;
         this.classLoader = getClass().getClassLoader();
     }
 
+    /**
+     * Returns the resource at the given URI, resolved relative to the request base path, or null if not found.
+     *
+     * @param requestBasePath the base path prefix to strip from the URI
+     * @param uri the request URI
+     * @return the resource, or null if not found
+     * @throws IOException if reading the resource fails
+     */
     public Resource getResource(String requestBasePath, String uri) throws IOException {
         requestBasePath = requestBasePath.endsWith("/") ? requestBasePath : requestBasePath + "/";
         return getResource(stripBasePath(requestBasePath, uri));
     }
 
+    /**
+     * Returns the named resource, or null if not found.
+     *
+     * @param resourceName the resource path relative to the resource base
+     * @return the resource, or null if not found
+     * @throws IOException if reading the resource fails
+     */
     public Resource getResource(String resourceName) throws IOException {
         InputStream stream = classLoader.getResourceAsStream(RESOURCE_BASE_PATH + resourceName);
         if (stream == null) {
@@ -54,6 +75,13 @@ public class ResourceHelper {
         return new Resource(bytes, guessContentType(resourceName));
     }
 
+    /**
+     * Returns the content of the named resource as a string, or null if not found.
+     *
+     * @param resource the resource path relative to the resource base path
+     * @return the resource content as a string, or null if not found
+     * @throws IOException if reading the resource fails
+     */
     public String getResourceAsString(String resource) throws IOException {
         InputStream stream = classLoader.getResourceAsStream(resourceBasePath + resource);
         if (stream == null) {
@@ -88,10 +116,24 @@ public class ResourceHelper {
         }
     }
 
+    /**
+     * Returns true if the given URI starts with the given request base path.
+     *
+     * @param requestBasePath the base path to match against
+     * @param uri the URI to check
+     * @return true if the URI starts with the base path
+     */
     public boolean uriMatches(String requestBasePath, String uri) {
         return uri.startsWith(requestBasePath);
     }
 
+    /**
+     * Strips the request base path prefix from the given URI and returns the remainder.
+     *
+     * @param requestBasePath the base path prefix to strip
+     * @param uri the URI to strip the prefix from
+     * @return the URI with the base path prefix removed
+     */
     public String stripBasePath(String requestBasePath, String uri) {
         if (!uriMatches(requestBasePath, uri)) {
             throw new IllegalArgumentException("URI " + uri + " does not match request base path " + requestBasePath);
@@ -99,23 +141,45 @@ public class ResourceHelper {
         return uri.substring(requestBasePath.length());
     }
 
+    /** A loaded resource with its raw content and content type. */
     public static class Resource {
         private final byte[] content;
         private final String contentType;
 
+        /**
+         * Creates a new resource with the given content and content type.
+         *
+         * @param content the raw bytes of the resource
+         * @param contentType the MIME content type
+         */
         public Resource(byte[] content, String contentType) {
             this.content = content;
             this.contentType = contentType;
         }
 
+        /**
+         * Returns the raw bytes of the resource content.
+         *
+         * @return the resource content bytes
+         */
         public byte[] getContent() {
             return content;
         }
 
+        /**
+         * Returns the length in bytes of the resource content.
+         *
+         * @return the content length in bytes
+         */
         public int getContentLength() {
             return content.length;
         }
 
+        /**
+         * Returns the MIME content type of the resource.
+         *
+         * @return the MIME content type
+         */
         public String getContentType() {
             return contentType;
         }

--- a/doc/manual/manual.gradle.kts
+++ b/doc/manual/manual.gradle.kts
@@ -20,7 +20,7 @@ import org.gradle.jvm.toolchain.JavaToolchainService
 plugins {
     id("build.base")
     id("build.publish")
-    `java-base`
+    id("java-base")
     alias(libs.plugins.asciidoctor)
 }
 
@@ -34,6 +34,7 @@ tasks.asciidoctor.configure {
 
 tasks.named("sanityCheck") {
     dependsOn(tasks.named("asciidoctor"))
+    dependsOn(api)
 }
 
 val api by tasks.registering(Javadoc::class) {
@@ -53,12 +54,18 @@ val api by tasks.registering(Javadoc::class) {
     javadocTasks.forEach { source(it.source) }
     classpath = files(javadocTasks.map { it.classpath })
 
+    javadocTool = javaToolchains.javadocToolFor {
+        languageVersion = JavaLanguageVersion.of(25)
+    }
     (options as StandardJavadocDocletOptions).run {
         isUse = true
-        addStringOption("Xdoclint:all,-missing/private")
-        links("http://docs.oracle.com/javase/8/docs/api/")
+        links("https://docs.oracle.com/en/java/javase/25/docs/api/")
         windowTitle = "MiniProfiler JVM API ($project.version)"
         docTitle =  "MiniProfiler JVM API ($project.version)"
+        memberLevel = JavadocMemberLevel.PROTECTED
+        addBooleanOption("Xdoclint:all", true)
+        addBooleanOption("Xdoclint/package:-io.jdev.miniprofiler.internal,-io.jdev.miniprofiler.ratpack.internal", true)
+        addBooleanOption("Xwerror", true)
     }
 }
 

--- a/eclipselink/src/main/java/io/jdev/miniprofiler/eclipselink/LegacyProfilingSessionCustomizer.java
+++ b/eclipselink/src/main/java/io/jdev/miniprofiler/eclipselink/LegacyProfilingSessionCustomizer.java
@@ -35,10 +35,16 @@ public class LegacyProfilingSessionCustomizer implements org.eclipse.persistence
 
     private final ProfilerProvider profilerProvider;
 
+    /** Creates a new instance using the static {@link io.jdev.miniprofiler.MiniProfiler} profiler provider. */
     public LegacyProfilingSessionCustomizer() {
         this.profilerProvider = null;
     }
 
+    /**
+     * Creates a new instance using the given profiler provider.
+     *
+     * @param profilerProvider the profiler provider to use
+     */
     public LegacyProfilingSessionCustomizer(ProfilerProvider profilerProvider) {
         this.profilerProvider = profilerProvider;
     }

--- a/eclipselink/src/main/java/io/jdev/miniprofiler/eclipselink/ProfilingConnector.java
+++ b/eclipselink/src/main/java/io/jdev/miniprofiler/eclipselink/ProfilingConnector.java
@@ -30,8 +30,14 @@ import java.util.Properties;
  */
 public class ProfilingConnector implements Connector {
 
+    /** The underlying connector being wrapped. */
     private Connector target;
 
+    /**
+     * Creates a new connector wrapping the given target.
+     *
+     * @param target the connector to wrap
+     */
     public ProfilingConnector(Connector target) {
         this.target = target;
     }

--- a/eclipselink/src/main/java/io/jdev/miniprofiler/eclipselink/ProfilingSessionCustomizer.java
+++ b/eclipselink/src/main/java/io/jdev/miniprofiler/eclipselink/ProfilingSessionCustomizer.java
@@ -33,10 +33,16 @@ public class ProfilingSessionCustomizer implements SessionCustomizer {
 
     private final ProfilerProvider profilerProvider;
 
+    /** Creates a new instance using the static {@link io.jdev.miniprofiler.MiniProfiler} profiler provider. */
     public ProfilingSessionCustomizer() {
         this.profilerProvider = null;
     }
 
+    /**
+     * Creates a new instance using the given profiler provider.
+     *
+     * @param profilerProvider the profiler provider to use
+     */
     public ProfilingSessionCustomizer(ProfilerProvider profilerProvider) {
         this.profilerProvider = profilerProvider;
     }

--- a/gradle/plugins/src/main/kotlin/build.java-module.gradle.kts
+++ b/gradle/plugins/src/main/kotlin/build.java-module.gradle.kts
@@ -102,7 +102,15 @@ tasks.withType<GroovyCompile>().configureEach {
 
 plugins.withId("build.publish") {
     tasks.withType<Javadoc>().configureEach {
-        (options as StandardJavadocDocletOptions).addStringOption("Xdoclint:all,-missing/private")
+        javadocTool = javaToolchains.javadocToolFor {
+            languageVersion = JavaLanguageVersion.of(25)
+        }
+        (options as StandardJavadocDocletOptions).run {
+            memberLevel = JavadocMemberLevel.PROTECTED
+            addBooleanOption("Xdoclint:all", true)
+            addBooleanOption("Xdoclint/package:-io.jdev.miniprofiler.internal,-io.jdev.miniprofiler.ratpack.internal", true)
+            addBooleanOption("Xwerror", true)
+        }
     }
     tasks.named("sanityCheck") {
         dependsOn(tasks.withType<Javadoc>())

--- a/hibernate/src/main/java/io/jdev/miniprofiler/hibernate/ProfilingDatasourceConnectionProvider.java
+++ b/hibernate/src/main/java/io/jdev/miniprofiler/hibernate/ProfilingDatasourceConnectionProvider.java
@@ -27,13 +27,21 @@ import java.sql.Connection;
 import java.sql.SQLException;
 import java.util.Map;
 
+/** A Hibernate {@link DatasourceConnectionProviderImpl} that records SQL query timings in MiniProfiler. */
 public class ProfilingDatasourceConnectionProvider extends DatasourceConnectionProviderImpl {
 
+    /** Whether profiling has been configured for this connection provider. */
     private boolean profilingConfigured;
 
+    /** Creates a new instance using the static {@link io.jdev.miniprofiler.MiniProfiler} profiler provider. */
     public ProfilingDatasourceConnectionProvider() {
     }
 
+    /**
+     * Creates a new instance using the given profiler provider.
+     *
+     * @param profilerProvider the profiler provider to use
+     */
     public ProfilingDatasourceConnectionProvider(ProfilerProvider profilerProvider) {
         setupProfiling(profilerProvider);
     }

--- a/jakarta-ee/src/main/java/io/jdev/miniprofiler/jakarta/ee/CdiProfilerProviderLocator.java
+++ b/jakarta-ee/src/main/java/io/jdev/miniprofiler/jakarta/ee/CdiProfilerProviderLocator.java
@@ -33,6 +33,10 @@ import java.util.Set;
  */
 public class CdiProfilerProviderLocator implements ProfilerProviderLocator {
 
+    /** Default constructor. */
+    public CdiProfilerProviderLocator() {
+    }
+
     @Override
     public int getOrder() {
         return 10;

--- a/jakarta-ee/src/main/java/io/jdev/miniprofiler/jakarta/ee/DefaultCDIProfilerProvider.java
+++ b/jakarta-ee/src/main/java/io/jdev/miniprofiler/jakarta/ee/DefaultCDIProfilerProvider.java
@@ -28,4 +28,8 @@ import jakarta.enterprise.inject.Default;
 @ApplicationScoped
 @Default
 public class DefaultCDIProfilerProvider extends DefaultProfilerProvider {
+
+    /** Default constructor for CDI. */
+    public DefaultCDIProfilerProvider() {
+    }
 }

--- a/jakarta-ee/src/main/java/io/jdev/miniprofiler/jakarta/ee/ProfilingEJBInterceptor.java
+++ b/jakarta-ee/src/main/java/io/jdev/miniprofiler/jakarta/ee/ProfilingEJBInterceptor.java
@@ -33,6 +33,10 @@ import jakarta.interceptor.InvocationContext;
 @Profiled
 public class ProfilingEJBInterceptor {
 
+    /** Default constructor for CDI. */
+    public ProfilingEJBInterceptor() {
+    }
+
     @Inject
     private ProfilerProvider profilerProvider;
 

--- a/jakarta-servlet/src/main/java/io/jdev/miniprofiler/jakarta/servlet/ProfilingFilter.java
+++ b/jakarta-servlet/src/main/java/io/jdev/miniprofiler/jakarta/servlet/ProfilingFilter.java
@@ -52,6 +52,9 @@ import java.util.UUID;
  */
 public class ProfilingFilter implements Filter {
 
+    /** Default constructor. */
+    public ProfilingFilter() {}
+
     private static final String DEFAULT_PROFILER_PATH = "/miniprofiler/";
     private static final String PROFILER_PATH_PARAM = "path";
     private static final String ALLOWED_ORIGIN_PARAM = "allowed-origin";

--- a/jakarta-servlet/src/main/java/io/jdev/miniprofiler/jakarta/servlet/jsp/ScriptTag.java
+++ b/jakarta-servlet/src/main/java/io/jdev/miniprofiler/jakarta/servlet/jsp/ScriptTag.java
@@ -33,20 +33,33 @@ import java.io.IOException;
 @SuppressWarnings("WeakerAccess")
 public class ScriptTag extends TagSupport {
 
+    /** The profiler provider used to retrieve the current profiler. */
     private ProfilerProvider profilerProvider;
+    /** Writer used to render the script tag. */
     private ScriptTagWriter scriptTagWriter;
 
+    /** The path to the MiniProfiler resources. */
     private String path;
 
+    /** The UI widget position. */
     private ProfilerUiConfig.Position position;
+    /** The UI color scheme. */
     private ProfilerUiConfig.ColorScheme colorScheme;
+    /** The keyboard shortcut to toggle the UI. */
     private String toggleShortcut;
+    /** The maximum number of traces to show. */
     private Integer maxTraces;
+    /** The threshold in milliseconds below which timings are considered trivial. */
     private Integer trivialMilliseconds;
+    /** Whether trivial timings are shown by default. */
     private Boolean trivial;
+    /** Whether child timings are shown by default. */
     private Boolean children;
+    /** Whether the controls panel is shown. */
     private Boolean controls;
+    /** Whether the current user is authorized to view profiling results. */
     private Boolean authorized;
+    /** Whether the MiniProfiler UI starts hidden. */
     private Boolean startHidden;
 
     /** Creates a new instance backed by the current global {@link io.jdev.miniprofiler.ProfilerProvider}. */
@@ -115,63 +128,111 @@ public class ScriptTag extends TagSupport {
         return config;
     }
 
-    /** Sets the {@link ProfilerProvider} that supplies the current profiler. */
+    /**
+     * Sets the {@link ProfilerProvider} that supplies the current profiler.
+     *
+     * @param profilerProvider the profiler provider to use
+     */
     public void setProfilerProvider(ProfilerProvider profilerProvider) {
         this.profilerProvider = profilerProvider;
         this.scriptTagWriter = new ScriptTagWriter(profilerProvider);
     }
 
-    /** Sets an explicit path override for MiniProfiler resources; if {@code null}, the provider's configured path is used. */
+    /**
+     * Sets an explicit path override for MiniProfiler resources; if {@code null}, the provider's configured path is used.
+     *
+     * @param path the path to the MiniProfiler resources
+     */
     public void setPath(String path) {
         this.path = path;
     }
 
-    /** Sets the UI display position; value is matched case-insensitively to {@link io.jdev.miniprofiler.ProfilerUiConfig.Position}. */
+    /**
+     * Sets the UI display position; value is matched case-insensitively to {@link io.jdev.miniprofiler.ProfilerUiConfig.Position}.
+     *
+     * @param position the UI widget position
+     */
     public void setPosition(String position) {
         this.position = position == null ? null : ConfigHelper.findEnum(ProfilerUiConfig.Position.class, position);
     }
 
-    /** Sets the UI color scheme; value is matched case-insensitively to {@link io.jdev.miniprofiler.ProfilerUiConfig.ColorScheme}. */
+    /**
+     * Sets the UI color scheme; value is matched case-insensitively to {@link io.jdev.miniprofiler.ProfilerUiConfig.ColorScheme}.
+     *
+     * @param scheme the UI color scheme
+     */
     public void setColorScheme(String scheme) {
         this.colorScheme = scheme == null ? null : ConfigHelper.findEnum(ProfilerUiConfig.ColorScheme.class, scheme);
     }
 
-    /** Sets the keyboard shortcut for toggling the MiniProfiler popup. */
+    /**
+     * Sets the keyboard shortcut for toggling the MiniProfiler popup.
+     *
+     * @param toggleShortcut the keyboard shortcut string
+     */
     public void setToggleShortcut(String toggleShortcut) {
         this.toggleShortcut = toggleShortcut;
     }
 
-    /** Sets the maximum number of trace entries to display in the popup. */
+    /**
+     * Sets the maximum number of trace entries to display in the popup.
+     *
+     * @param maxTraces the maximum number of traces
+     */
     public void setMaxTraces(Integer maxTraces) {
         this.maxTraces = maxTraces;
     }
 
-    /** Sets the threshold in milliseconds below which timings are considered trivial. */
+    /**
+     * Sets the threshold in milliseconds below which timings are considered trivial.
+     *
+     * @param trivialMilliseconds the trivial threshold in milliseconds
+     */
     public void setTrivialMilliseconds(Integer trivialMilliseconds) {
         this.trivialMilliseconds = trivialMilliseconds;
     }
 
-    /** Sets whether trivial timings are shown by default. */
+    /**
+     * Sets whether trivial timings are shown by default.
+     *
+     * @param trivial true to show trivial timings by default
+     */
     public void setTrivial(boolean trivial) {
         this.trivial = trivial;
     }
 
-    /** Sets whether child timings are expanded by default. */
+    /**
+     * Sets whether child timings are expanded by default.
+     *
+     * @param children true to show child timings by default
+     */
     public void setChildren(boolean children) {
         this.children = children;
     }
 
-    /** Sets whether control buttons are shown in the popup. */
+    /**
+     * Sets whether control buttons are shown in the popup.
+     *
+     * @param controls true to show control buttons
+     */
     public void setControls(boolean controls) {
         this.controls = controls;
     }
 
-    /** Sets whether the current user is authorized to view profiling results. */
+    /**
+     * Sets whether the current user is authorized to view profiling results.
+     *
+     * @param authorized true if the user is authorized
+     */
     public void setAuthorized(boolean authorized) {
         this.authorized = authorized;
     }
 
-    /** Sets whether the MiniProfiler popup starts in the hidden state. */
+    /**
+     * Sets whether the MiniProfiler popup starts in the hidden state.
+     *
+     * @param startHidden true to start the UI hidden
+     */
     public void setStartHidden(boolean startHidden) {
         this.startHidden = startHidden;
     }

--- a/javax-ee/src/main/java/io/jdev/miniprofiler/javax/ee/CdiProfilerProviderLocator.java
+++ b/javax-ee/src/main/java/io/jdev/miniprofiler/javax/ee/CdiProfilerProviderLocator.java
@@ -33,11 +33,17 @@ import java.util.Set;
  */
 public class CdiProfilerProviderLocator implements ProfilerProviderLocator {
 
+    /** Default constructor. */
+    public CdiProfilerProviderLocator() {
+    }
+
+    /** {@inheritDoc} Returns {@code 20}. */
     @Override
     public int getOrder() {
         return 20;
     }
 
+    /** {@inheritDoc} */
     @Override
     @SuppressWarnings("unchecked")
     public Optional<ProfilerProvider> locate() {

--- a/javax-ee/src/main/java/io/jdev/miniprofiler/javax/ee/DefaultCDIProfilerProvider.java
+++ b/javax-ee/src/main/java/io/jdev/miniprofiler/javax/ee/DefaultCDIProfilerProvider.java
@@ -21,7 +21,12 @@ import io.jdev.miniprofiler.DefaultProfilerProvider;
 import javax.enterprise.context.ApplicationScoped;
 import javax.enterprise.inject.Default;
 
+/** Default CDI-managed {@link io.jdev.miniprofiler.ProfilerProvider} for use with javax CDI containers. */
 @ApplicationScoped
 @Default
 public class DefaultCDIProfilerProvider extends DefaultProfilerProvider {
+
+    /** Default constructor for CDI. */
+    public DefaultCDIProfilerProvider() {
+    }
 }

--- a/javax-ee/src/main/java/io/jdev/miniprofiler/javax/ee/Profiled.java
+++ b/javax-ee/src/main/java/io/jdev/miniprofiler/javax/ee/Profiled.java
@@ -24,6 +24,7 @@ import static java.lang.annotation.ElementType.METHOD;
 import static java.lang.annotation.ElementType.TYPE;
 import static java.lang.annotation.RetentionPolicy.RUNTIME;
 
+/** Marks a class or method for profiling via {@link ProfilingEJBInterceptor}. */
 @InterceptorBinding
 @Target({METHOD, TYPE})
 

--- a/javax-ee/src/main/java/io/jdev/miniprofiler/javax/ee/ProfilingEJBInterceptor.java
+++ b/javax-ee/src/main/java/io/jdev/miniprofiler/javax/ee/ProfilingEJBInterceptor.java
@@ -25,13 +25,25 @@ import javax.interceptor.AroundInvoke;
 import javax.interceptor.Interceptor;
 import javax.interceptor.InvocationContext;
 
+/** EJB interceptor that profiles method invocations annotated with {@link Profiled}. */
 @Interceptor
 @Profiled
 public class ProfilingEJBInterceptor {
 
+    /** Default constructor for CDI. */
+    public ProfilingEJBInterceptor() {
+    }
+
     @Inject
     private ProfilerProvider profilerProvider;
 
+    /**
+     * Profiles the intercepted method invocation.
+     *
+     * @param ctx the invocation context
+     * @return the result of the intercepted method
+     * @throws Exception if the intercepted method throws
+     */
     @AroundInvoke
     public Object profile(InvocationContext ctx) throws Exception {
         Profiler profiler = profilerProvider.current();

--- a/javax-servlet/src/main/java/io/jdev/miniprofiler/javax/servlet/ProfilingFilter.java
+++ b/javax-servlet/src/main/java/io/jdev/miniprofiler/javax/servlet/ProfilingFilter.java
@@ -52,6 +52,9 @@ import java.util.UUID;
  */
 public class ProfilingFilter implements Filter {
 
+    /** Default constructor. */
+    public ProfilingFilter() {}
+
     private static final String DEFAULT_PROFILER_PATH = "/miniprofiler/";
     private static final String PROFILER_PATH_PARAM = "path";
     private static final String ALLOWED_ORIGIN_PARAM = "allowed-origin";
@@ -61,10 +64,15 @@ public class ProfilingFilter implements Filter {
     private static final String CONTENT_TYPE_JSON = "application/json";
     private static final String ID_PARAM = "id";
 
+    /** The profiler provider used to start new profiling sessions. */
     protected ProfilerProvider profilerProvider = new StaticProfilerProvider();
+    /** The URL path prefix under which MiniProfiler resources are served. */
     protected String profilerPath = DEFAULT_PROFILER_PATH;
+    /** The value of the {@code Access-Control-Allow-Origin} header, or null to omit it. */
     protected String allowedOrigin;
+    /** Helper for loading and serving MiniProfiler static resources. */
     protected ResourceHelper resourceHelper = new ResourceHelper();
+    /** The servlet context, set during filter initialisation. */
     protected ServletContext servletContext;
 
     @Override
@@ -268,6 +276,13 @@ public class ProfilingFilter implements Filter {
         }
     }
 
+    /**
+     * Starts a new profiling session for the given request. Override to customise session creation.
+     *
+     * @param id the UUID to use for the new profiler
+     * @param request the current HTTP request
+     * @return the new profiler
+     */
     protected Profiler startProfiling(UUID id, HttpServletRequest request) {
         return profilerProvider.start(id, request.getRequestURI());
     }

--- a/javax-servlet/src/main/java/io/jdev/miniprofiler/javax/servlet/jsp/ScriptTag.java
+++ b/javax-servlet/src/main/java/io/jdev/miniprofiler/javax/servlet/jsp/ScriptTag.java
@@ -33,22 +33,36 @@ import java.io.IOException;
 @SuppressWarnings("WeakerAccess")
 public class ScriptTag extends TagSupport {
 
+    /** The profiler provider used to retrieve the current profiler. */
     private ProfilerProvider profilerProvider;
+    /** Writer used to render the script tag. */
     private ScriptTagWriter scriptTagWriter;
 
+    /** The path to the MiniProfiler resources. */
     private String path;
 
+    /** The UI widget position. */
     private ProfilerUiConfig.Position position;
+    /** The UI color scheme. */
     private ProfilerUiConfig.ColorScheme colorScheme;
+    /** The keyboard shortcut to toggle the UI. */
     private String toggleShortcut;
+    /** The maximum number of traces to show. */
     private Integer maxTraces;
+    /** The threshold in milliseconds below which timings are considered trivial. */
     private Integer trivialMilliseconds;
+    /** Whether trivial timings are shown by default. */
     private Boolean trivial;
+    /** Whether child timings are shown by default. */
     private Boolean children;
+    /** Whether the controls panel is shown. */
     private Boolean controls;
+    /** Whether the current user is authorized to view profiling results. */
     private Boolean authorized;
+    /** Whether the MiniProfiler UI starts hidden. */
     private Boolean startHidden;
 
+    /** Creates a new instance using the static {@link MiniProfiler} profiler provider. */
     public ScriptTag() {
         setProfilerProvider(MiniProfiler.getProfilerProvider());
     }
@@ -114,51 +128,111 @@ public class ScriptTag extends TagSupport {
         return config;
     }
 
+    /**
+     * Sets the profiler provider to use when rendering the script tag.
+     *
+     * @param profilerProvider the profiler provider to use
+     */
     public void setProfilerProvider(ProfilerProvider profilerProvider) {
         this.profilerProvider = profilerProvider;
         this.scriptTagWriter = new ScriptTagWriter(profilerProvider);
     }
 
+    /**
+     * Sets the path to the MiniProfiler resources, overriding the provider default.
+     *
+     * @param path the path to the MiniProfiler resources
+     */
     public void setPath(String path) {
         this.path = path;
     }
 
+    /**
+     * Sets the UI position (e.g. {@code "Left"}, {@code "Right"}).
+     *
+     * @param position the UI widget position
+     */
     public void setPosition(String position) {
         this.position = position == null ? null : ConfigHelper.findEnum(ProfilerUiConfig.Position.class, position);
     }
 
+    /**
+     * Sets the UI color scheme (e.g. {@code "Light"}, {@code "Dark"}).
+     *
+     * @param scheme the UI color scheme
+     */
     public void setColorScheme(String scheme) {
         this.colorScheme = scheme == null ? null : ConfigHelper.findEnum(ProfilerUiConfig.ColorScheme.class, scheme);
     }
 
+    /**
+     * Sets the keyboard shortcut to toggle the MiniProfiler UI.
+     *
+     * @param toggleShortcut the keyboard shortcut string
+     */
     public void setToggleShortcut(String toggleShortcut) {
         this.toggleShortcut = toggleShortcut;
     }
 
+    /**
+     * Sets the maximum number of traces to show in the UI.
+     *
+     * @param maxTraces the maximum number of traces
+     */
     public void setMaxTraces(Integer maxTraces) {
         this.maxTraces = maxTraces;
     }
 
+    /**
+     * Sets the threshold in milliseconds below which timings are considered trivial.
+     *
+     * @param trivialMilliseconds the trivial threshold in milliseconds
+     */
     public void setTrivialMilliseconds(Integer trivialMilliseconds) {
         this.trivialMilliseconds = trivialMilliseconds;
     }
 
+    /**
+     * Sets whether trivial timings are shown by default.
+     *
+     * @param trivial true to show trivial timings by default
+     */
     public void setTrivial(boolean trivial) {
         this.trivial = trivial;
     }
 
+    /**
+     * Sets whether child timings are shown by default.
+     *
+     * @param children true to show child timings by default
+     */
     public void setChildren(boolean children) {
         this.children = children;
     }
 
+    /**
+     * Sets whether the controls panel is shown.
+     *
+     * @param controls true to show the controls panel
+     */
     public void setControls(boolean controls) {
         this.controls = controls;
     }
 
+    /**
+     * Sets whether the current user is authorized to view profiling results.
+     *
+     * @param authorized true if the user is authorized
+     */
     public void setAuthorized(boolean authorized) {
         this.authorized = authorized;
     }
 
+    /**
+     * Sets whether the MiniProfiler UI starts hidden.
+     *
+     * @param startHidden true to start the UI hidden
+     */
     public void setStartHidden(boolean startHidden) {
         this.startHidden = startHidden;
     }

--- a/jooq/src/main/java/io/jdev/miniprofiler/jooq/MiniProfilerExecuteListener.java
+++ b/jooq/src/main/java/io/jdev/miniprofiler/jooq/MiniProfilerExecuteListener.java
@@ -40,7 +40,9 @@ import static io.jdev.miniprofiler.jooq.MiniProfilerJooqUtil.renderInlined;
 @SuppressWarnings("WeakerAccess")
 public class MiniProfilerExecuteListener extends DefaultExecuteListener {
 
+    /** The profiler provider used to record SQL timings. */
     protected final ProfilerProvider provider;
+    /** The start time in milliseconds of the current SQL execution. */
     private long start;
 
     /**
@@ -51,11 +53,13 @@ public class MiniProfilerExecuteListener extends DefaultExecuteListener {
         this.provider = provider;
     }
 
+    /** Records the start time of the SQL execution. */
     @Override
     public void start(ExecuteContext ctx) {
         start = System.currentTimeMillis();
     }
 
+    /** Records the timing if a profiler is active and the context contains a SQL statement. */
     @Override
     public void end(ExecuteContext ctx) {
         if (provider.hasCurrent()) {
@@ -64,6 +68,12 @@ public class MiniProfilerExecuteListener extends DefaultExecuteListener {
         }
     }
 
+    /**
+     * Adds a timing if the context contains a renderable SQL statement. Override to customise filtering.
+     *
+     * @param ctx the jOOQ execute context
+     * @param duration the duration of the execution in milliseconds
+     */
     protected void maybeAddTiming(ExecuteContext ctx, long duration) {
         String query = renderInlined(ctx);
         if (query != null) {
@@ -71,6 +81,13 @@ public class MiniProfilerExecuteListener extends DefaultExecuteListener {
         }
     }
 
+    /**
+     * Records the given SQL query and duration in the current profiler session. Override to customise recording.
+     *
+     * @param ctx the jOOQ execute context
+     * @param query the SQL query string to record
+     * @param duration the duration of the execution in milliseconds
+     */
     @SuppressWarnings("unused")
     protected void addTiming(ExecuteContext ctx, String query, long duration) {
         provider.current().addCustomTiming("sql", "query", query, duration);

--- a/jooq/src/main/java/io/jdev/miniprofiler/jooq/MiniProfilerExecuteListenerProvider.java
+++ b/jooq/src/main/java/io/jdev/miniprofiler/jooq/MiniProfilerExecuteListenerProvider.java
@@ -35,6 +35,7 @@ import org.jooq.ExecuteListenerProvider;
  */
 public class MiniProfilerExecuteListenerProvider implements ExecuteListenerProvider {
 
+    /** The profiler provider used to create listeners. */
     protected final ProfilerProvider provider;
 
     /**
@@ -45,6 +46,7 @@ public class MiniProfilerExecuteListenerProvider implements ExecuteListenerProvi
         this.provider = provider;
     }
 
+    /** Returns a new {@link MiniProfilerExecuteListener} for profiling the current execution. */
     @Override
     public ExecuteListener provide() {
         return new MiniProfilerExecuteListener(provider);

--- a/jooq/src/main/java/io/jdev/miniprofiler/jooq/MiniProfilerJooqUtil.java
+++ b/jooq/src/main/java/io/jdev/miniprofiler/jooq/MiniProfilerJooqUtil.java
@@ -22,9 +22,16 @@ import org.jooq.ExecuteType;
 import org.jooq.impl.DSL;
 import org.jooq.tools.StringUtils;
 
+/** Utility class for rendering jOOQ SQL statements for MiniProfiler. */
 @SuppressWarnings("WeakerAccess")
 public final class MiniProfilerJooqUtil {
 
+    /**
+     * Returns the SQL statement from the given execute context with parameters inlined, or null if unavailable.
+     *
+     * @param ctx the jOOQ execute context
+     * @return the inlined SQL statement, or {@code null} if unavailable
+     */
     public static String renderInlined(ExecuteContext ctx) {
         Configuration configuration = ctx.configuration();
         if (ctx.type() == ExecuteType.BATCH) {

--- a/ratpack/src/main/java/io/jdev/miniprofiler/ratpack/AsyncStorage.java
+++ b/ratpack/src/main/java/io/jdev/miniprofiler/ratpack/AsyncStorage.java
@@ -99,6 +99,12 @@ public interface AsyncStorage extends Storage {
         return Blocking.get(() -> getUnviewedIds(user));
     }
 
+    /**
+     * Wraps the given {@link Storage} as an {@link AsyncStorage}, returning it unchanged if it already is one.
+     *
+     * @param storage the storage to wrap
+     * @return the given storage as an {@link AsyncStorage}
+     */
     static AsyncStorage adapt(Storage storage) {
         if (storage instanceof AsyncStorage) {
             return (AsyncStorage) storage;

--- a/ratpack/src/main/java/io/jdev/miniprofiler/ratpack/DiscardMiniProfilerHandler.java
+++ b/ratpack/src/main/java/io/jdev/miniprofiler/ratpack/DiscardMiniProfilerHandler.java
@@ -28,6 +28,9 @@ import ratpack.handling.Handler;
  */
 public class DiscardMiniProfilerHandler implements Handler {
 
+    /** Default constructor. */
+    public DiscardMiniProfilerHandler() {}
+
     @Override
     public void handle(Context ctx) throws Exception {
         Execution.current().add(ProfilerStoreOption.class, ProfilerStoreOption.DISCARD_RESULTS);

--- a/ratpack/src/main/java/io/jdev/miniprofiler/ratpack/EagerMiniProfilerExecInitializer.java
+++ b/ratpack/src/main/java/io/jdev/miniprofiler/ratpack/EagerMiniProfilerExecInitializer.java
@@ -25,10 +25,21 @@ import ratpack.exec.Execution;
  */
 public class EagerMiniProfilerExecInitializer extends MiniProfilerExecInitializer {
 
+    /**
+     * Creates a new initializer with the given provider and store option.
+     *
+     * @param provider the profiler provider
+     * @param defaultProfilerStoreOption the default store option
+     */
     public EagerMiniProfilerExecInitializer(ProfilerProvider provider, ProfilerStoreOption defaultProfilerStoreOption) {
         super(provider, defaultProfilerStoreOption);
     }
 
+    /**
+     * Creates a new initializer with the given provider, defaulting to storing results.
+     *
+     * @param provider the profiler provider
+     */
     public EagerMiniProfilerExecInitializer(ProfilerProvider provider) {
         super(provider);
     }

--- a/ratpack/src/main/java/io/jdev/miniprofiler/ratpack/MiniProfilerAjaxHeaderHandler.java
+++ b/ratpack/src/main/java/io/jdev/miniprofiler/ratpack/MiniProfilerAjaxHeaderHandler.java
@@ -44,6 +44,10 @@ import ratpack.handling.Handler;
  */
 public class MiniProfilerAjaxHeaderHandler implements Handler {
 
+    /** Creates a new AJAX header handler. */
+    public MiniProfilerAjaxHeaderHandler() {
+    }
+
     @Override
     public void handle(Context ctx) throws Exception {
         ctx.maybeGet(Profiler.class).ifPresent(profiler -> {

--- a/ratpack/src/main/java/io/jdev/miniprofiler/ratpack/MiniProfilerExecInitializer.java
+++ b/ratpack/src/main/java/io/jdev/miniprofiler/ratpack/MiniProfilerExecInitializer.java
@@ -111,6 +111,12 @@ public class MiniProfilerExecInitializer implements ExecInitializer {
         }
     }
 
+    /**
+     * Returns the current profiler for the given execution, if any.
+     *
+     * @param execution the execution to look up the profiler for
+     * @return the current profiler, or empty if none
+     */
     protected Optional<Profiler> maybeCurrentProfiler(Execution execution) {
         if (provider instanceof RatpackContextProfilerProvider) {
             return ((RatpackContextProfilerProvider) provider).lookupCurrentProfiler(execution);
@@ -119,10 +125,21 @@ public class MiniProfilerExecInitializer implements ExecInitializer {
         }
     }
 
+    /**
+     * Called when execution completes; stops the profiler if one is present.
+     *
+     * @param execution the completed execution
+     */
     protected void executionComplete(Execution execution) {
         maybeCurrentProfiler(execution).ifPresent(profiler -> stopProfiler(execution, profiler));
     }
 
+    /**
+     * Stops the given profiler, discarding or storing results based on the execution's store option.
+     *
+     * @param execution the execution context
+     * @param profiler the profiler to stop
+     */
     protected void stopProfiler(Execution execution, Profiler profiler) {
         ProfilerStoreOption store = execution.maybeGet(ProfilerStoreOption.class).orElse(defaultProfilerStoreOption);
         profiler.stop(store == ProfilerStoreOption.DISCARD_RESULTS);

--- a/ratpack/src/main/java/io/jdev/miniprofiler/ratpack/MiniProfilerH2Module.java
+++ b/ratpack/src/main/java/io/jdev/miniprofiler/ratpack/MiniProfilerH2Module.java
@@ -37,19 +37,40 @@ public class MiniProfilerH2Module extends H2Module {
         this.suppressProfiling = suppressProfiling;
     }
 
+    /** Creates a module with default settings and profiling enabled. */
     public MiniProfilerH2Module() {
         this(false);
     }
 
+    /**
+     * Creates a module with the given H2 credentials and URL, and profiling enabled.
+     *
+     * @param username the H2 username
+     * @param password the H2 password
+     * @param url      the H2 JDBC URL
+     */
     public MiniProfilerH2Module(String username, String password, String url) {
         this(username, password, url, false);
     }
 
+    /**
+     * Creates a module with the given H2 credentials, URL, and suppress-profiling flag.
+     *
+     * @param username          the H2 username
+     * @param password          the H2 password
+     * @param url               the H2 JDBC URL
+     * @param suppressProfiling whether to suppress profiling
+     */
     public MiniProfilerH2Module(String username, String password, String url, boolean suppressProfiling) {
         super(username, password, url);
         this.suppressProfiling = suppressProfiling;
     }
 
+    /**
+     * Returns a {@link ProfilingDataSource} wrapping the H2 data source, unless profiling is suppressed.
+     *
+     * @return the data source, optionally wrapped for profiling
+     */
     protected DataSource createDataSource() {
         DataSource ds = super.createDataSource();
         return suppressProfiling ? ds : new ProfilingDataSource(ds);

--- a/ratpack/src/main/java/io/jdev/miniprofiler/ratpack/MiniProfilerHandlerChain.java
+++ b/ratpack/src/main/java/io/jdev/miniprofiler/ratpack/MiniProfilerHandlerChain.java
@@ -24,6 +24,10 @@ import ratpack.handling.Chain;
  */
 public class MiniProfilerHandlerChain implements Action<Chain> {
 
+    /** Creates a new handler chain. */
+    public MiniProfilerHandlerChain() {
+    }
+
     /** The default URI prefix that this handler chain should be installed under. */
     public static final String DEFAULT_PREFIX = "miniprofiler";
 

--- a/ratpack/src/main/java/io/jdev/miniprofiler/ratpack/MiniProfilerHikariModule.java
+++ b/ratpack/src/main/java/io/jdev/miniprofiler/ratpack/MiniProfilerHikariModule.java
@@ -30,6 +30,7 @@ public class MiniProfilerHikariModule extends HikariModule {
 
     private final boolean suppressProfiling;
 
+    /** Creates a module with default settings and profiling enabled. */
     public MiniProfilerHikariModule() {
         this(false);
     }
@@ -42,6 +43,12 @@ public class MiniProfilerHikariModule extends HikariModule {
         this.suppressProfiling = suppressProfiling;
     }
 
+    /**
+     * Returns a {@link ProfilingDataSource} wrapping the Hikari data source, unless profiling is suppressed.
+     *
+     * @param service the HikariService to get the base data source from
+     * @return the data source, optionally wrapped for profiling
+     */
     protected DataSource getDataSource(HikariService service) {
         DataSource ds = super.getDataSource(service);
         return suppressProfiling ? ds : new ProfilingDataSource(ds);

--- a/ratpack/src/main/java/io/jdev/miniprofiler/ratpack/MiniProfilerModule.java
+++ b/ratpack/src/main/java/io/jdev/miniprofiler/ratpack/MiniProfilerModule.java
@@ -40,6 +40,10 @@ import ratpack.guice.ConfigurableModule;
  */
 public class MiniProfilerModule extends ConfigurableModule<MiniProfilerModule.Config> {
 
+    /** Creates a new MiniProfiler Guice module. */
+    public MiniProfilerModule() {
+    }
+
     /**
      * Installs Ratpack / MiniProfiler support code.
      */
@@ -73,24 +77,53 @@ public class MiniProfilerModule extends ConfigurableModule<MiniProfilerModule.Co
         return true;
     }
 
+    /**
+     * Provides the {@link ExecInitializer} that starts profiling for each Ratpack execution.
+     *
+     * @param provider the profiler provider
+     * @param config   the module configuration
+     * @return the exec initializer
+     */
     @ProvidesIntoSet
     @Singleton
     public ExecInitializer initializer(ProfilerProvider provider, Config config) {
         return createInitializer(provider, config);
     }
 
+    /**
+     * Provides the handler that starts profiling for each request.
+     *
+     * @param provider the profiler provider
+     * @return the start-profiling handler
+     */
     @Provides
     @Singleton
     public MiniProfilerStartProfilingHandler startProfilingHandler(ProfilerProvider provider) {
         return new MiniProfilerStartProfilingHandler(provider);
     }
 
+    /**
+     * Creates the {@link MiniProfilerExecInitializer} used by this module.
+     *
+     * <p>Subclasses can override this method to customize the initializer.</p>
+     *
+     * @param provider the profiler provider
+     * @param config   the module configuration
+     * @return the exec initializer
+     */
     protected MiniProfilerExecInitializer createInitializer(ProfilerProvider provider, Config config) {
         return new MiniProfilerExecInitializer(provider, config.defaultProfilerStoreOption);
     }
 
+    /** Configuration for {@link MiniProfilerModule}. */
     public static class Config {
+        /** Creates a new configuration with default settings. */
+        public Config() {
+        }
+
+        /** The default store option applied to each request; defaults to {@link ProfilerStoreOption#STORE_RESULTS}. */
         public ProfilerStoreOption defaultProfilerStoreOption = ProfilerStoreOption.STORE_RESULTS;
+        /** The UI configuration to use when rendering the MiniProfiler widget. */
         public ProfilerUiConfig uiConfig = ProfilerUiConfig.create();
     }
 

--- a/ratpack/src/main/java/io/jdev/miniprofiler/ratpack/MiniProfilerRatpackUtil.java
+++ b/ratpack/src/main/java/io/jdev/miniprofiler/ratpack/MiniProfilerRatpackUtil.java
@@ -29,6 +29,9 @@ import java.util.concurrent.atomic.AtomicBoolean;
  */
 public class MiniProfilerRatpackUtil {
 
+    private MiniProfilerRatpackUtil() {
+    }
+
     /**
      * Add a profiling step for the promise, starting with when the promise is first subscribed-to and finishing
      * when the promise supplies results.

--- a/ratpack/src/main/java/io/jdev/miniprofiler/ratpack/MiniProfilerResourceHandler.java
+++ b/ratpack/src/main/java/io/jdev/miniprofiler/ratpack/MiniProfilerResourceHandler.java
@@ -26,6 +26,10 @@ import ratpack.http.Response;
  */
 public class MiniProfilerResourceHandler implements Handler {
 
+    /** Creates a new resource handler. */
+    public MiniProfilerResourceHandler() {
+    }
+
     private final ResourceHelper resourceHelper = new ResourceHelper();
 
     /**

--- a/ratpack/src/main/java/io/jdev/miniprofiler/ratpack/MiniProfilerResultsHandler.java
+++ b/ratpack/src/main/java/io/jdev/miniprofiler/ratpack/MiniProfilerResultsHandler.java
@@ -41,6 +41,11 @@ public class MiniProfilerResultsHandler implements Handler {
 
     private final ProfilerProvider provider;
 
+    /**
+     * Creates a new instance using the given profiler provider.
+     *
+     * @param provider the profiler provider to use for loading results
+     */
     @Inject
     public MiniProfilerResultsHandler(ProfilerProvider provider) {
         this.provider = provider;
@@ -59,6 +64,11 @@ public class MiniProfilerResultsHandler implements Handler {
         );
     }
 
+    /**
+     * Handles a GET or POST request by serving the profiling results for the requested id.
+     *
+     * @param ctx the current context
+     */
     public void handleRequest(Context ctx) {
         Response response = ctx.getResponse();
 

--- a/ratpack/src/main/java/io/jdev/miniprofiler/ratpack/MiniProfilerResultsIndexHandler.java
+++ b/ratpack/src/main/java/io/jdev/miniprofiler/ratpack/MiniProfilerResultsIndexHandler.java
@@ -34,6 +34,11 @@ public class MiniProfilerResultsIndexHandler implements Handler {
 
     private final ProfilerProvider provider;
 
+    /**
+     * Creates a new instance using the given profiler provider.
+     *
+     * @param provider the profiler provider to use
+     */
     @Inject
     public MiniProfilerResultsIndexHandler(ProfilerProvider provider) {
         this.provider = provider;

--- a/ratpack/src/main/java/io/jdev/miniprofiler/ratpack/MiniProfilerResultsListHandler.java
+++ b/ratpack/src/main/java/io/jdev/miniprofiler/ratpack/MiniProfilerResultsListHandler.java
@@ -39,6 +39,11 @@ public class MiniProfilerResultsListHandler implements Handler {
 
     private final ProfilerProvider provider;
 
+    /**
+     * Creates a new instance using the given profiler provider.
+     *
+     * @param provider the profiler provider to use
+     */
     @Inject
     public MiniProfilerResultsListHandler(ProfilerProvider provider) {
         this.provider = provider;

--- a/ratpack/src/main/java/io/jdev/miniprofiler/ratpack/MiniProfilerStartProfilingHandler.java
+++ b/ratpack/src/main/java/io/jdev/miniprofiler/ratpack/MiniProfilerStartProfilingHandler.java
@@ -32,6 +32,11 @@ public class MiniProfilerStartProfilingHandler implements Handler {
 
     private final ProfilerProvider profilerProvider;
 
+    /**
+     * Creates a new instance using the given profiler provider.
+     *
+     * @param profilerProvider the profiler provider to use
+     */
     public MiniProfilerStartProfilingHandler(ProfilerProvider profilerProvider) {
         this.profilerProvider = profilerProvider;
     }

--- a/ratpack/src/main/java/io/jdev/miniprofiler/ratpack/MiniProfilerStartProfilingHandlers.java
+++ b/ratpack/src/main/java/io/jdev/miniprofiler/ratpack/MiniProfilerStartProfilingHandlers.java
@@ -19,7 +19,13 @@ package io.jdev.miniprofiler.ratpack;
 import ratpack.func.Action;
 import ratpack.handling.Chain;
 
+/**
+ * A Ratpack {@link ratpack.func.Action} that installs MiniProfiler start-profiling handlers into a handler chain.
+ */
 public class MiniProfilerStartProfilingHandlers implements Action<Chain> {
+
+    /** Default constructor. */
+    public MiniProfilerStartProfilingHandlers() {}
 
     @Override
     public void execute(Chain chain) throws Exception {

--- a/ratpack/src/main/java/io/jdev/miniprofiler/ratpack/ProfilerStoreOption.java
+++ b/ratpack/src/main/java/io/jdev/miniprofiler/ratpack/ProfilerStoreOption.java
@@ -16,7 +16,10 @@
 
 package io.jdev.miniprofiler.ratpack;
 
+/** Controls whether profiling results are stored after a request completes. */
 public enum ProfilerStoreOption {
+    /** Store profiling results so they can be viewed later. */
     STORE_RESULTS,
+    /** Discard profiling results after the request completes. */
     DISCARD_RESULTS
 }

--- a/ratpack/src/main/java/io/jdev/miniprofiler/ratpack/RatpackContextProfilerProvider.java
+++ b/ratpack/src/main/java/io/jdev/miniprofiler/ratpack/RatpackContextProfilerProvider.java
@@ -30,6 +30,9 @@ import java.util.Optional;
  */
 public class RatpackContextProfilerProvider extends BaseProfilerProvider {
 
+    /** Default constructor. */
+    public RatpackContextProfilerProvider() {}
+
     /**
      * Adds the given rofiler to the current {@link Execution}.
      *
@@ -73,6 +76,12 @@ public class RatpackContextProfilerProvider extends BaseProfilerProvider {
         }
     }
 
+    /**
+     * Returns the current profiler from the given execution, or empty if none is present.
+     *
+     * @param execution the current Ratpack execution
+     * @return the current profiler, or empty if not present
+     */
     protected Optional<Profiler> lookupCurrentProfiler(Execution execution) {
         return execution.maybeGet(Profiler.class);
     }

--- a/ratpack/src/main/java/io/jdev/miniprofiler/ratpack/StoreMiniProfilerHandler.java
+++ b/ratpack/src/main/java/io/jdev/miniprofiler/ratpack/StoreMiniProfilerHandler.java
@@ -29,6 +29,9 @@ import ratpack.handling.Handler;
  */
 public class StoreMiniProfilerHandler implements Handler {
 
+    /** Default constructor. */
+    public StoreMiniProfilerHandler() {}
+
     @Override
     public void handle(Context ctx) throws Exception {
         Execution.current().add(ProfilerStoreOption.class, ProfilerStoreOption.STORE_RESULTS);

--- a/test/src/main/java/io/jdev/miniprofiler/test/ExpectedCustomTiming.java
+++ b/test/src/main/java/io/jdev/miniprofiler/test/ExpectedCustomTiming.java
@@ -36,14 +36,29 @@ public final class ExpectedCustomTiming {
         this.minDurationMs = minDurationMs;
     }
 
+    /**
+     * Returns the execute type (e.g. {@code "sql"}).
+     *
+     * @return the execute type
+     */
     public String getExecuteType() {
         return executeType;
     }
 
+    /**
+     * Returns the command string (e.g. the SQL query), with whitespace normalised for comparison.
+     *
+     * @return the command string
+     */
     public String getCommandString() {
         return commandString;
     }
 
+    /**
+     * Returns the minimum expected duration in milliseconds.
+     *
+     * @return the minimum duration in milliseconds
+     */
     public long getMinDurationMs() {
         return minDurationMs;
     }

--- a/test/src/main/java/io/jdev/miniprofiler/test/ExpectedProfiler.java
+++ b/test/src/main/java/io/jdev/miniprofiler/test/ExpectedProfiler.java
@@ -30,10 +30,20 @@ public final class ExpectedProfiler {
         this.root = root;
     }
 
+    /**
+     * Returns the expected profiling session name.
+     *
+     * @return the expected name
+     */
     public String getName() {
         return name;
     }
 
+    /**
+     * Returns the expected root timing step.
+     *
+     * @return the expected root timing
+     */
     public ExpectedTiming getRoot() {
         return root;
     }

--- a/test/src/main/java/io/jdev/miniprofiler/test/ExpectedTiming.java
+++ b/test/src/main/java/io/jdev/miniprofiler/test/ExpectedTiming.java
@@ -40,10 +40,20 @@ public final class ExpectedTiming {
         this.customTimings = Collections.unmodifiableMap(customTimings);
     }
 
+    /**
+     * Returns the expected timing step name.
+     *
+     * @return the expected name
+     */
     public String getName() {
         return name;
     }
 
+    /**
+     * Returns the minimum expected duration in milliseconds.
+     *
+     * @return the minimum duration in milliseconds
+     */
     public long getMinDurationMs() {
         return minDurationMs;
     }

--- a/test/src/main/java/io/jdev/miniprofiler/test/TestProfilerProvider.java
+++ b/test/src/main/java/io/jdev/miniprofiler/test/TestProfilerProvider.java
@@ -30,9 +30,15 @@ public class TestProfilerProvider extends BaseProfilerProvider {
     private Profiler profiler;
     private boolean discarded;
 
+    /** Creates a new instance with no initial profiler. */
     public TestProfilerProvider() {
     }
 
+    /**
+     * Creates a new instance that returns the given profiler as the current session.
+     *
+     * @param profiler the profiler to return as the current session
+     */
     public TestProfilerProvider(Profiler profiler) {
         this.profiler = profiler;
     }
@@ -57,6 +63,11 @@ public class TestProfilerProvider extends BaseProfilerProvider {
         super.stopSession(profilingSession, discardResults);
     }
 
+    /**
+     * Returns true if the last stopped profiling session was discarded.
+     *
+     * @return {@code true} if the last session was discarded
+     */
     public boolean wasDiscarded() {
         return discarded;
     }

--- a/test/src/main/java/io/jdev/miniprofiler/test/TestProfilerProviderLocator.java
+++ b/test/src/main/java/io/jdev/miniprofiler/test/TestProfilerProviderLocator.java
@@ -33,6 +33,10 @@ import java.util.Optional;
  */
 public class TestProfilerProviderLocator implements ProfilerProviderLocator {
 
+    /** Default constructor. */
+    public TestProfilerProviderLocator() {
+    }
+
     private static volatile boolean enabled;
     private static volatile ProfilerProvider provider;
 
@@ -49,11 +53,17 @@ public class TestProfilerProviderLocator implements ProfilerProviderLocator {
         return Optional.empty();
     }
 
+    /**
+     * Activates this locator so that {@link #locate()} returns the given provider.
+     *
+     * @param profilerProvider the provider to return from {@link #locate()}
+     */
     public static void activate(ProfilerProvider profilerProvider) {
         provider = profilerProvider;
         enabled = true;
     }
 
+    /** Deactivates this locator so that {@link #locate()} returns empty. */
     public static void deactivate() {
         enabled = false;
         provider = null;

--- a/viewer/src/main/java/io/jdev/miniprofiler/viewer/MiniProfilerViewerMain.java
+++ b/viewer/src/main/java/io/jdev/miniprofiler/viewer/MiniProfilerViewerMain.java
@@ -19,8 +19,19 @@ package io.jdev.miniprofiler.viewer;
 import java.nio.file.Path;
 import java.nio.file.Paths;
 
+/** Entry point for the standalone MiniProfiler viewer application. */
 public final class MiniProfilerViewerMain {
 
+    private MiniProfilerViewerMain() {
+    }
+
+    /**
+     * Starts the viewer server for the profile file given as the first argument
+     * or via the {@code miniprofiler.viewer.file} system property.
+     *
+     * @param args command-line arguments; the first element, if present, is the path to the profile file
+     * @throws Exception if the server fails to start or the file cannot be read
+     */
     public static void main(String... args) throws Exception {
         String filePath = args.length > 0 ? args[0] : System.getProperty("miniprofiler.viewer.file");
         if (filePath == null) {

--- a/viewer/src/main/java/io/jdev/miniprofiler/viewer/MiniProfilerViewerServer.java
+++ b/viewer/src/main/java/io/jdev/miniprofiler/viewer/MiniProfilerViewerServer.java
@@ -25,12 +25,19 @@ import io.jdev.miniprofiler.storage.Storage;
 import java.io.IOException;
 import java.nio.charset.StandardCharsets;
 
+/** Embedded HTTP server that serves the MiniProfiler viewer UI for a given storage or provider. */
 public class MiniProfilerViewerServer implements AutoCloseable {
 
     static final String DEFAULT_PREFIX = "/miniprofiler";
 
     private final MiniProfilerServer server;
 
+    /**
+     * Creates a new viewer server backed by the given storage.
+     *
+     * @param storage the storage to serve profiles from
+     * @throws IOException if the HTTP server cannot be started
+     */
     public MiniProfilerViewerServer(Storage storage) throws IOException {
         this(makeProvider(storage));
     }
@@ -46,6 +53,12 @@ public class MiniProfilerViewerServer implements AutoCloseable {
         return provider;
     }
 
+    /**
+     * Creates a new viewer server backed by the given profiler provider.
+     *
+     * @param provider the profiler provider to serve profiles from
+     * @throws IOException if the HTTP server cannot be started
+     */
     public MiniProfilerViewerServer(ProfilerProvider provider) throws IOException {
         String indexPath = provider.getUiConfig().getPath() + "/results-index";
         server = new MiniProfilerServer(provider, httpServer ->
@@ -68,6 +81,11 @@ public class MiniProfilerViewerServer implements AutoCloseable {
         );
     }
 
+    /**
+     * Returns the local port on which the server is listening.
+     *
+     * @return the local port number
+     */
     public int getPort() {
         return server.getPort();
     }

--- a/viewer/src/main/java/io/jdev/miniprofiler/viewer/MiniProfilerViewerSingleFileStorage.java
+++ b/viewer/src/main/java/io/jdev/miniprofiler/viewer/MiniProfilerViewerSingleFileStorage.java
@@ -28,6 +28,7 @@ import java.util.Collections;
 import java.util.Date;
 import java.util.UUID;
 
+/** A read-only {@link Storage} backed by a single MiniProfiler JSON file on disk. */
 public class MiniProfilerViewerSingleFileStorage implements Storage {
 
     private final UUID uuid;
@@ -38,6 +39,12 @@ public class MiniProfilerViewerSingleFileStorage implements Storage {
         this.profiler = profiler;
     }
 
+    /**
+     * Creates a storage instance by reading and deserializing the profile JSON at the given path.
+     *
+     * @param path the path to the MiniProfiler JSON file
+     * @return a new storage instance backed by the file
+     */
     public static MiniProfilerViewerSingleFileStorage forFile(Path path) {
         if (!path.toFile().isFile()) {
             throw new IllegalArgumentException("File not found: " + path);
@@ -52,10 +59,16 @@ public class MiniProfilerViewerSingleFileStorage implements Storage {
         }
     }
 
+    /**
+     * Returns the UUID of the single profiling session stored in this instance.
+     *
+     * @return the UUID of the stored profiling session
+     */
     public UUID getUuid() {
         return uuid;
     }
 
+    /** {@inheritDoc} Returns the single stored session if its start time falls within the given range. */
     @Override
     public Collection<UUID> list(int maxResults, Date start, Date finish, ListResultsOrder orderBy) {
         long started = profiler.getStarted();
@@ -65,23 +78,28 @@ public class MiniProfilerViewerSingleFileStorage implements Storage {
         return Collections.emptyList();
     }
 
+    /** {@inheritDoc} No-op: this storage is read-only. */
     @Override
     public void save(ProfilerImpl profiler) {
     }
 
+    /** {@inheritDoc} Returns the stored profiler if the given id matches, otherwise null. */
     @Override
     public ProfilerImpl load(UUID id) {
         return uuid.equals(id) ? profiler : null;
     }
 
+    /** {@inheritDoc} No-op. */
     @Override
     public void setUnviewed(String user, UUID id) {
     }
 
+    /** {@inheritDoc} No-op. */
     @Override
     public void setViewed(String user, UUID id) {
     }
 
+    /** {@inheritDoc} Always returns an empty collection. */
     @Override
     public Collection<UUID> getUnviewedIds(String user) {
         return Collections.emptyList();


### PR DESCRIPTION
## Summary
- Configure javadoc toolchain to use JDK 25 with `-Xwerror` so all warnings become fatal errors
- Use `-Xdoclint:all` with package exclusions for internal packages, since JDK 25 dropped the `/access` qualifier that previously allowed suppressing private member checks
- Wire `sanityCheck` to depend on javadoc tasks so they run as part of `check`
- Add missing javadoc across all published modules to satisfy doclint
- Add missing `@Override` annotations on interface implementation methods
- Make `SqlFormatterFactory` and `MiniProfilerRatpackUtil` proper utility classes with private constructors

## Test plan
- [x] `gradle check --continue` passes locally (285 passed, 1 skipped, 0 failed)
- [x] `gradle javadoc --rerun` passes for all modules
- [x] CI workflow passes