### PR TITLE
CDI module cleanups

### DIFF
--- a/README.md
+++ b/README.md
@@ -116,20 +116,26 @@ You can change this by passing it an `init-param` of `path`. Be sure to pass the
 
 The filter can also be configured to accept cross-origin requests by passing an `allowed-origin` `init-param` with the value that you would like the `Access-Control-Allow-Origin` header to be.
 
-Inclusion in Java EE applications with CDI
-------------------------------------------
-There are a couple of extra pieces of support for modern Java EE applications. Simply include the `miniprofiler-javaee` module:
+Inclusion in Java EE / Jakarta EE applications with CDI
+--------------------------------------------------------
+There are a couple of extra pieces of support for Java EE and Jakarta EE applications. Include the appropriate module for your platform:
+
+For **Jakarta EE** (Jakarta CDI / EJB):
 
     groupId: io.jdev.miniprofiler
-    artifactId: miniprofiler-javaee
-    version: 0.11.1
+    artifactId: miniprofiler-jakarta-ee
 
-That module contains a `DefaultCDIProfilerProvider` which is a `ProfilerProvider` instance ready to be injected into your CDI-managed beans.
+For **Javax EE** (legacy javax CDI / EJB):
 
-It also contains an interceptor for profiling EJB calls. Add the following to your `beans.xml`:
+    groupId: io.jdev.miniprofiler
+    artifactId: miniprofiler-javax-ee
+
+Each module contains a `DefaultCdiProfilerProvider` which is a `ProfilerProvider` instance ready to be injected into your CDI-managed beans.
+
+They also contain an interceptor for profiling EJB calls. Add the following to your `beans.xml` (using the appropriate package):
 
     <interceptors>
-        <class>io.jdev.miniprofiler.javaee.ProfilingEJBInterceptor</class>
+        <class>io.jdev.miniprofiler.jakarta.ee.ProfilingEJBInterceptor</class>
     </interceptors>
 
 Then add the `@Profiled` annotation to any EJB that you want profiled, and EJB method calls will appear in your profiler output.

