### PR TITLE
Move ResourceHelper from util to server subpackage

### DIFF
--- a/core/src/main/java/io/jdev/miniprofiler/MiniProfiler.java
+++ b/core/src/main/java/io/jdev/miniprofiler/MiniProfiler.java
@@ -18,7 +18,7 @@ package io.jdev.miniprofiler;
 
 import io.jdev.miniprofiler.internal.NullProfiler;
 import io.jdev.miniprofiler.storage.Storage;
-import io.jdev.miniprofiler.util.ResourceHelper;
+import io.jdev.miniprofiler.server.ResourceHelper;
 
 import java.io.IOException;
 import java.util.Optional;

--- a/core/src/main/java/io/jdev/miniprofiler/server/MiniProfilerServer.java
+++ b/core/src/main/java/io/jdev/miniprofiler/server/MiniProfilerServer.java
@@ -21,7 +21,6 @@ import com.sun.net.httpserver.HttpServer;
 import io.jdev.miniprofiler.ProfilerProvider;
 import io.jdev.miniprofiler.internal.ProfilerImpl;
 import io.jdev.miniprofiler.storage.Storage;
-import io.jdev.miniprofiler.util.ResourceHelper;
 
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;

--- a/core/src/main/java/io/jdev/miniprofiler/server/ResourceHelper.java
+++ b/core/src/main/java/io/jdev/miniprofiler/server/ResourceHelper.java
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-package io.jdev.miniprofiler.util;
+package io.jdev.miniprofiler.server;
 
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;

--- a/jakarta-servlet/src/main/java/io/jdev/miniprofiler/jakarta/servlet/ProfilingFilter.java
+++ b/jakarta-servlet/src/main/java/io/jdev/miniprofiler/jakarta/servlet/ProfilingFilter.java
@@ -25,7 +25,7 @@ import io.jdev.miniprofiler.internal.ProfilerImpl;
 import io.jdev.miniprofiler.server.IdParser;
 import io.jdev.miniprofiler.sql.DriverUtil;
 import io.jdev.miniprofiler.storage.Storage;
-import io.jdev.miniprofiler.util.ResourceHelper;
+import io.jdev.miniprofiler.server.ResourceHelper;
 
 import jakarta.servlet.*;
 import jakarta.servlet.http.HttpServletRequest;

--- a/javax-servlet/src/main/java/io/jdev/miniprofiler/javax/servlet/ProfilingFilter.java
+++ b/javax-servlet/src/main/java/io/jdev/miniprofiler/javax/servlet/ProfilingFilter.java
@@ -25,7 +25,7 @@ import io.jdev.miniprofiler.internal.ProfilerImpl;
 import io.jdev.miniprofiler.server.IdParser;
 import io.jdev.miniprofiler.sql.DriverUtil;
 import io.jdev.miniprofiler.storage.Storage;
-import io.jdev.miniprofiler.util.ResourceHelper;
+import io.jdev.miniprofiler.server.ResourceHelper;
 
 import javax.servlet.*;
 import javax.servlet.http.HttpServletRequest;

--- a/ratpack/src/main/java/io/jdev/miniprofiler/ratpack/MiniProfilerResourceHandler.java
+++ b/ratpack/src/main/java/io/jdev/miniprofiler/ratpack/MiniProfilerResourceHandler.java
@@ -16,7 +16,7 @@
 
 package io.jdev.miniprofiler.ratpack;
 
-import io.jdev.miniprofiler.util.ResourceHelper;
+import io.jdev.miniprofiler.server.ResourceHelper;
 import ratpack.handling.Context;
 import ratpack.handling.Handler;
 import ratpack.http.Response;


### PR DESCRIPTION
ResourceHelper is used exclusively by server-side components (MiniProfilerServer, ProfilingFilter, MiniProfilerResourceHandler). Place it alongside the other server utilities it supports.