--- a/jakarta-ee/src/integrationTest/groovy/io/jdev/miniprofiler/jakarta/ee/CdiProfilerProviderLocatorIntegrationSpec.groovy
+++ b/jakarta-ee/src/integrationTest/groovy/io/jdev/miniprofiler/jakarta/ee/CdiProfilerProviderLocatorIntegrationSpec.groovy
@@ -29,7 +29,7 @@ class CdiProfilerProviderLocatorIntegrationSpec extends Specification {
 
     void setupSpec() {
         container = SeContainerInitializer.newInstance()
-            .addBeanClasses(DefaultCDIProfilerProvider)
+            .addBeanClasses(DefaultCdiProfilerProvider)
             .initialize()
     }
 

--- a/jakarta-ee/src/integrationTest/groovy/io/jdev/miniprofiler/jakarta/ee/CdiProfilerProviderLocatorIntegrationSpec.groovy
+++ b/jakarta-ee/src/integrationTest/groovy/io/jdev/miniprofiler/jakarta/ee/CdiProfilerProviderLocatorIntegrationSpec.groovy
@@ -37,17 +37,9 @@ class CdiProfilerProviderLocatorIntegrationSpec extends Specification {
         container?.close()
     }
 
-    CdiProfilerProviderLocator locatorWithContainerBeanManager() {
-        def beanManager = container.beanManager
-        return new CdiProfilerProviderLocator() {
-            @Override
-            Object lookupBeanManagerFromJndi() { return beanManager }
-        }
-    }
-
     void "locator finds ProfilerProvider from CDI container"() {
         when:
-        def result = locatorWithContainerBeanManager().locate()
+        def result = new CdiProfilerProviderLocator().locate()
 
         then:
         result.present
@@ -56,7 +48,7 @@ class CdiProfilerProviderLocatorIntegrationSpec extends Specification {
 
     void "locator returns the CDI-managed singleton ProfilerProvider"() {
         given:
-        def locatorProvider = locatorWithContainerBeanManager().locate().get()
+        def locatorProvider = new CdiProfilerProviderLocator().locate().get()
         def containerProvider = container.select(ProfilerProvider).get()
 
         when:

--- a/jakarta-ee/src/integrationTest/groovy/io/jdev/miniprofiler/jakarta/ee/ProfilingEJBInterceptorIntegrationSpec.groovy
+++ b/jakarta-ee/src/integrationTest/groovy/io/jdev/miniprofiler/jakarta/ee/ProfilingEJBInterceptorIntegrationSpec.groovy
@@ -30,7 +30,7 @@ class ProfilingEJBInterceptorIntegrationSpec extends Specification {
     void setupSpec() {
         container = SeContainerInitializer.newInstance()
             .addBeanClasses(
-                DefaultCDIProfilerProvider,
+                DefaultCdiProfilerProvider,
                 ProfilingEJBInterceptor,
                 ProfiledService,
                 ProfiledClassLevelService

--- a/jakarta-ee/src/main/java/io/jdev/miniprofiler/jakarta/ee/CdiProfilerProviderLocator.java
+++ b/jakarta-ee/src/main/java/io/jdev/miniprofiler/jakarta/ee/CdiProfilerProviderLocator.java
@@ -19,17 +19,14 @@ package io.jdev.miniprofiler.jakarta.ee;
 import io.jdev.miniprofiler.ProfilerProvider;
 import io.jdev.miniprofiler.ProfilerProviderLocator;
 
-import jakarta.enterprise.context.spi.CreationalContext;
-import jakarta.enterprise.inject.spi.Bean;
-import jakarta.enterprise.inject.spi.BeanManager;
-import javax.naming.InitialContext;
+import jakarta.enterprise.inject.Instance;
+import jakarta.enterprise.inject.spi.CDI;
 import java.util.Optional;
-import java.util.Set;
 
 /**
  * {@link ProfilerProviderLocator} that looks up a {@link ProfilerProvider} from the
- * Jakarta CDI container via JNDI. Returns an empty {@link Optional} if the Jakarta CDI
- * API is not available or no {@link ProfilerProvider} bean is registered.
+ * Jakarta CDI container using {@link CDI#current()}. Returns an empty {@link Optional}
+ * if the Jakarta CDI API is not available or no {@link ProfilerProvider} bean is registered.
  */
 public class CdiProfilerProviderLocator implements ProfilerProviderLocator {
 
@@ -43,31 +40,16 @@ public class CdiProfilerProviderLocator implements ProfilerProviderLocator {
     }
 
     @Override
-    @SuppressWarnings("unchecked")
     public Optional<ProfilerProvider> locate() {
         try {
-            Object lookedUp = lookupBeanManagerFromJndi();
-            if (!(lookedUp instanceof BeanManager)) {
-                return Optional.empty();
+            CDI<Object> cdi = CDI.current();
+            Instance<ProfilerProvider> instance = cdi.select(ProfilerProvider.class);
+            if (instance.isResolvable()) {
+                return Optional.of(instance.get());
             }
-            BeanManager bm = (BeanManager) lookedUp;
-            Set<Bean<?>> beans = bm.getBeans(ProfilerProvider.class);
-            if (beans.isEmpty()) {
-                return Optional.empty();
-            }
-            Bean<ProfilerProvider> bean = (Bean<ProfilerProvider>) bm.resolve(beans);
-            CreationalContext<ProfilerProvider> ctx = bm.createCreationalContext(bean);
-            Object reference = bm.getReference(bean, ProfilerProvider.class, ctx);
-            if (!(reference instanceof ProfilerProvider)) {
-                return Optional.empty();
-            }
-            return Optional.of((ProfilerProvider) reference);
+            return Optional.empty();
         } catch (Exception | NoClassDefFoundError e) {
             return Optional.empty();
         }
-    }
-
-    Object lookupBeanManagerFromJndi() throws Exception {
-        return new InitialContext().lookup("java:comp/BeanManager");
     }
 }

--- a/jakarta-ee/src/main/java/io/jdev/miniprofiler/jakarta/ee/DefaultCdiProfilerProvider.java
+++ b/jakarta-ee/src/main/java/io/jdev/miniprofiler/jakarta/ee/DefaultCdiProfilerProvider.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014 the original author or authors.
+ * Copyright 2026 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -14,19 +14,22 @@
  * limitations under the License.
  */
 
-package io.jdev.miniprofiler.javax.ee;
+package io.jdev.miniprofiler.jakarta.ee;
 
 import io.jdev.miniprofiler.DefaultProfilerProvider;
 
-import javax.enterprise.context.ApplicationScoped;
-import javax.enterprise.inject.Default;
+import jakarta.enterprise.context.ApplicationScoped;
+import jakarta.enterprise.inject.Default;
 
-/** Default CDI-managed {@link io.jdev.miniprofiler.ProfilerProvider} for use with javax CDI containers. */
+/**
+ * CDI {@link jakarta.enterprise.context.ApplicationScoped} implementation of
+ * {@link io.jdev.miniprofiler.DefaultProfilerProvider} for use in Jakarta EE applications.
+ */
 @ApplicationScoped
 @Default
-public class DefaultCDIProfilerProvider extends DefaultProfilerProvider {
+public class DefaultCdiProfilerProvider extends DefaultProfilerProvider {
 
     /** Default constructor for CDI. */
-    public DefaultCDIProfilerProvider() {
+    public DefaultCdiProfilerProvider() {
     }
 }

--- a/jakarta-ee/src/test/groovy/io/jdev/miniprofiler/jakarta/ee/CdiProfilerProviderLocatorSpec.groovy
+++ b/jakarta-ee/src/test/groovy/io/jdev/miniprofiler/jakarta/ee/CdiProfilerProviderLocatorSpec.groovy
@@ -16,12 +16,7 @@
 
 package io.jdev.miniprofiler.jakarta.ee
 
-import io.jdev.miniprofiler.ProfilerProvider
 import spock.lang.Specification
-
-import jakarta.enterprise.context.spi.CreationalContext
-import jakarta.enterprise.inject.spi.Bean
-import jakarta.enterprise.inject.spi.BeanManager
 
 class CdiProfilerProviderLocatorSpec extends Specification {
 
@@ -33,45 +28,9 @@ class CdiProfilerProviderLocatorSpec extends Specification {
     }
 
     void "locator returns empty optional when CDI is not available"() {
-        // In a plain unit test environment there is no JNDI BeanManager
+        // In a plain unit test environment there is no CDI container
         when:
         def result = locator.locate()
-
-        then:
-        !result.present
-    }
-
-    void "locator returns empty optional when JNDI returns a BeanManager of the wrong type"() {
-        given: 'a locator that simulates finding a javax BeanManager instead of jakarta'
-        def wrongTypeLocator = new CdiProfilerProviderLocator() {
-            @Override
-            Object lookupBeanManagerFromJndi() {
-                return "not a jakarta BeanManager" // simulates javax BeanManager on classpath
-            }
-        }
-
-        when:
-        def result = wrongTypeLocator.locate()
-
-        then:
-        !result.present
-    }
-
-    void "locator returns empty optional when CDI returns wrong ProfilerProvider type"() {
-        given: 'a locator that finds a valid BeanManager but the resolved bean is not a ProfilerProvider'
-        def bm = Mock(BeanManager)
-        def wrongTypeLocator = new CdiProfilerProviderLocator() {
-            @Override
-            Object lookupBeanManagerFromJndi() { return bm }
-        }
-
-        bm.getBeans(ProfilerProvider) >> ([Mock(Bean)] as Set)
-        bm.resolve(_) >> Mock(Bean)
-        bm.createCreationalContext(_) >> Mock(CreationalContext)
-        bm.getReference(_, _, _) >> "not a ProfilerProvider"
-
-        when:
-        def result = wrongTypeLocator.locate()
 
         then:
         !result.present

--- a/javax-ee/src/integrationTest/groovy/io/jdev/miniprofiler/javax/ee/CdiProfilerProviderLocatorIntegrationSpec.groovy
+++ b/javax-ee/src/integrationTest/groovy/io/jdev/miniprofiler/javax/ee/CdiProfilerProviderLocatorIntegrationSpec.groovy
@@ -29,7 +29,7 @@ class CdiProfilerProviderLocatorIntegrationSpec extends Specification {
 
     void setupSpec() {
         container = SeContainerInitializer.newInstance()
-            .addBeanClasses(DefaultCDIProfilerProvider)
+            .addBeanClasses(DefaultCdiProfilerProvider)
             .initialize()
     }
 

--- a/javax-ee/src/integrationTest/groovy/io/jdev/miniprofiler/javax/ee/CdiProfilerProviderLocatorIntegrationSpec.groovy
+++ b/javax-ee/src/integrationTest/groovy/io/jdev/miniprofiler/javax/ee/CdiProfilerProviderLocatorIntegrationSpec.groovy
@@ -37,17 +37,9 @@ class CdiProfilerProviderLocatorIntegrationSpec extends Specification {
         container?.close()
     }
 
-    CdiProfilerProviderLocator locatorWithContainerBeanManager() {
-        def beanManager = container.beanManager
-        return new CdiProfilerProviderLocator() {
-            @Override
-            Object lookupBeanManagerFromJndi() { return beanManager }
-        }
-    }
-
     void "locator finds ProfilerProvider from CDI container"() {
         when:
-        def result = locatorWithContainerBeanManager().locate()
+        def result = new CdiProfilerProviderLocator().locate()
 
         then:
         result.present
@@ -56,7 +48,7 @@ class CdiProfilerProviderLocatorIntegrationSpec extends Specification {
 
     void "locator returns the CDI-managed singleton ProfilerProvider"() {
         given:
-        def locatorProvider = locatorWithContainerBeanManager().locate().get()
+        def locatorProvider = new CdiProfilerProviderLocator().locate().get()
         def containerProvider = container.select(ProfilerProvider).get()
 
         when:

--- a/javax-ee/src/integrationTest/groovy/io/jdev/miniprofiler/javax/ee/ProfilingEJBInterceptorIntegrationSpec.groovy
+++ b/javax-ee/src/integrationTest/groovy/io/jdev/miniprofiler/javax/ee/ProfilingEJBInterceptorIntegrationSpec.groovy
@@ -30,7 +30,7 @@ class ProfilingEJBInterceptorIntegrationSpec extends Specification {
     void setupSpec() {
         container = SeContainerInitializer.newInstance()
             .addBeanClasses(
-                DefaultCDIProfilerProvider,
+                DefaultCdiProfilerProvider,
                 ProfilingEJBInterceptor,
                 ProfiledService,
                 ProfiledClassLevelService

--- a/javax-ee/src/main/java/io/jdev/miniprofiler/javax/ee/CdiProfilerProviderLocator.java
+++ b/javax-ee/src/main/java/io/jdev/miniprofiler/javax/ee/CdiProfilerProviderLocator.java
@@ -19,17 +19,14 @@ package io.jdev.miniprofiler.javax.ee;
 import io.jdev.miniprofiler.ProfilerProvider;
 import io.jdev.miniprofiler.ProfilerProviderLocator;
 
-import javax.enterprise.context.spi.CreationalContext;
-import javax.enterprise.inject.spi.Bean;
-import javax.enterprise.inject.spi.BeanManager;
-import javax.naming.InitialContext;
+import javax.enterprise.inject.Instance;
+import javax.enterprise.inject.spi.CDI;
 import java.util.Optional;
-import java.util.Set;
 
 /**
  * {@link ProfilerProviderLocator} that looks up a {@link ProfilerProvider} from the
- * javax CDI container via JNDI. Returns an empty {@link Optional} if the javax CDI
- * API is not available or no {@link ProfilerProvider} bean is registered.
+ * javax CDI container using {@link CDI#current()}. Returns an empty {@link Optional}
+ * if the javax CDI API is not available or no {@link ProfilerProvider} bean is registered.
  */
 public class CdiProfilerProviderLocator implements ProfilerProviderLocator {
 
@@ -45,31 +42,16 @@ public class CdiProfilerProviderLocator implements ProfilerProviderLocator {
 
     /** {@inheritDoc} */
     @Override
-    @SuppressWarnings("unchecked")
     public Optional<ProfilerProvider> locate() {
         try {
-            Object lookedUp = lookupBeanManagerFromJndi();
-            if (!(lookedUp instanceof BeanManager)) {
-                return Optional.empty();
+            CDI<Object> cdi = CDI.current();
+            Instance<ProfilerProvider> instance = cdi.select(ProfilerProvider.class);
+            if (!instance.isUnsatisfied() && !instance.isAmbiguous()) {
+                return Optional.of(instance.get());
             }
-            BeanManager bm = (BeanManager) lookedUp;
-            Set<Bean<?>> beans = bm.getBeans(ProfilerProvider.class);
-            if (beans.isEmpty()) {
-                return Optional.empty();
-            }
-            Bean<ProfilerProvider> bean = (Bean<ProfilerProvider>) bm.resolve(beans);
-            CreationalContext<ProfilerProvider> ctx = bm.createCreationalContext(bean);
-            Object reference = bm.getReference(bean, ProfilerProvider.class, ctx);
-            if (!(reference instanceof ProfilerProvider)) {
-                return Optional.empty();
-            }
-            return Optional.of((ProfilerProvider) reference);
+            return Optional.empty();
         } catch (Exception | NoClassDefFoundError e) {
             return Optional.empty();
         }
-    }
-
-    Object lookupBeanManagerFromJndi() throws Exception {
-        return new InitialContext().lookup("java:comp/BeanManager");
     }
 }

--- a/javax-ee/src/main/java/io/jdev/miniprofiler/javax/ee/DefaultCdiProfilerProvider.java
+++ b/javax-ee/src/main/java/io/jdev/miniprofiler/javax/ee/DefaultCdiProfilerProvider.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2026 the original author or authors.
+ * Copyright 2014 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -14,22 +14,19 @@
  * limitations under the License.
  */
 
-package io.jdev.miniprofiler.jakarta.ee;
+package io.jdev.miniprofiler.javax.ee;
 
 import io.jdev.miniprofiler.DefaultProfilerProvider;
 
-import jakarta.enterprise.context.ApplicationScoped;
-import jakarta.enterprise.inject.Default;
+import javax.enterprise.context.ApplicationScoped;
+import javax.enterprise.inject.Default;
 
-/**
- * CDI {@link jakarta.enterprise.context.ApplicationScoped} implementation of
- * {@link io.jdev.miniprofiler.DefaultProfilerProvider} for use in Jakarta EE applications.
- */
+/** Default CDI-managed {@link io.jdev.miniprofiler.ProfilerProvider} for use with javax CDI containers. */
 @ApplicationScoped
 @Default
-public class DefaultCDIProfilerProvider extends DefaultProfilerProvider {
+public class DefaultCdiProfilerProvider extends DefaultProfilerProvider {
 
     /** Default constructor for CDI. */
-    public DefaultCDIProfilerProvider() {
+    public DefaultCdiProfilerProvider() {
     }
 }

--- a/javax-ee/src/test/groovy/io/jdev/miniprofiler/javax/ee/CdiProfilerProviderLocatorSpec.groovy
+++ b/javax-ee/src/test/groovy/io/jdev/miniprofiler/javax/ee/CdiProfilerProviderLocatorSpec.groovy
@@ -16,12 +16,7 @@
 
 package io.jdev.miniprofiler.javax.ee
 
-import io.jdev.miniprofiler.ProfilerProvider
 import spock.lang.Specification
-
-import javax.enterprise.context.spi.CreationalContext
-import javax.enterprise.inject.spi.Bean
-import javax.enterprise.inject.spi.BeanManager
 
 class CdiProfilerProviderLocatorSpec extends Specification {
 
@@ -33,45 +28,9 @@ class CdiProfilerProviderLocatorSpec extends Specification {
     }
 
     void "locator returns empty optional when CDI is not available"() {
-        // In a plain unit test environment there is no JNDI BeanManager
+        // In a plain unit test environment there is no CDI container
         when:
         def result = locator.locate()
-
-        then:
-        !result.present
-    }
-
-    void "locator returns empty optional when JNDI returns a BeanManager of the wrong type"() {
-        given: 'a locator that simulates finding a jakarta BeanManager instead of javax'
-        def wrongTypeLocator = new CdiProfilerProviderLocator() {
-            @Override
-            Object lookupBeanManagerFromJndi() {
-                return "not a javax BeanManager" // simulates jakarta BeanManager on classpath
-            }
-        }
-
-        when:
-        def result = wrongTypeLocator.locate()
-
-        then:
-        !result.present
-    }
-
-    void "locator returns empty optional when CDI returns wrong ProfilerProvider type"() {
-        given: 'a locator that finds a valid BeanManager but the resolved bean is not a ProfilerProvider'
-        def bm = Mock(BeanManager)
-        def wrongTypeLocator = new CdiProfilerProviderLocator() {
-            @Override
-            Object lookupBeanManagerFromJndi() { return bm }
-        }
-
-        bm.getBeans(ProfilerProvider) >> ([Mock(Bean)] as Set)
-        bm.resolve(_) >> Mock(Bean)
-        bm.createCreationalContext(_) >> Mock(CreationalContext)
-        bm.getReference(_, _, _) >> "not a ProfilerProvider"
-
-        when:
-        def result = wrongTypeLocator.locate()
 
         then:
         !result.present


### PR DESCRIPTION


  - Rename `DefaultCDIProfilerProvider` to `DefaultCdiProfilerProvider` for consistent
  title-case naming with `CdiProfilerProviderLocator`
  - Simplify `CdiProfilerProviderLocator` to use `CDI.current()` instead of manual JNDI
  `BeanManager` lookup and bean resolution
  - Update README to reflect the current `miniprofiler-jakarta-ee` /
  `miniprofiler-javax-ee` module split (replacing the old `miniprofiler-javaee`
  references)