### PR TITLE
Add UserProvider implementations for servlet and EE environments

### DIFF
--- a/core/src/main/java/io/jdev/miniprofiler/user/CompositeUserProvider.java
+++ b/core/src/main/java/io/jdev/miniprofiler/user/CompositeUserProvider.java
@@ -1,0 +1,56 @@
+/*
+ * Copyright 2026 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.jdev.miniprofiler.user;
+
+import java.util.Collections;
+import java.util.List;
+import java.util.Objects;
+
+/**
+ * A {@link UserProvider} that delegates to an ordered list of providers,
+ * returning the first non-null, non-empty result from
+ * {@link UserProvider#getUser()}.
+ *
+ * <p>Used internally by {@link UserProviderLocator#findUserProvider()} to
+ * combine providers contributed by all registered locators, so that a
+ * provider whose backing context is unavailable (for example a servlet
+ * request provider on a non-request thread) can fall through to the next
+ * provider in order.</p>
+ */
+final class CompositeUserProvider implements UserProvider {
+
+    private final List<UserProvider> providers;
+
+    CompositeUserProvider(List<UserProvider> providers) {
+        this.providers = Collections.unmodifiableList(Objects.requireNonNull(providers, "providers"));
+    }
+
+    @Override
+    public String getUser() {
+        for (UserProvider provider : providers) {
+            String user = provider.getUser();
+            if (user != null && !user.isEmpty()) {
+                return user;
+            }
+        }
+        return null;
+    }
+
+    List<UserProvider> getProviders() {
+        return providers;
+    }
+}

--- a/core/src/main/java/io/jdev/miniprofiler/user/UserProviderLocator.java
+++ b/core/src/main/java/io/jdev/miniprofiler/user/UserProviderLocator.java
@@ -23,13 +23,20 @@ import java.util.Optional;
 import java.util.ServiceLoader;
 
 /**
- * SPI for locating the current {@link UserProvider} implementation. Implementations are
- * discovered via {@link ServiceLoader} and consulted in ascending {@link #getOrder()}
- * order. The first implementation that returns a non-empty {@link Optional} wins.
+ * SPI for locating {@link UserProvider} implementations. Implementations are discovered
+ * via {@link ServiceLoader} and consulted in ascending {@link #getOrder()} order.
+ *
+ * <p>Unlike the other locator SPIs in miniprofiler (which resolve a single canonical
+ * owner of state), {@link #findUserProvider()} <em>combines</em> the providers returned
+ * by every locator into a chain. At lookup time each provider is asked for the current
+ * user in order, and the first non-null, non-empty answer wins. This lets request-bound
+ * providers (e.g. a servlet provider that needs an in-flight {@code HttpServletRequest})
+ * cleanly fall through to providers with broader applicability (e.g. a CDI-based one) on
+ * threads where the more specific context is missing.</p>
  *
  * <p>An {@link UnknownUserProviderLocator} is registered by default in
  * {@code miniprofiler-core} at order {@link #UNKNOWN_USER_PROVIDER_LOCATOR_ORDER}
- * as a fallback.</p>
+ * as the terminal fallback in the chain.</p>
  */
 public interface UserProviderLocator {
 
@@ -55,11 +62,13 @@ public interface UserProviderLocator {
 
     /**
      * Discovers all registered {@link UserProviderLocator} implementations via
-     * {@link ServiceLoader}, sorts them by {@link #getOrder()}, and returns the
-     * result of the first one that returns a non-empty {@link Optional}.
+     * {@link ServiceLoader}, sorts them by {@link #getOrder()}, collects every
+     * provider returned by a non-empty {@link #locate()}, and wraps them in a
+     * chain that returns the first non-null, non-empty result from
+     * {@link UserProvider#getUser()}.
      *
-     * <p>Falls back to an {@link UnknownUserProvider} if no locator succeeds,
-     * though in practice the {@link UnknownUserProviderLocator} always succeeds.</p>
+     * <p>{@link UnknownUserProviderLocator} provides the terminal {@code null}
+     * answer at the end of the chain.</p>
      *
      * @return the located {@link UserProvider}
      */
@@ -69,12 +78,13 @@ public interface UserProviderLocator {
             locators.add(locator);
         }
         locators.sort(Comparator.comparingInt(UserProviderLocator::getOrder));
+        List<UserProvider> providers = new ArrayList<>();
         for (UserProviderLocator locator : locators) {
-            Optional<UserProvider> provider = locator.locate();
-            if (provider.isPresent()) {
-                return provider.get();
-            }
+            locator.locate().ifPresent(providers::add);
         }
-        throw new IllegalStateException("No UserProviderLocator returned a provider. Ensure miniprofiler-core is on the classpath.");
+        if (providers.isEmpty()) {
+            throw new IllegalStateException("No UserProviderLocator returned a provider. Ensure miniprofiler-core is on the classpath.");
+        }
+        return new CompositeUserProvider(providers);
     }
 }

--- a/core/src/test/groovy/io/jdev/miniprofiler/user/CompositeUserProviderSpec.groovy
+++ b/core/src/test/groovy/io/jdev/miniprofiler/user/CompositeUserProviderSpec.groovy
@@ -1,0 +1,95 @@
+/*
+ * Copyright 2026 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.jdev.miniprofiler.user
+
+import spock.lang.Specification
+
+class CompositeUserProviderSpec extends Specification {
+
+    void "returns the result from the first provider when present"() {
+        given:
+        def first = { 'alice' } as UserProvider
+        def second = { throw new AssertionError('should not be called') } as UserProvider
+
+        expect:
+        new CompositeUserProvider([first, second]).user == 'alice'
+    }
+
+    void "falls through to next provider when earlier returns null"() {
+        given:
+        def first = { null } as UserProvider
+        def second = { 'bob' } as UserProvider
+
+        expect:
+        new CompositeUserProvider([first, second]).user == 'bob'
+    }
+
+    void "treats empty string as no answer and falls through"() {
+        given:
+        def first = { '' } as UserProvider
+        def second = { 'carol' } as UserProvider
+
+        expect:
+        new CompositeUserProvider([first, second]).user == 'carol'
+    }
+
+    void "returns null when every provider returns null"() {
+        given:
+        def first = { null } as UserProvider
+        def second = { null } as UserProvider
+
+        expect:
+        new CompositeUserProvider([first, second]).user == null
+    }
+
+    void "returns null for empty chain"() {
+        expect:
+        new CompositeUserProvider([]).user == null
+    }
+
+    void "preserves the order of providers"() {
+        given:
+        def first = { 'alice' } as UserProvider
+        def second = { 'bob' } as UserProvider
+        def composite = new CompositeUserProvider([first, second])
+
+        expect:
+        composite.providers == [first, second]
+        composite.user == 'alice'
+    }
+
+    void "stops asking once a provider has answered"() {
+        given:
+        def callCount = 0
+        def first = { callCount++; 'alice' } as UserProvider
+        def second = { throw new AssertionError('must not be invoked') } as UserProvider
+
+        when:
+        new CompositeUserProvider([first, second]).user
+
+        then:
+        callCount == 1
+    }
+
+    void "rejects null providers list"() {
+        when:
+        new CompositeUserProvider(null)
+
+        then:
+        thrown(NullPointerException)
+    }
+}

--- a/core/src/test/groovy/io/jdev/miniprofiler/user/UserProviderLocatorSpec.groovy
+++ b/core/src/test/groovy/io/jdev/miniprofiler/user/UserProviderLocatorSpec.groovy
@@ -47,43 +47,10 @@ class UserProviderLocatorSpec extends Specification {
         provider != null
     }
 
-    void "findUserProvider returns provider from lowest-order locator"() {
-        given: 'a low-order locator returning a specific provider'
-        def expectedProvider = Mock(UserProvider)
-        def lowOrderLocator = new UserProviderLocator() {
-            int getOrder() { return 1 }
-            Optional<UserProvider> locate() { Optional.of(expectedProvider) }
-        }
-        def highOrderLocator = new UserProviderLocator() {
-            int getOrder() { return 99 }
-            Optional<UserProvider> locate() { throw new AssertionError("should not be called") }
-        }
-
-        when:
-        def locators = [highOrderLocator, lowOrderLocator].sort { it.order }
-        def result = locators.findResult { it.locate().orElse(null) }
-
-        then:
-        result == expectedProvider
-    }
-
-    void "findUserProvider skips locators returning empty optional"() {
-        given:
-        def expectedProvider = Mock(UserProvider)
-        def emptyLocator = new UserProviderLocator() {
-            int getOrder() { return 1 }
-            Optional<UserProvider> locate() { Optional.empty() }
-        }
-        def successLocator = new UserProviderLocator() {
-            int getOrder() { return 2 }
-            Optional<UserProvider> locate() { Optional.of(expectedProvider) }
-        }
-
-        when:
-        def locators = [emptyLocator, successLocator].sort { it.order }
-        def result = locators.findResult { it.locate().orElse(null) }
-
-        then:
-        result == expectedProvider
+    void "findUserProvider returns the unknown provider when only the fallback is registered"() {
+        // The bundled META-INF/services registration only contains UnknownUserProviderLocator,
+        // so the resolved chain reports no user.
+        expect:
+        UserProviderLocator.findUserProvider().user == null
     }
 }

--- a/jakarta-ee/src/integrationTest/groovy/io/jdev/miniprofiler/jakarta/ee/CdiPrincipalUserProviderIntegrationSpec.groovy
+++ b/jakarta-ee/src/integrationTest/groovy/io/jdev/miniprofiler/jakarta/ee/CdiPrincipalUserProviderIntegrationSpec.groovy
@@ -1,0 +1,58 @@
+/*
+ * Copyright 2026 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.jdev.miniprofiler.jakarta.ee
+
+import spock.lang.AutoCleanup
+import spock.lang.Shared
+import spock.lang.Specification
+
+import jakarta.enterprise.context.ApplicationScoped
+import jakarta.enterprise.inject.Produces
+import jakarta.enterprise.inject.se.SeContainer
+import jakarta.enterprise.inject.se.SeContainerInitializer
+import java.security.Principal
+
+class CdiPrincipalUserProviderIntegrationSpec extends Specification {
+
+    @Shared
+    @AutoCleanup('close')
+    SeContainer container
+
+    void setupSpec() {
+        container = SeContainerInitializer.newInstance()
+            .addBeanClasses(TestPrincipalProducer)
+            .initialize()
+    }
+
+    void "provider returns the principal name resolved from CDI"() {
+        expect:
+        new CdiPrincipalUserProvider().user == 'alice'
+    }
+
+    void "locator returns a provider in a CDI environment"() {
+        expect:
+        new CdiPrincipalUserProviderLocator().locate().present
+    }
+
+    @ApplicationScoped
+    static class TestPrincipalProducer {
+        @Produces
+        Principal currentPrincipal() {
+            return { 'alice' } as Principal
+        }
+    }
+}

--- a/jakarta-ee/src/main/java/io/jdev/miniprofiler/jakarta/ee/CdiPrincipalUserProvider.java
+++ b/jakarta-ee/src/main/java/io/jdev/miniprofiler/jakarta/ee/CdiPrincipalUserProvider.java
@@ -1,0 +1,65 @@
+/*
+ * Copyright 2026 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.jdev.miniprofiler.jakarta.ee;
+
+import io.jdev.miniprofiler.user.UserProvider;
+
+import jakarta.enterprise.inject.Instance;
+import jakarta.enterprise.inject.spi.CDI;
+import java.security.Principal;
+
+/**
+ * {@link UserProvider} that resolves the current user from the CDI built-in
+ * {@link Principal} bean. Works in any context where CDI exposes a caller
+ * principal (servlet, JAX-RS, EJB, async EJB).
+ *
+ * <p>Returns {@code null} when CDI is not available, when no Principal bean
+ * is resolvable in the current context, or when the resolved principal name
+ * is empty (some containers return placeholder names like
+ * {@code "ANONYMOUS"} for unauthenticated callers, which are also treated as
+ * no user).</p>
+ */
+public class CdiPrincipalUserProvider implements UserProvider {
+
+    private static final String ANONYMOUS_PRINCIPAL = "ANONYMOUS";
+
+    /** Creates a new instance. */
+    public CdiPrincipalUserProvider() {
+    }
+
+    @Override
+    public String getUser() {
+        try {
+            CDI<Object> cdi = CDI.current();
+            Instance<Principal> instance = cdi.select(Principal.class);
+            if (instance.isUnsatisfied() || instance.isAmbiguous()) {
+                return null;
+            }
+            Principal principal = instance.get();
+            if (principal == null) {
+                return null;
+            }
+            String name = principal.getName();
+            if (name == null || name.isEmpty() || ANONYMOUS_PRINCIPAL.equalsIgnoreCase(name)) {
+                return null;
+            }
+            return name;
+        } catch (Exception | NoClassDefFoundError e) {
+            return null;
+        }
+    }
+}

--- a/jakarta-ee/src/main/java/io/jdev/miniprofiler/jakarta/ee/CdiPrincipalUserProviderLocator.java
+++ b/jakarta-ee/src/main/java/io/jdev/miniprofiler/jakarta/ee/CdiPrincipalUserProviderLocator.java
@@ -1,0 +1,59 @@
+/*
+ * Copyright 2026 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.jdev.miniprofiler.jakarta.ee;
+
+import io.jdev.miniprofiler.user.UserProvider;
+import io.jdev.miniprofiler.user.UserProviderLocator;
+
+import jakarta.enterprise.inject.spi.CDI;
+import java.util.Optional;
+
+/**
+ * Registers a {@link CdiPrincipalUserProvider} so that miniprofiler can capture the
+ * caller principal from CDI in jakarta EE deployments. Returns an empty
+ * {@link Optional} if the jakarta CDI API is not available on the classpath.
+ *
+ * <p>Ordered after the servlet provider so that the request-bound provider wins on
+ * request threads in mixed deployments; this provider takes over for
+ * non-request contexts (EJB timers, {@code @Asynchronous}, etc.) via the chain in
+ * {@link UserProviderLocator#findUserProvider()}.</p>
+ */
+public class CdiPrincipalUserProviderLocator implements UserProviderLocator {
+
+    /** Creates a new instance. */
+    public CdiPrincipalUserProviderLocator() {
+    }
+
+    /** {@inheritDoc} Returns {@code 40}. */
+    @Override
+    public int getOrder() {
+        return 40;
+    }
+
+    @Override
+    public Optional<UserProvider> locate() {
+        try {
+            // Trigger class loading to confirm the jakarta CDI API is available; the actual
+            // CDI.current() call is deferred to UserProvider.getUser() so that a deployment
+            // without an active container at locator time still works.
+            Class.forName(CDI.class.getName());
+            return Optional.of(new CdiPrincipalUserProvider());
+        } catch (Exception | NoClassDefFoundError e) {
+            return Optional.empty();
+        }
+    }
+}

--- a/jakarta-ee/src/main/resources/META-INF/services/io.jdev.miniprofiler.user.UserProviderLocator
+++ b/jakarta-ee/src/main/resources/META-INF/services/io.jdev.miniprofiler.user.UserProviderLocator
@@ -1,0 +1,1 @@
+io.jdev.miniprofiler.jakarta.ee.CdiPrincipalUserProviderLocator

--- a/jakarta-ee/src/scenarioTestFixtures/groovy/io/jdev/miniprofiler/scenariotest/DockerGlassfish7Server.groovy
+++ b/jakarta-ee/src/scenarioTestFixtures/groovy/io/jdev/miniprofiler/scenariotest/DockerGlassfish7Server.groovy
@@ -17,6 +17,7 @@
 package io.jdev.miniprofiler.scenariotest
 
 import io.jdev.miniprofiler.integtest.TestedServer
+import org.testcontainers.containers.Container
 import org.testcontainers.containers.GenericContainer
 import org.testcontainers.containers.wait.strategy.Wait
 import org.testcontainers.utility.MountableFile
@@ -71,6 +72,33 @@ class DockerGlassfish7Server implements TestedServer {
             exec("create-jdbc-resource",
                 "--connectionpoolid", "MiniprofilerPool",
                 "jdbc/DataSource")
+
+            // Provision a test user in the default file realm so the scenario tests
+            // can hit BASIC-auth-protected endpoints. asadmin reads the new user's
+            // password from a properties file via --passwordfile, which must be passed
+            // as a utility option (i.e. before the subcommand).
+            // Once --passwordfile is given, asadmin stops using the local-password
+            // shortcut and demands an explicit AS_ADMIN_PASSWORD. Read the local-password
+            // token straight off disk so asadmin authenticates as the running server's
+            // admin without us having to know any real admin credentials.
+            container.execInContainer("/bin/sh", "-c",
+                "printf 'AS_ADMIN_PASSWORD=%s\\nAS_ADMIN_USERPASSWORD=secret\\n' " +
+                    "\"\$(cat /opt/glassfish7/glassfish/domains/domain1/config/local-password)\" > /tmp/pw.txt")
+            Container.ExecResult userResult = container.execInContainer(
+                "/opt/glassfish7/bin/asadmin",
+                "--user", "admin",
+                "--passwordfile", "/tmp/pw.txt",
+                "create-file-user",
+                "--groups", "user",
+                "alice")
+            println "asadmin create-file-user stdout: ${userResult.stdout}"
+            if (userResult.stderr) {
+                println "asadmin create-file-user stderr: ${userResult.stderr}"
+            }
+            if (userResult.exitCode != 0) {
+                throw new RuntimeException(
+                    "asadmin create-file-user failed (exit ${userResult.exitCode}): ${userResult.stdout} / ${userResult.stderr}")
+            }
 
             // Now deploy the WAR at the root context
             container.copyFileToContainer(

--- a/jakarta-ee/src/scenarioTestFixtures/groovy/io/jdev/miniprofiler/scenariotest/DockerWildfly27Server.groovy
+++ b/jakarta-ee/src/scenarioTestFixtures/groovy/io/jdev/miniprofiler/scenariotest/DockerWildfly27Server.groovy
@@ -19,8 +19,10 @@ package io.jdev.miniprofiler.scenariotest
 import io.jdev.miniprofiler.integtest.TestedServer
 import org.testcontainers.containers.GenericContainer
 import org.testcontainers.containers.wait.strategy.Wait
+import org.testcontainers.images.builder.Transferable
 import org.testcontainers.utility.MountableFile
 
+import java.security.MessageDigest
 import java.time.Duration
 
 class DockerWildfly27Server implements TestedServer {
@@ -37,8 +39,21 @@ class DockerWildfly27Server implements TestedServer {
         // the jakarta.* namespace. It ships with Hibernate 6. The WAR is dropped
         // into the deployments directory and picked up by WildFly's hot-deploy
         // scanner on startup. We wait for the "Deployed ROOT.war" log line.
+        //
+        // Provision a test user in the default ApplicationRealm (still backed by
+        // application-users.properties under Elytron) so the BASIC-auth-protected
+        // endpoint is reachable as soon as the WAR deploys.
+        String userHash = md5Hex("alice:ApplicationRealm:secret")
         container = new GenericContainer<>("quay.io/wildfly/wildfly:27.0.1.Final-jdk17")
             .withExposedPorts(8080)
+            .withCopyToContainer(
+                Transferable.of("alice=" + userHash + "\n"),
+                "/opt/jboss/wildfly/standalone/configuration/application-users.properties"
+            )
+            .withCopyToContainer(
+                Transferable.of("alice=user\n"),
+                "/opt/jboss/wildfly/standalone/configuration/application-roles.properties"
+            )
             .withCopyFileToContainer(
                 MountableFile.forHostPath(war.absolutePath),
                 "/opt/jboss/wildfly/standalone/deployments/ROOT.war"
@@ -53,6 +68,14 @@ class DockerWildfly27Server implements TestedServer {
         baseUrl = "http://" + container.host + ":" + container.getMappedPort(8080) + "/"
 
         System.setProperty("scenarioTest.baseUrl", baseUrl)
+    }
+
+    private static String md5Hex(String input) {
+        StringBuilder sb = new StringBuilder()
+        for (byte b : MessageDigest.getInstance("MD5").digest(input.bytes)) {
+            sb.append(String.format("%02x", b))
+        }
+        return sb.toString()
     }
 
     @Override

--- a/jakarta-ee/src/test/groovy/io/jdev/miniprofiler/jakarta/ee/CdiPrincipalUserProviderSpec.groovy
+++ b/jakarta-ee/src/test/groovy/io/jdev/miniprofiler/jakarta/ee/CdiPrincipalUserProviderSpec.groovy
@@ -1,0 +1,39 @@
+/*
+ * Copyright 2026 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.jdev.miniprofiler.jakarta.ee
+
+import spock.lang.Specification
+
+class CdiPrincipalUserProviderSpec extends Specification {
+
+    void "locator has order 40"() {
+        expect:
+        new CdiPrincipalUserProviderLocator().order == 40
+    }
+
+    void "locator returns a provider when the CDI API is on the classpath"() {
+        expect:
+        new CdiPrincipalUserProviderLocator().locate().present
+    }
+
+    void "provider returns null when no CDI container is active"() {
+        // The classpath has the CDI API but no SeContainer is bootstrapped in this unit test,
+        // so CDI.current() throws and the provider must return null without propagating.
+        expect:
+        new CdiPrincipalUserProvider().user == null
+    }
+}

--- a/jakarta-servlet/src/integrationTest/groovy/io/jdev/miniprofiler/jakarta/servlet/ServletUserProviderIntegrationSpec.groovy
+++ b/jakarta-servlet/src/integrationTest/groovy/io/jdev/miniprofiler/jakarta/servlet/ServletUserProviderIntegrationSpec.groovy
@@ -1,0 +1,81 @@
+/*
+ * Copyright 2026 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.jdev.miniprofiler.jakarta.servlet
+
+import io.jdev.miniprofiler.integtest.TestMiniProfilerHttpClient
+import spock.lang.AutoCleanup
+import spock.lang.Shared
+import spock.lang.Specification
+
+class ServletUserProviderIntegrationSpec extends Specification {
+
+    @Shared
+    @AutoCleanup
+    InProcessJetty12 server = new InProcessJetty12()
+
+    @Shared
+    TestMiniProfilerHttpClient client = new TestMiniProfilerHttpClient(server.serverUrl)
+
+    static Map<String, String> basicAuth(String user, String password) {
+        ['Authorization': 'Basic ' + Base64.encoder.encodeToString("${user}:${password}".bytes)]
+    }
+
+    Map findInResultsList(String id) {
+        def list = client.getResultsList().bodyAsJson() as List<Map>
+        list.find { it.Id == id }
+    }
+
+    void "anonymous request to public page records no user"() {
+        when:
+        def response = client.get('test-page')
+
+        then:
+        response.statusCode() == 200
+
+        when:
+        def entry = findInResultsList(response.miniProfilerId())
+
+        then:
+        entry != null
+        entry.User == null
+    }
+
+    void "authenticated request to secured page records the principal name"() {
+        when:
+        def response = client.get('secure/hello', basicAuth('alice', 'secret'))
+
+        then:
+        response.statusCode() == 200
+        response.body() == 'hello alice'
+
+        when:
+        def entry = findInResultsList(response.miniProfilerId())
+
+        then:
+        entry != null
+        entry.User == 'alice'
+    }
+
+    void "request to secured page without credentials is rejected before profiling"() {
+        when:
+        def response = client.get('secure/hello')
+
+        then:
+        response.statusCode() == 401
+        !response.header('X-MiniProfiler-Ids').present
+    }
+}

--- a/jakarta-servlet/src/main/java/io/jdev/miniprofiler/jakarta/servlet/ProfilingFilter.java
+++ b/jakarta-servlet/src/main/java/io/jdev/miniprofiler/jakarta/servlet/ProfilingFilter.java
@@ -120,16 +120,21 @@ public class ProfilingFilter implements Filter {
                     // ignore, just generate it then
                 }
             }
-            Profiler profiler = startProfiling(id, request);
+            ServletRequestHolder.set(request);
             try {
-                // add header, this is mostly for ajax
-                id = profiler.getId();
-                if (id != null) {
-                    response.addHeader("X-MiniProfiler-Ids", "[\"" + id.toString() + "\"]");
+                Profiler profiler = startProfiling(id, request);
+                try {
+                    // add header, this is mostly for ajax
+                    id = profiler.getId();
+                    if (id != null) {
+                        response.addHeader("X-MiniProfiler-Ids", "[\"" + id.toString() + "\"]");
+                    }
+                    filterChain.doFilter(servletRequest, servletResponse);
+                } finally {
+                    profiler.stop();
                 }
-                filterChain.doFilter(servletRequest, servletResponse);
             } finally {
-                profiler.stop();
+                ServletRequestHolder.clear();
             }
         }
     }

--- a/jakarta-servlet/src/main/java/io/jdev/miniprofiler/jakarta/servlet/ServletRequestHolder.java
+++ b/jakarta-servlet/src/main/java/io/jdev/miniprofiler/jakarta/servlet/ServletRequestHolder.java
@@ -1,0 +1,44 @@
+/*
+ * Copyright 2026 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.jdev.miniprofiler.jakarta.servlet;
+
+import jakarta.servlet.http.HttpServletRequest;
+
+/**
+ * Thread-local holder used by {@link ProfilingFilter} to make the in-flight
+ * {@link HttpServletRequest} available to {@link ServletUserProvider} during
+ * profiling without changing the {@code ProfilerProvider} API.
+ */
+final class ServletRequestHolder {
+
+    private static final ThreadLocal<HttpServletRequest> CURRENT = new ThreadLocal<>();
+
+    private ServletRequestHolder() {
+    }
+
+    static void set(HttpServletRequest request) {
+        CURRENT.set(request);
+    }
+
+    static void clear() {
+        CURRENT.remove();
+    }
+
+    static HttpServletRequest current() {
+        return CURRENT.get();
+    }
+}

--- a/jakarta-servlet/src/main/java/io/jdev/miniprofiler/jakarta/servlet/ServletUserProvider.java
+++ b/jakarta-servlet/src/main/java/io/jdev/miniprofiler/jakarta/servlet/ServletUserProvider.java
@@ -1,0 +1,59 @@
+/*
+ * Copyright 2026 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.jdev.miniprofiler.jakarta.servlet;
+
+import io.jdev.miniprofiler.user.UserProvider;
+
+import jakarta.servlet.http.HttpServletRequest;
+import java.security.Principal;
+
+/**
+ * {@link UserProvider} that reads the current user from the in-flight
+ * {@link HttpServletRequest}, which {@link ProfilingFilter} stores in a
+ * thread-local for the duration of the request.
+ *
+ * <p>Returns {@link Principal#getName()} from
+ * {@link HttpServletRequest#getUserPrincipal()} when present, falling back to
+ * {@link HttpServletRequest#getRemoteUser()}, and {@code null} when no request
+ * is bound to the current thread or no user has been authenticated.</p>
+ */
+public class ServletUserProvider implements UserProvider {
+
+    /** Creates a new instance. */
+    public ServletUserProvider() {
+    }
+
+    @Override
+    public String getUser() {
+        HttpServletRequest request = ServletRequestHolder.current();
+        if (request == null) {
+            return null;
+        }
+        Principal principal = request.getUserPrincipal();
+        if (principal != null) {
+            String name = principal.getName();
+            if (name != null && !name.isEmpty()) {
+                return name;
+            }
+        }
+        String remoteUser = request.getRemoteUser();
+        if (remoteUser != null && !remoteUser.isEmpty()) {
+            return remoteUser;
+        }
+        return null;
+    }
+}

--- a/jakarta-servlet/src/main/java/io/jdev/miniprofiler/jakarta/servlet/ServletUserProviderLocator.java
+++ b/jakarta-servlet/src/main/java/io/jdev/miniprofiler/jakarta/servlet/ServletUserProviderLocator.java
@@ -1,0 +1,48 @@
+/*
+ * Copyright 2026 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.jdev.miniprofiler.jakarta.servlet;
+
+import io.jdev.miniprofiler.user.UserProvider;
+import io.jdev.miniprofiler.user.UserProviderLocator;
+
+import java.util.Optional;
+
+/**
+ * Registers a {@link ServletUserProvider} so that miniprofiler can capture the
+ * authenticated servlet user on profiles started inside the request lifecycle.
+ *
+ * <p>The provider returns {@code null} when no {@link jakarta.servlet.http.HttpServletRequest}
+ * is bound to the current thread, allowing later providers in the
+ * {@link UserProviderLocator#findUserProvider() chain} to take over for
+ * non-request profiling contexts.</p>
+ */
+public class ServletUserProviderLocator implements UserProviderLocator {
+
+    /** Creates a new instance. */
+    public ServletUserProviderLocator() {
+    }
+
+    @Override
+    public int getOrder() {
+        return 20;
+    }
+
+    @Override
+    public Optional<UserProvider> locate() {
+        return Optional.of(new ServletUserProvider());
+    }
+}

--- a/jakarta-servlet/src/main/resources/META-INF/services/io.jdev.miniprofiler.user.UserProviderLocator
+++ b/jakarta-servlet/src/main/resources/META-INF/services/io.jdev.miniprofiler.user.UserProviderLocator
@@ -1,0 +1,1 @@
+io.jdev.miniprofiler.jakarta.servlet.ServletUserProviderLocator

--- a/jakarta-servlet/src/test/groovy/io/jdev/miniprofiler/jakarta/servlet/ProfilingFilterSpec.groovy
+++ b/jakarta-servlet/src/test/groovy/io/jdev/miniprofiler/jakarta/servlet/ProfilingFilterSpec.groovy
@@ -27,6 +27,7 @@ import jakarta.servlet.FilterChain
 import jakarta.servlet.ServletException
 import jakarta.servlet.ServletRequest
 import jakarta.servlet.ServletResponse
+import jakarta.servlet.http.HttpServletRequest
 import org.springframework.mock.web.MockFilterConfig
 import org.springframework.mock.web.MockHttpServletRequest
 import org.springframework.mock.web.MockHttpServletResponse
@@ -35,6 +36,7 @@ import spock.lang.Specification
 import spock.lang.Unroll
 
 import java.nio.charset.StandardCharsets
+import java.security.Principal
 
 class ProfilingFilterSpec extends Specification {
 
@@ -276,6 +278,50 @@ class ProfilingFilterSpec extends Specification {
         json*.Id.contains(p2.id.toString())
         json*.Id.contains(p3.id.toString())
         !json*.Id.contains(p1.id.toString())
+    }
+
+    void "binds the request to ServletRequestHolder during chain invocation and clears it afterwards"() {
+        given: 'request and a chain that captures the bound request'
+        request.requestURI = '/foo'
+        request.userPrincipal = { 'alice' } as Principal
+        HttpServletRequest holderDuringChain = null
+        def captured = new FilterChain() {
+            @Override
+            void doFilter(ServletRequest req, ServletResponse resp) throws IOException, ServletException {
+                holderDuringChain = ServletRequestHolder.current()
+                profilerProvider.current().step('MockFilterChain').close()
+            }
+        }
+
+        when: 'invoked'
+        filter.doFilter(request, response, captured)
+
+        then: 'holder pointed at the request during the chain'
+        holderDuringChain.is(request)
+
+        and: 'holder is cleared once the filter returns'
+        ServletRequestHolder.current() == null
+
+        and: 'captured user is recorded on the profile'
+        storage.profiler.user == 'alice'
+    }
+
+    void "clears ServletRequestHolder even when the chain throws"() {
+        given:
+        request.requestURI = '/boom'
+        def boomChain = new FilterChain() {
+            @Override
+            void doFilter(ServletRequest req, ServletResponse resp) throws IOException, ServletException {
+                throw new ServletException('boom')
+            }
+        }
+
+        when:
+        filter.doFilter(request, response, boomChain)
+
+        then:
+        thrown(ServletException)
+        ServletRequestHolder.current() == null
     }
 
     void "serves standalone results"() {

--- a/jakarta-servlet/src/test/groovy/io/jdev/miniprofiler/jakarta/servlet/ServletUserProviderSpec.groovy
+++ b/jakarta-servlet/src/test/groovy/io/jdev/miniprofiler/jakarta/servlet/ServletUserProviderSpec.groovy
@@ -1,0 +1,96 @@
+/*
+ * Copyright 2026 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.jdev.miniprofiler.jakarta.servlet
+
+import org.springframework.mock.web.MockHttpServletRequest
+import spock.lang.Specification
+
+import java.security.Principal
+
+class ServletUserProviderSpec extends Specification {
+
+    ServletUserProvider provider = new ServletUserProvider()
+
+    void cleanup() {
+        ServletRequestHolder.clear()
+    }
+
+    void "returns null when no request is bound to the thread"() {
+        expect:
+        provider.user == null
+    }
+
+    void "returns the principal name when set"() {
+        given:
+        def request = new MockHttpServletRequest()
+        request.userPrincipal = { 'alice' } as Principal
+        ServletRequestHolder.set(request)
+
+        expect:
+        provider.user == 'alice'
+    }
+
+    void "falls back to remote user when no principal is set"() {
+        given:
+        def request = new MockHttpServletRequest()
+        request.remoteUser = 'bob'
+        ServletRequestHolder.set(request)
+
+        expect:
+        provider.user == 'bob'
+    }
+
+    void "prefers principal name over remote user when both are set"() {
+        given:
+        def request = new MockHttpServletRequest()
+        request.userPrincipal = { 'alice' } as Principal
+        request.remoteUser = 'bob'
+        ServletRequestHolder.set(request)
+
+        expect:
+        provider.user == 'alice'
+    }
+
+    void "falls back to remote user when principal name is empty"() {
+        given:
+        def request = new MockHttpServletRequest()
+        request.userPrincipal = { '' } as Principal
+        request.remoteUser = 'bob'
+        ServletRequestHolder.set(request)
+
+        expect:
+        provider.user == 'bob'
+    }
+
+    void "returns null when neither principal nor remote user is set"() {
+        given:
+        ServletRequestHolder.set(new MockHttpServletRequest())
+
+        expect:
+        provider.user == null
+    }
+
+    void "ServletUserProviderLocator returns a provider"() {
+        expect:
+        new ServletUserProviderLocator().locate().present
+    }
+
+    void "ServletUserProviderLocator order is below javax fallback"() {
+        expect:
+        new ServletUserProviderLocator().order == 20
+    }
+}

--- a/jakarta-servlet/src/testFixtures/groovy/io/jdev/miniprofiler/jakarta/servlet/InProcessJetty12.groovy
+++ b/jakarta-servlet/src/testFixtures/groovy/io/jdev/miniprofiler/jakarta/servlet/InProcessJetty12.groovy
@@ -26,7 +26,14 @@ import jakarta.servlet.http.HttpServletRequest
 import jakarta.servlet.http.HttpServletResponse
 import org.eclipse.jetty.ee10.servlet.DefaultServlet
 import org.eclipse.jetty.ee10.servlet.ServletContextHandler
+import org.eclipse.jetty.ee10.servlet.security.ConstraintMapping
+import org.eclipse.jetty.ee10.servlet.security.ConstraintSecurityHandler
+import org.eclipse.jetty.security.Constraint
+import org.eclipse.jetty.security.HashLoginService
+import org.eclipse.jetty.security.UserStore
+import org.eclipse.jetty.security.authentication.BasicAuthenticator
 import org.eclipse.jetty.server.Server
+import org.eclipse.jetty.util.security.Password
 
 /**
  * An {@link InProcessTestedServer} running an embedded Jetty 12 EE10 server with a
@@ -43,6 +50,7 @@ class InProcessJetty12 implements InProcessTestedServer {
     InProcessJetty12() {
         server = new Server(0).tap {
             server.handler = new ServletContextHandler('/').tap {
+                securityHandler = buildSecurityHandler()
                 addServlet(new HttpServlet() {
                     @Override
                     protected void doGet(HttpServletRequest req, HttpServletResponse resp)
@@ -72,6 +80,15 @@ class InProcessJetty12 implements InProcessTestedServer {
                         resp.writer.write('{"status":"ok"}')
                     }
                 }, '/ajax-endpoint')
+                addServlet(new HttpServlet() {
+                    @Override
+                    protected void doGet(HttpServletRequest req, HttpServletResponse resp)
+                            throws IOException {
+                        profilerProvider.current().step('secure step').close()
+                        resp.setContentType('text/plain')
+                        resp.writer.write("hello ${req.remoteUser}")
+                    }
+                }, '/secure/hello')
                 addServlet(DefaultServlet, '/')
                 addFilter(
                     new ProfilingFilter(profilerProvider: profilerProvider),
@@ -80,6 +97,26 @@ class InProcessJetty12 implements InProcessTestedServer {
                 )
             }
             start()
+        }
+    }
+
+    private static ConstraintSecurityHandler buildSecurityHandler() {
+        def loginService = new HashLoginService('miniprofiler-test')
+        def userStore = new UserStore()
+        userStore.addUser('alice', new Password('secret'), ['user'] as String[])
+        loginService.userStore = userStore
+
+        def constraint = Constraint.from('user', 'user')
+
+        def mapping = new ConstraintMapping()
+        mapping.constraint = constraint
+        mapping.pathSpec = '/secure/*'
+
+        new ConstraintSecurityHandler().tap {
+            authenticator = new BasicAuthenticator()
+            realmName = 'miniprofiler-test'
+            it.loginService = loginService
+            constraintMappings = [mapping]
         }
     }
 

--- a/javax-ee/src/integrationTest/groovy/io/jdev/miniprofiler/javax/ee/CdiPrincipalUserProviderIntegrationSpec.groovy
+++ b/javax-ee/src/integrationTest/groovy/io/jdev/miniprofiler/javax/ee/CdiPrincipalUserProviderIntegrationSpec.groovy
@@ -1,0 +1,58 @@
+/*
+ * Copyright 2026 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.jdev.miniprofiler.javax.ee
+
+import spock.lang.AutoCleanup
+import spock.lang.Shared
+import spock.lang.Specification
+
+import javax.enterprise.context.ApplicationScoped
+import javax.enterprise.inject.Produces
+import javax.enterprise.inject.se.SeContainer
+import javax.enterprise.inject.se.SeContainerInitializer
+import java.security.Principal
+
+class CdiPrincipalUserProviderIntegrationSpec extends Specification {
+
+    @Shared
+    @AutoCleanup('close')
+    SeContainer container
+
+    void setupSpec() {
+        container = SeContainerInitializer.newInstance()
+            .addBeanClasses(TestPrincipalProducer)
+            .initialize()
+    }
+
+    void "provider returns the principal name resolved from CDI"() {
+        expect:
+        new CdiPrincipalUserProvider().user == 'alice'
+    }
+
+    void "locator returns a provider in a CDI environment"() {
+        expect:
+        new CdiPrincipalUserProviderLocator().locate().present
+    }
+
+    @ApplicationScoped
+    static class TestPrincipalProducer {
+        @Produces
+        Principal currentPrincipal() {
+            return { 'alice' } as Principal
+        }
+    }
+}

--- a/javax-ee/src/main/java/io/jdev/miniprofiler/javax/ee/CdiPrincipalUserProvider.java
+++ b/javax-ee/src/main/java/io/jdev/miniprofiler/javax/ee/CdiPrincipalUserProvider.java
@@ -1,0 +1,65 @@
+/*
+ * Copyright 2026 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.jdev.miniprofiler.javax.ee;
+
+import io.jdev.miniprofiler.user.UserProvider;
+
+import javax.enterprise.inject.Instance;
+import javax.enterprise.inject.spi.CDI;
+import java.security.Principal;
+
+/**
+ * {@link UserProvider} that resolves the current user from the CDI built-in
+ * {@link Principal} bean. Works in any context where CDI exposes a caller
+ * principal (servlet, JAX-RS, EJB, async EJB).
+ *
+ * <p>Returns {@code null} when CDI is not available, when no Principal bean
+ * is resolvable in the current context, or when the resolved principal name
+ * is empty (some containers return placeholder names like
+ * {@code "ANONYMOUS"} for unauthenticated callers, which are also treated as
+ * no user).</p>
+ */
+public class CdiPrincipalUserProvider implements UserProvider {
+
+    private static final String ANONYMOUS_PRINCIPAL = "ANONYMOUS";
+
+    /** Creates a new instance. */
+    public CdiPrincipalUserProvider() {
+    }
+
+    @Override
+    public String getUser() {
+        try {
+            CDI<Object> cdi = CDI.current();
+            Instance<Principal> instance = cdi.select(Principal.class);
+            if (instance.isUnsatisfied() || instance.isAmbiguous()) {
+                return null;
+            }
+            Principal principal = instance.get();
+            if (principal == null) {
+                return null;
+            }
+            String name = principal.getName();
+            if (name == null || name.isEmpty() || ANONYMOUS_PRINCIPAL.equalsIgnoreCase(name)) {
+                return null;
+            }
+            return name;
+        } catch (Exception | NoClassDefFoundError e) {
+            return null;
+        }
+    }
+}

--- a/javax-ee/src/main/java/io/jdev/miniprofiler/javax/ee/CdiPrincipalUserProviderLocator.java
+++ b/javax-ee/src/main/java/io/jdev/miniprofiler/javax/ee/CdiPrincipalUserProviderLocator.java
@@ -1,0 +1,59 @@
+/*
+ * Copyright 2026 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.jdev.miniprofiler.javax.ee;
+
+import io.jdev.miniprofiler.user.UserProvider;
+import io.jdev.miniprofiler.user.UserProviderLocator;
+
+import javax.enterprise.inject.spi.CDI;
+import java.util.Optional;
+
+/**
+ * Registers a {@link CdiPrincipalUserProvider} so that miniprofiler can capture the
+ * caller principal from CDI in javax EE deployments. Returns an empty
+ * {@link Optional} if the javax CDI API is not available on the classpath.
+ *
+ * <p>Ordered after the servlet provider so that the request-bound provider wins on
+ * request threads in mixed deployments; this provider takes over for
+ * non-request contexts (EJB timers, {@code @Asynchronous}, etc.) via the chain in
+ * {@link UserProviderLocator#findUserProvider()}.</p>
+ */
+public class CdiPrincipalUserProviderLocator implements UserProviderLocator {
+
+    /** Creates a new instance. */
+    public CdiPrincipalUserProviderLocator() {
+    }
+
+    /** {@inheritDoc} Returns {@code 50}. */
+    @Override
+    public int getOrder() {
+        return 50;
+    }
+
+    @Override
+    public Optional<UserProvider> locate() {
+        try {
+            // Trigger class loading to confirm the javax CDI API is available; the actual
+            // CDI.current() call is deferred to UserProvider.getUser() so that a deployment
+            // without an active container at locator time still works.
+            Class.forName(CDI.class.getName());
+            return Optional.of(new CdiPrincipalUserProvider());
+        } catch (Exception | NoClassDefFoundError e) {
+            return Optional.empty();
+        }
+    }
+}

--- a/javax-ee/src/main/resources/META-INF/services/io.jdev.miniprofiler.user.UserProviderLocator
+++ b/javax-ee/src/main/resources/META-INF/services/io.jdev.miniprofiler.user.UserProviderLocator
@@ -1,0 +1,1 @@
+io.jdev.miniprofiler.javax.ee.CdiPrincipalUserProviderLocator

--- a/javax-ee/src/scenarioTestFixtures/groovy/io/jdev/miniprofiler/scenariotest/DockerGlassfish4Server.groovy
+++ b/javax-ee/src/scenarioTestFixtures/groovy/io/jdev/miniprofiler/scenariotest/DockerGlassfish4Server.groovy
@@ -72,6 +72,28 @@ class DockerGlassfish4Server implements TestedServer {
                 "--connectionpoolid", "MiniprofilerPool",
                 "jdbc/DataSource")
 
+            // Provision a test user in the default file realm so the scenario tests
+            // can hit BASIC-auth-protected endpoints. asadmin reads the new user's
+            // password from a properties file via --passwordfile, which must be passed
+            // as a utility option (i.e. before the subcommand).
+            container.execInContainer("/bin/sh", "-c",
+                "echo 'AS_ADMIN_USERPASSWORD=secret' > /tmp/pw.txt")
+            Container.ExecResult userResult = container.execInContainer(
+                "/usr/local/glassfish4/bin/asadmin",
+                "--user", "admin",
+                "--passwordfile", "/tmp/pw.txt",
+                "create-file-user",
+                "--groups", "user",
+                "alice")
+            println "asadmin create-file-user stdout: ${userResult.stdout}"
+            if (userResult.stderr) {
+                println "asadmin create-file-user stderr: ${userResult.stderr}"
+            }
+            if (userResult.exitCode != 0) {
+                throw new RuntimeException(
+                    "asadmin create-file-user failed (exit ${userResult.exitCode}): ${userResult.stdout} / ${userResult.stderr}")
+            }
+
             // Now deploy the WAR at the root context
             container.copyFileToContainer(
                 MountableFile.forHostPath(war.absolutePath), "/tmp/ROOT.war")

--- a/javax-ee/src/scenarioTestFixtures/groovy/io/jdev/miniprofiler/scenariotest/DockerWildfly10Server.groovy
+++ b/javax-ee/src/scenarioTestFixtures/groovy/io/jdev/miniprofiler/scenariotest/DockerWildfly10Server.groovy
@@ -19,8 +19,10 @@ package io.jdev.miniprofiler.scenariotest
 import io.jdev.miniprofiler.integtest.TestedServer
 import org.testcontainers.containers.GenericContainer
 import org.testcontainers.containers.wait.strategy.Wait
+import org.testcontainers.images.builder.Transferable
 import org.testcontainers.utility.MountableFile
 
+import java.security.MessageDigest
 import java.time.Duration
 
 class DockerWildfly10Server implements TestedServer {
@@ -37,8 +39,21 @@ class DockerWildfly10Server implements TestedServer {
         // hot-deploy scanner on startup. We wait for the "Deployed ROOT.war" log line
         // rather than a plain HTTP 200, which could match the welcome page before our
         // WAR loads.
+        //
+        // Provision a test user in the default ApplicationRealm before WildFly boots so
+        // the BASIC-auth-protected endpoint is reachable as soon as the WAR deploys.
+        // application-users.properties expects an MD5 hex digest of "user:realm:password".
+        String userHash = md5Hex("alice:ApplicationRealm:secret")
         container = new GenericContainer<>("jboss/wildfly:10.1.0.Final")
             .withExposedPorts(8080)
+            .withCopyToContainer(
+                Transferable.of("alice=" + userHash + "\n"),
+                "/opt/jboss/wildfly/standalone/configuration/application-users.properties"
+            )
+            .withCopyToContainer(
+                Transferable.of("alice=user\n"),
+                "/opt/jboss/wildfly/standalone/configuration/application-roles.properties"
+            )
             .withCopyFileToContainer(
                 MountableFile.forHostPath(war.absolutePath),
                 "/opt/jboss/wildfly/standalone/deployments/ROOT.war"
@@ -53,6 +68,14 @@ class DockerWildfly10Server implements TestedServer {
         baseUrl = "http://" + container.host + ":" + container.getMappedPort(8080) + "/"
 
         System.setProperty("scenarioTest.baseUrl", baseUrl)
+    }
+
+    private static String md5Hex(String input) {
+        StringBuilder sb = new StringBuilder()
+        for (byte b : MessageDigest.getInstance("MD5").digest(input.bytes)) {
+            sb.append(String.format("%02x", b))
+        }
+        return sb.toString()
     }
 
     @Override

--- a/javax-ee/src/test/groovy/io/jdev/miniprofiler/javax/ee/CdiPrincipalUserProviderSpec.groovy
+++ b/javax-ee/src/test/groovy/io/jdev/miniprofiler/javax/ee/CdiPrincipalUserProviderSpec.groovy
@@ -1,0 +1,39 @@
+/*
+ * Copyright 2026 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.jdev.miniprofiler.javax.ee
+
+import spock.lang.Specification
+
+class CdiPrincipalUserProviderSpec extends Specification {
+
+    void "locator has order 50"() {
+        expect:
+        new CdiPrincipalUserProviderLocator().order == 50
+    }
+
+    void "locator returns a provider when the CDI API is on the classpath"() {
+        expect:
+        new CdiPrincipalUserProviderLocator().locate().present
+    }
+
+    void "provider returns null when no CDI container is active"() {
+        // The classpath has the CDI API but no SeContainer is bootstrapped in this unit test,
+        // so CDI.current() throws and the provider must return null without propagating.
+        expect:
+        new CdiPrincipalUserProvider().user == null
+    }
+}

--- a/javax-servlet/src/integrationTest/groovy/io/jdev/miniprofiler/javax/servlet/ServletUserProviderIntegrationSpec.groovy
+++ b/javax-servlet/src/integrationTest/groovy/io/jdev/miniprofiler/javax/servlet/ServletUserProviderIntegrationSpec.groovy
@@ -1,0 +1,81 @@
+/*
+ * Copyright 2026 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.jdev.miniprofiler.javax.servlet
+
+import io.jdev.miniprofiler.integtest.TestMiniProfilerHttpClient
+import spock.lang.AutoCleanup
+import spock.lang.Shared
+import spock.lang.Specification
+
+class ServletUserProviderIntegrationSpec extends Specification {
+
+    @Shared
+    @AutoCleanup
+    InProcessJetty9 server = new InProcessJetty9()
+
+    @Shared
+    TestMiniProfilerHttpClient client = new TestMiniProfilerHttpClient(server.serverUrl)
+
+    static Map<String, String> basicAuth(String user, String password) {
+        ['Authorization': 'Basic ' + Base64.encoder.encodeToString("${user}:${password}".bytes)]
+    }
+
+    Map findInResultsList(String id) {
+        def list = client.getResultsList().bodyAsJson() as List<Map>
+        list.find { it.Id == id }
+    }
+
+    void "anonymous request to public page records no user"() {
+        when:
+        def response = client.get('test-page')
+
+        then:
+        response.statusCode() == 200
+
+        when:
+        def entry = findInResultsList(response.miniProfilerId())
+
+        then:
+        entry != null
+        entry.User == null
+    }
+
+    void "authenticated request to secured page records the principal name"() {
+        when:
+        def response = client.get('secure/hello', basicAuth('alice', 'secret'))
+
+        then:
+        response.statusCode() == 200
+        response.body() == 'hello alice'
+
+        when:
+        def entry = findInResultsList(response.miniProfilerId())
+
+        then:
+        entry != null
+        entry.User == 'alice'
+    }
+
+    void "request to secured page without credentials is rejected before profiling"() {
+        when:
+        def response = client.get('secure/hello')
+
+        then:
+        response.statusCode() == 401
+        !response.header('X-MiniProfiler-Ids').present
+    }
+}

--- a/javax-servlet/src/main/java/io/jdev/miniprofiler/javax/servlet/ProfilingFilter.java
+++ b/javax-servlet/src/main/java/io/jdev/miniprofiler/javax/servlet/ProfilingFilter.java
@@ -120,16 +120,21 @@ public class ProfilingFilter implements Filter {
                     // ignore, just generate it then
                 }
             }
-            Profiler profiler = startProfiling(id, request);
+            ServletRequestHolder.set(request);
             try {
-                // add header, this is mostly for ajax
-                id = profiler.getId();
-                if (id != null) {
-                    response.addHeader("X-MiniProfiler-Ids", "[\"" + id.toString() + "\"]");
+                Profiler profiler = startProfiling(id, request);
+                try {
+                    // add header, this is mostly for ajax
+                    id = profiler.getId();
+                    if (id != null) {
+                        response.addHeader("X-MiniProfiler-Ids", "[\"" + id.toString() + "\"]");
+                    }
+                    filterChain.doFilter(servletRequest, servletResponse);
+                } finally {
+                    profiler.stop();
                 }
-                filterChain.doFilter(servletRequest, servletResponse);
             } finally {
-                profiler.stop();
+                ServletRequestHolder.clear();
             }
         }
     }

--- a/javax-servlet/src/main/java/io/jdev/miniprofiler/javax/servlet/ServletRequestHolder.java
+++ b/javax-servlet/src/main/java/io/jdev/miniprofiler/javax/servlet/ServletRequestHolder.java
@@ -1,0 +1,44 @@
+/*
+ * Copyright 2026 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.jdev.miniprofiler.javax.servlet;
+
+import javax.servlet.http.HttpServletRequest;
+
+/**
+ * Thread-local holder used by {@link ProfilingFilter} to make the in-flight
+ * {@link HttpServletRequest} available to {@link ServletUserProvider} during
+ * profiling without changing the {@code ProfilerProvider} API.
+ */
+final class ServletRequestHolder {
+
+    private static final ThreadLocal<HttpServletRequest> CURRENT = new ThreadLocal<>();
+
+    private ServletRequestHolder() {
+    }
+
+    static void set(HttpServletRequest request) {
+        CURRENT.set(request);
+    }
+
+    static void clear() {
+        CURRENT.remove();
+    }
+
+    static HttpServletRequest current() {
+        return CURRENT.get();
+    }
+}

--- a/javax-servlet/src/main/java/io/jdev/miniprofiler/javax/servlet/ServletUserProvider.java
+++ b/javax-servlet/src/main/java/io/jdev/miniprofiler/javax/servlet/ServletUserProvider.java
@@ -1,0 +1,59 @@
+/*
+ * Copyright 2026 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.jdev.miniprofiler.javax.servlet;
+
+import io.jdev.miniprofiler.user.UserProvider;
+
+import javax.servlet.http.HttpServletRequest;
+import java.security.Principal;
+
+/**
+ * {@link UserProvider} that reads the current user from the in-flight
+ * {@link HttpServletRequest}, which {@link ProfilingFilter} stores in a
+ * thread-local for the duration of the request.
+ *
+ * <p>Returns {@link Principal#getName()} from
+ * {@link HttpServletRequest#getUserPrincipal()} when present, falling back to
+ * {@link HttpServletRequest#getRemoteUser()}, and {@code null} when no request
+ * is bound to the current thread or no user has been authenticated.</p>
+ */
+public class ServletUserProvider implements UserProvider {
+
+    /** Creates a new instance. */
+    public ServletUserProvider() {
+    }
+
+    @Override
+    public String getUser() {
+        HttpServletRequest request = ServletRequestHolder.current();
+        if (request == null) {
+            return null;
+        }
+        Principal principal = request.getUserPrincipal();
+        if (principal != null) {
+            String name = principal.getName();
+            if (name != null && !name.isEmpty()) {
+                return name;
+            }
+        }
+        String remoteUser = request.getRemoteUser();
+        if (remoteUser != null && !remoteUser.isEmpty()) {
+            return remoteUser;
+        }
+        return null;
+    }
+}

--- a/javax-servlet/src/main/java/io/jdev/miniprofiler/javax/servlet/ServletUserProviderLocator.java
+++ b/javax-servlet/src/main/java/io/jdev/miniprofiler/javax/servlet/ServletUserProviderLocator.java
@@ -1,0 +1,48 @@
+/*
+ * Copyright 2026 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.jdev.miniprofiler.javax.servlet;
+
+import io.jdev.miniprofiler.user.UserProvider;
+import io.jdev.miniprofiler.user.UserProviderLocator;
+
+import java.util.Optional;
+
+/**
+ * Registers a {@link ServletUserProvider} so that miniprofiler can capture the
+ * authenticated servlet user on profiles started inside the request lifecycle.
+ *
+ * <p>The provider returns {@code null} when no {@link javax.servlet.http.HttpServletRequest}
+ * is bound to the current thread, allowing later providers in the
+ * {@link UserProviderLocator#findUserProvider() chain} to take over for
+ * non-request profiling contexts.</p>
+ */
+public class ServletUserProviderLocator implements UserProviderLocator {
+
+    /** Creates a new instance. */
+    public ServletUserProviderLocator() {
+    }
+
+    @Override
+    public int getOrder() {
+        return 30;
+    }
+
+    @Override
+    public Optional<UserProvider> locate() {
+        return Optional.of(new ServletUserProvider());
+    }
+}

--- a/javax-servlet/src/main/resources/META-INF/services/io.jdev.miniprofiler.user.UserProviderLocator
+++ b/javax-servlet/src/main/resources/META-INF/services/io.jdev.miniprofiler.user.UserProviderLocator
@@ -1,0 +1,1 @@
+io.jdev.miniprofiler.javax.servlet.ServletUserProviderLocator

--- a/javax-servlet/src/test/groovy/io/jdev/miniprofiler/javax/servlet/ProfilingFilterSpec.groovy
+++ b/javax-servlet/src/test/groovy/io/jdev/miniprofiler/javax/servlet/ProfilingFilterSpec.groovy
@@ -34,7 +34,9 @@ import javax.servlet.FilterChain
 import javax.servlet.ServletException
 import javax.servlet.ServletRequest
 import javax.servlet.ServletResponse
+import javax.servlet.http.HttpServletRequest
 import java.nio.charset.StandardCharsets
+import java.security.Principal
 
 class ProfilingFilterSpec extends Specification {
 
@@ -277,6 +279,50 @@ class ProfilingFilterSpec extends Specification {
         json*.Id.contains(p2.id.toString())
         json*.Id.contains(p3.id.toString())
         !json*.Id.contains(p1.id.toString())
+    }
+
+    void "binds the request to ServletRequestHolder during chain invocation and clears it afterwards"() {
+        given: 'request and a chain that captures the bound request'
+        request.requestURI = '/foo'
+        request.userPrincipal = { 'alice' } as Principal
+        HttpServletRequest holderDuringChain = null
+        def captured = new FilterChain() {
+            @Override
+            void doFilter(ServletRequest req, ServletResponse resp) throws IOException, ServletException {
+                holderDuringChain = ServletRequestHolder.current()
+                profilerProvider.current().step('MockFilterChain').close()
+            }
+        }
+
+        when: 'invoked'
+        filter.doFilter(request, response, captured)
+
+        then: 'holder pointed at the request during the chain'
+        holderDuringChain.is(request)
+
+        and: 'holder is cleared once the filter returns'
+        ServletRequestHolder.current() == null
+
+        and: 'captured user is recorded on the profile'
+        storage.profiler.user == 'alice'
+    }
+
+    void "clears ServletRequestHolder even when the chain throws"() {
+        given:
+        request.requestURI = '/boom'
+        def boomChain = new FilterChain() {
+            @Override
+            void doFilter(ServletRequest req, ServletResponse resp) throws IOException, ServletException {
+                throw new ServletException('boom')
+            }
+        }
+
+        when:
+        filter.doFilter(request, response, boomChain)
+
+        then:
+        thrown(ServletException)
+        ServletRequestHolder.current() == null
     }
 
     void "serves standalone results"() {

--- a/javax-servlet/src/test/groovy/io/jdev/miniprofiler/javax/servlet/ServletUserProviderSpec.groovy
+++ b/javax-servlet/src/test/groovy/io/jdev/miniprofiler/javax/servlet/ServletUserProviderSpec.groovy
@@ -1,0 +1,96 @@
+/*
+ * Copyright 2026 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.jdev.miniprofiler.javax.servlet
+
+import org.springframework.mock.web.MockHttpServletRequest
+import spock.lang.Specification
+
+import java.security.Principal
+
+class ServletUserProviderSpec extends Specification {
+
+    ServletUserProvider provider = new ServletUserProvider()
+
+    void cleanup() {
+        ServletRequestHolder.clear()
+    }
+
+    void "returns null when no request is bound to the thread"() {
+        expect:
+        provider.user == null
+    }
+
+    void "returns the principal name when set"() {
+        given:
+        def request = new MockHttpServletRequest()
+        request.userPrincipal = { 'alice' } as Principal
+        ServletRequestHolder.set(request)
+
+        expect:
+        provider.user == 'alice'
+    }
+
+    void "falls back to remote user when no principal is set"() {
+        given:
+        def request = new MockHttpServletRequest()
+        request.remoteUser = 'bob'
+        ServletRequestHolder.set(request)
+
+        expect:
+        provider.user == 'bob'
+    }
+
+    void "prefers principal name over remote user when both are set"() {
+        given:
+        def request = new MockHttpServletRequest()
+        request.userPrincipal = { 'alice' } as Principal
+        request.remoteUser = 'bob'
+        ServletRequestHolder.set(request)
+
+        expect:
+        provider.user == 'alice'
+    }
+
+    void "falls back to remote user when principal name is empty"() {
+        given:
+        def request = new MockHttpServletRequest()
+        request.userPrincipal = { '' } as Principal
+        request.remoteUser = 'bob'
+        ServletRequestHolder.set(request)
+
+        expect:
+        provider.user == 'bob'
+    }
+
+    void "returns null when neither principal nor remote user is set"() {
+        given:
+        ServletRequestHolder.set(new MockHttpServletRequest())
+
+        expect:
+        provider.user == null
+    }
+
+    void "ServletUserProviderLocator returns a provider"() {
+        expect:
+        new ServletUserProviderLocator().locate().present
+    }
+
+    void "ServletUserProviderLocator order is below CDI fallback"() {
+        expect:
+        new ServletUserProviderLocator().order == 30
+    }
+}

--- a/javax-servlet/src/testFixtures/groovy/io/jdev/miniprofiler/javax/servlet/InProcessJetty9.groovy
+++ b/javax-servlet/src/testFixtures/groovy/io/jdev/miniprofiler/javax/servlet/InProcessJetty9.groovy
@@ -20,11 +20,18 @@ import io.jdev.miniprofiler.DefaultProfilerProvider
 import io.jdev.miniprofiler.ProfilerProvider
 import io.jdev.miniprofiler.ScriptTagWriter
 import io.jdev.miniprofiler.integtest.InProcessTestedServer
+import org.eclipse.jetty.security.ConstraintMapping
+import org.eclipse.jetty.security.ConstraintSecurityHandler
+import org.eclipse.jetty.security.HashLoginService
+import org.eclipse.jetty.security.UserStore
+import org.eclipse.jetty.security.authentication.BasicAuthenticator
 import org.eclipse.jetty.server.Server
 import org.eclipse.jetty.servlet.DefaultServlet
 import org.eclipse.jetty.servlet.FilterHolder
 import org.eclipse.jetty.servlet.ServletContextHandler
 import org.eclipse.jetty.servlet.ServletHolder
+import org.eclipse.jetty.util.security.Constraint
+import org.eclipse.jetty.util.security.Password
 
 import javax.servlet.DispatcherType
 import javax.servlet.http.HttpServlet
@@ -47,6 +54,7 @@ class InProcessJetty9 implements InProcessTestedServer {
     InProcessJetty9() {
         server = new Server(0)
         new ServletContextHandler(server, '/', false, false).tap {
+            securityHandler = buildSecurityHandler()
             addServlet(new ServletHolder(new HttpServlet() {
                 @Override
                 protected void doGet(HttpServletRequest req, HttpServletResponse resp)
@@ -76,6 +84,15 @@ class InProcessJetty9 implements InProcessTestedServer {
                     resp.writer.write('{"status":"ok"}')
                 }
             }), '/ajax-endpoint')
+            addServlet(new ServletHolder(new HttpServlet() {
+                @Override
+                protected void doGet(HttpServletRequest req, HttpServletResponse resp)
+                        throws IOException {
+                    profilerProvider.current().step('secure step').close()
+                    resp.setContentType('text/plain')
+                    resp.writer.write("hello ${req.remoteUser}")
+                }
+            }), '/secure/hello')
             addServlet(DefaultServlet, '/')
             addFilter(
                 new FilterHolder(new ProfilingFilter(profilerProvider: profilerProvider)),
@@ -84,6 +101,29 @@ class InProcessJetty9 implements InProcessTestedServer {
             )
         }
         server.start()
+    }
+
+    private static ConstraintSecurityHandler buildSecurityHandler() {
+        def loginService = new HashLoginService('miniprofiler-test')
+        def userStore = new UserStore()
+        userStore.addUser('alice', new Password('secret'), ['user'] as String[])
+        loginService.userStore = userStore
+
+        def constraint = new Constraint()
+        constraint.name = Constraint.__BASIC_AUTH
+        constraint.roles = ['user'] as String[]
+        constraint.authenticate = true
+
+        def mapping = new ConstraintMapping()
+        mapping.constraint = constraint
+        mapping.pathSpec = '/secure/*'
+
+        new ConstraintSecurityHandler().tap {
+            authenticator = new BasicAuthenticator()
+            realmName = 'miniprofiler-test'
+            it.loginService = loginService
+            constraintMappings = [mapping]
+        }
     }
 
     @Override

--- a/scenario-test/glassfish4/src/main/java/io/jdev/miniprofiler/glassfish4/funtest/SecureServlet.java
+++ b/scenario-test/glassfish4/src/main/java/io/jdev/miniprofiler/glassfish4/funtest/SecureServlet.java
@@ -1,0 +1,39 @@
+/*
+ * Copyright 2026 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.jdev.miniprofiler.glassfish4.funtest;
+
+import io.jdev.miniprofiler.MiniProfiler;
+import io.jdev.miniprofiler.Timing;
+
+import javax.servlet.ServletException;
+import javax.servlet.annotation.WebServlet;
+import javax.servlet.http.HttpServlet;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+import java.io.IOException;
+
+@WebServlet("/secure/hello")
+public class SecureServlet extends HttpServlet {
+
+    @Override
+    protected void doGet(HttpServletRequest req, HttpServletResponse resp) throws ServletException, IOException {
+        try (Timing t = MiniProfiler.current().step("secure work")) {
+            resp.setContentType("text/plain");
+            resp.getWriter().write("hello " + req.getRemoteUser());
+        }
+    }
+}

--- a/scenario-test/glassfish4/src/main/webapp/WEB-INF/glassfish-web.xml
+++ b/scenario-test/glassfish4/src/main/webapp/WEB-INF/glassfish-web.xml
@@ -14,7 +14,11 @@
   ~ See the License for the specific language governing permissions and
   ~ limitations under the License.
   -->
-<jboss-web>
-    <context-root>/</context-root>
-    <security-domain>other</security-domain>
-</jboss-web>
+<!DOCTYPE glassfish-web-app PUBLIC "-//GlassFish.org//DTD GlassFish Application Server 3.1 Servlet 3.0//EN"
+        "http://glassfish.org/dtds/glassfish-web-app_3_0-1.dtd">
+<glassfish-web-app>
+    <security-role-mapping>
+        <role-name>user</role-name>
+        <group-name>user</group-name>
+    </security-role-mapping>
+</glassfish-web-app>

--- a/scenario-test/glassfish4/src/main/webapp/WEB-INF/web.xml
+++ b/scenario-test/glassfish4/src/main/webapp/WEB-INF/web.xml
@@ -41,4 +41,23 @@
 		<url-pattern>/*</url-pattern>
 	</filter-mapping>
 
+	<security-constraint>
+		<web-resource-collection>
+			<web-resource-name>secured</web-resource-name>
+			<url-pattern>/secure/*</url-pattern>
+		</web-resource-collection>
+		<auth-constraint>
+			<role-name>user</role-name>
+		</auth-constraint>
+	</security-constraint>
+
+	<login-config>
+		<auth-method>BASIC</auth-method>
+		<realm-name>file</realm-name>
+	</login-config>
+
+	<security-role>
+		<role-name>user</role-name>
+	</security-role>
+
 </web-app>

--- a/scenario-test/glassfish4/src/scenarioTest/groovy/io/jdev/miniprofiler/glassfish4/funtest/AuthenticatedGlassfish4ScenarioSpec.groovy
+++ b/scenario-test/glassfish4/src/scenarioTest/groovy/io/jdev/miniprofiler/glassfish4/funtest/AuthenticatedGlassfish4ScenarioSpec.groovy
@@ -1,0 +1,78 @@
+/*
+ * Copyright 2026 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.jdev.miniprofiler.glassfish4.funtest
+
+import io.jdev.miniprofiler.integtest.TestMiniProfilerHttpClient
+import spock.lang.Shared
+import spock.lang.Specification
+
+class AuthenticatedGlassfish4ScenarioSpec extends Specification {
+
+    @Shared
+    String baseUrl = System.getProperty("scenarioTest.baseUrl") ?: 'http://127.0.0.1:8080/'
+
+    @Shared
+    TestMiniProfilerHttpClient client = new TestMiniProfilerHttpClient(baseUrl, 'admin/miniprofiler')
+
+    static Map<String, String> basicAuth(String user, String password) {
+        ['Authorization': 'Basic ' + Base64.encoder.encodeToString("${user}:${password}".bytes)]
+    }
+
+    Map findInResultsList(String id) {
+        def list = client.getResultsList().bodyAsJson() as List<Map>
+        list.find { it.Id == id }
+    }
+
+    void "anonymous request to public page records no user on the profile"() {
+        when:
+        def response = client.get('')
+
+        then:
+        response.statusCode() == 200
+
+        when:
+        def entry = findInResultsList(response.miniProfilerId())
+
+        then:
+        entry != null
+        entry.User == null
+    }
+
+    void "authenticated request to secured page records the principal name on the profile"() {
+        when:
+        def response = client.get('secure/hello', basicAuth('alice', 'secret'))
+
+        then:
+        response.statusCode() == 200
+        response.body() == 'hello alice'
+
+        when:
+        def entry = findInResultsList(response.miniProfilerId())
+
+        then:
+        entry != null
+        entry.User == 'alice'
+    }
+
+    void "request to secured page without credentials is rejected"() {
+        when:
+        def response = client.get('secure/hello')
+
+        then:
+        response.statusCode() == 401
+    }
+}

--- a/scenario-test/glassfish7/src/main/java/io/jdev/miniprofiler/glassfish7/funtest/SecureServlet.java
+++ b/scenario-test/glassfish7/src/main/java/io/jdev/miniprofiler/glassfish7/funtest/SecureServlet.java
@@ -1,0 +1,39 @@
+/*
+ * Copyright 2026 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.jdev.miniprofiler.glassfish7.funtest;
+
+import io.jdev.miniprofiler.MiniProfiler;
+import io.jdev.miniprofiler.Timing;
+
+import jakarta.servlet.ServletException;
+import jakarta.servlet.annotation.WebServlet;
+import jakarta.servlet.http.HttpServlet;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import java.io.IOException;
+
+@WebServlet("/secure/hello")
+public class SecureServlet extends HttpServlet {
+
+    @Override
+    protected void doGet(HttpServletRequest req, HttpServletResponse resp) throws ServletException, IOException {
+        try (Timing t = MiniProfiler.current().step("secure work")) {
+            resp.setContentType("text/plain");
+            resp.getWriter().write("hello " + req.getRemoteUser());
+        }
+    }
+}

--- a/scenario-test/glassfish7/src/main/webapp/WEB-INF/glassfish-web.xml
+++ b/scenario-test/glassfish7/src/main/webapp/WEB-INF/glassfish-web.xml
@@ -14,7 +14,11 @@
   ~ See the License for the specific language governing permissions and
   ~ limitations under the License.
   -->
-<jboss-web>
-    <context-root>/</context-root>
-    <security-domain>other</security-domain>
-</jboss-web>
+<!DOCTYPE glassfish-web-app PUBLIC "-//GlassFish.org//DTD GlassFish Application Server 3.1 Servlet 3.0//EN"
+        "http://glassfish.org/dtds/glassfish-web-app_3_0-1.dtd">
+<glassfish-web-app>
+    <security-role-mapping>
+        <role-name>user</role-name>
+        <group-name>user</group-name>
+    </security-role-mapping>
+</glassfish-web-app>

--- a/scenario-test/glassfish7/src/main/webapp/WEB-INF/web.xml
+++ b/scenario-test/glassfish7/src/main/webapp/WEB-INF/web.xml
@@ -41,4 +41,23 @@
 		<url-pattern>/*</url-pattern>
 	</filter-mapping>
 
+	<security-constraint>
+		<web-resource-collection>
+			<web-resource-name>secured</web-resource-name>
+			<url-pattern>/secure/*</url-pattern>
+		</web-resource-collection>
+		<auth-constraint>
+			<role-name>user</role-name>
+		</auth-constraint>
+	</security-constraint>
+
+	<login-config>
+		<auth-method>BASIC</auth-method>
+		<realm-name>file</realm-name>
+	</login-config>
+
+	<security-role>
+		<role-name>user</role-name>
+	</security-role>
+
 </web-app>

--- a/scenario-test/glassfish7/src/scenarioTest/groovy/io/jdev/miniprofiler/glassfish7/funtest/AuthenticatedGlassfish7ScenarioSpec.groovy
+++ b/scenario-test/glassfish7/src/scenarioTest/groovy/io/jdev/miniprofiler/glassfish7/funtest/AuthenticatedGlassfish7ScenarioSpec.groovy
@@ -1,0 +1,78 @@
+/*
+ * Copyright 2026 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.jdev.miniprofiler.glassfish7.funtest
+
+import io.jdev.miniprofiler.integtest.TestMiniProfilerHttpClient
+import spock.lang.Shared
+import spock.lang.Specification
+
+class AuthenticatedGlassfish7ScenarioSpec extends Specification {
+
+    @Shared
+    String baseUrl = System.getProperty("scenarioTest.baseUrl") ?: 'http://127.0.0.1:8080/'
+
+    @Shared
+    TestMiniProfilerHttpClient client = new TestMiniProfilerHttpClient(baseUrl, 'admin/miniprofiler')
+
+    static Map<String, String> basicAuth(String user, String password) {
+        ['Authorization': 'Basic ' + Base64.encoder.encodeToString("${user}:${password}".bytes)]
+    }
+
+    Map findInResultsList(String id) {
+        def list = client.getResultsList().bodyAsJson() as List<Map>
+        list.find { it.Id == id }
+    }
+
+    void "anonymous request to public page records no user on the profile"() {
+        when:
+        def response = client.get('')
+
+        then:
+        response.statusCode() == 200
+
+        when:
+        def entry = findInResultsList(response.miniProfilerId())
+
+        then:
+        entry != null
+        entry.User == null
+    }
+
+    void "authenticated request to secured page records the principal name on the profile"() {
+        when:
+        def response = client.get('secure/hello', basicAuth('alice', 'secret'))
+
+        then:
+        response.statusCode() == 200
+        response.body() == 'hello alice'
+
+        when:
+        def entry = findInResultsList(response.miniProfilerId())
+
+        then:
+        entry != null
+        entry.User == 'alice'
+    }
+
+    void "request to secured page without credentials is rejected"() {
+        when:
+        def response = client.get('secure/hello')
+
+        then:
+        response.statusCode() == 401
+    }
+}

--- a/scenario-test/jetty12-servlet/src/main/java/io/jdev/miniprofiler/servlettest/SecureServlet.java
+++ b/scenario-test/jetty12-servlet/src/main/java/io/jdev/miniprofiler/servlettest/SecureServlet.java
@@ -1,0 +1,41 @@
+/*
+ * Copyright 2026 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.jdev.miniprofiler.servlettest;
+
+import io.jdev.miniprofiler.MiniProfiler;
+import io.jdev.miniprofiler.Timing;
+
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServlet;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import java.io.IOException;
+
+/**
+ * Trivial servlet served behind {@link BasicAuthFilter}; returns the authenticated user
+ * so the scenario test can verify both the response and the captured profile user.
+ */
+public class SecureServlet extends HttpServlet {
+
+    @Override
+    protected void doGet(HttpServletRequest request, HttpServletResponse response) throws ServletException, IOException {
+        try (Timing t = MiniProfiler.current().step("secure work")) {
+            response.setContentType("text/plain");
+            response.getWriter().write("hello " + request.getRemoteUser());
+        }
+    }
+}

--- a/scenario-test/jetty12-servlet/src/main/webapp/WEB-INF/jetty-ee10-web.xml
+++ b/scenario-test/jetty12-servlet/src/main/webapp/WEB-INF/jetty-ee10-web.xml
@@ -1,0 +1,41 @@
+<?xml version="1.0"?>
+<!--
+  ~ Copyright 2026 the original author or authors.
+  ~
+  ~ Licensed under the Apache License, Version 2.0 (the "License");
+  ~ you may not use this file except in compliance with the License.
+  ~ You may obtain a copy of the License at
+  ~
+  ~ http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  -->
+<!DOCTYPE Configure PUBLIC "-//Jetty//Configure//EN" "https://eclipse.dev/jetty/configure_10_0.dtd">
+<Configure class="org.eclipse.jetty.ee10.webapp.WebAppContext">
+    <Get name="securityHandler">
+        <Set name="loginService">
+            <New class="org.eclipse.jetty.security.HashLoginService">
+                <Set name="name">miniprofiler-test</Set>
+                <Set name="userStore">
+                    <New class="org.eclipse.jetty.security.UserStore">
+                        <Call name="addUser">
+                            <Arg>alice</Arg>
+                            <Arg>
+                                <New class="org.eclipse.jetty.util.security.Password">
+                                    <Arg>secret</Arg>
+                                </New>
+                            </Arg>
+                            <Arg>
+                                <Array type="String"><Item>user</Item></Array>
+                            </Arg>
+                        </Call>
+                    </New>
+                </Set>
+            </New>
+        </Set>
+    </Get>
+</Configure>

--- a/scenario-test/jetty12-servlet/src/main/webapp/WEB-INF/web.xml
+++ b/scenario-test/jetty12-servlet/src/main/webapp/WEB-INF/web.xml
@@ -31,6 +31,35 @@
 		<url-pattern>/*</url-pattern>
 	</filter-mapping>
 
+	<servlet>
+		<servlet-name>secure</servlet-name>
+		<servlet-class>io.jdev.miniprofiler.servlettest.SecureServlet</servlet-class>
+	</servlet>
+
+	<servlet-mapping>
+		<servlet-name>secure</servlet-name>
+		<url-pattern>/secure/*</url-pattern>
+	</servlet-mapping>
+
+	<security-constraint>
+		<web-resource-collection>
+			<web-resource-name>secured</web-resource-name>
+			<url-pattern>/secure/*</url-pattern>
+		</web-resource-collection>
+		<auth-constraint>
+			<role-name>user</role-name>
+		</auth-constraint>
+	</security-constraint>
+
+	<login-config>
+		<auth-method>BASIC</auth-method>
+		<realm-name>miniprofiler-test</realm-name>
+	</login-config>
+
+	<security-role>
+		<role-name>user</role-name>
+	</security-role>
+
 	<listener>
 		<listener-class>io.jdev.miniprofiler.servlettest.Startup</listener-class>
 	</listener>

--- a/scenario-test/jetty12-servlet/src/scenarioTest/groovy/io/jdev/miniprofiler/jakarta/servlet/funtest/AuthenticatedServletScenarioSpec.groovy
+++ b/scenario-test/jetty12-servlet/src/scenarioTest/groovy/io/jdev/miniprofiler/jakarta/servlet/funtest/AuthenticatedServletScenarioSpec.groovy
@@ -1,0 +1,79 @@
+/*
+ * Copyright 2026 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.jdev.miniprofiler.jakarta.servlet.funtest
+
+import io.jdev.miniprofiler.integtest.TestMiniProfilerHttpClient
+import spock.lang.Shared
+import spock.lang.Specification
+
+class AuthenticatedServletScenarioSpec extends Specification {
+
+    @Shared
+    String baseUrl = System.getProperty("scenarioTest.baseUrl") ?: 'http://127.0.0.1:8080/jakarta-servlet/'
+
+    @Shared
+    TestMiniProfilerHttpClient client = new TestMiniProfilerHttpClient(baseUrl)
+
+    static Map<String, String> basicAuth(String user, String password) {
+        ['Authorization': 'Basic ' + Base64.encoder.encodeToString("${user}:${password}".bytes)]
+    }
+
+    Map findInResultsList(String id) {
+        def list = client.getResultsList().bodyAsJson() as List<Map>
+        list.find { it.Id == id }
+    }
+
+    void "anonymous request to public page records no user on the profile"() {
+        when:
+        def response = client.get('')
+
+        then:
+        response.statusCode() == 200
+
+        when:
+        def entry = findInResultsList(response.miniProfilerId())
+
+        then:
+        entry != null
+        entry.User == null
+    }
+
+    void "authenticated request to secured page records the principal name on the profile"() {
+        when:
+        def response = client.get('secure/hello', basicAuth('alice', 'secret'))
+
+        then:
+        response.statusCode() == 200
+        response.body() == 'hello alice'
+
+        when:
+        def entry = findInResultsList(response.miniProfilerId())
+
+        then:
+        entry != null
+        entry.User == 'alice'
+    }
+
+    void "request to secured page without credentials is rejected and not profiled"() {
+        when:
+        def response = client.get('secure/hello')
+
+        then: 'auth filter rejects before miniprofiler runs, so no profiler header is set'
+        response.statusCode() == 401
+        !response.header('X-MiniProfiler-Ids').present
+    }
+}

--- a/scenario-test/jetty9-servlet/src/main/java/io/jdev/miniprofiler/servlettest/SecureServlet.java
+++ b/scenario-test/jetty9-servlet/src/main/java/io/jdev/miniprofiler/servlettest/SecureServlet.java
@@ -1,0 +1,41 @@
+/*
+ * Copyright 2026 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.jdev.miniprofiler.servlettest;
+
+import io.jdev.miniprofiler.MiniProfiler;
+import io.jdev.miniprofiler.Timing;
+
+import javax.servlet.ServletException;
+import javax.servlet.http.HttpServlet;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+import java.io.IOException;
+
+/**
+ * Trivial servlet served behind {@link BasicAuthFilter}; returns the authenticated user
+ * so the scenario test can verify both the response and the captured profile user.
+ */
+public class SecureServlet extends HttpServlet {
+
+    @Override
+    protected void doGet(HttpServletRequest request, HttpServletResponse response) throws ServletException, IOException {
+        try (Timing t = MiniProfiler.current().step("secure work")) {
+            response.setContentType("text/plain");
+            response.getWriter().write("hello " + request.getRemoteUser());
+        }
+    }
+}

--- a/scenario-test/jetty9-servlet/src/main/webapp/WEB-INF/jetty-web.xml
+++ b/scenario-test/jetty9-servlet/src/main/webapp/WEB-INF/jetty-web.xml
@@ -1,0 +1,41 @@
+<?xml version="1.0"?>
+<!--
+  ~ Copyright 2026 the original author or authors.
+  ~
+  ~ Licensed under the Apache License, Version 2.0 (the "License");
+  ~ you may not use this file except in compliance with the License.
+  ~ You may obtain a copy of the License at
+  ~
+  ~ http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  -->
+<!DOCTYPE Configure PUBLIC "-//Jetty//Configure//EN" "http://www.eclipse.org/jetty/configure_9_3.dtd">
+<Configure class="org.eclipse.jetty.webapp.WebAppContext">
+    <Get name="securityHandler">
+        <Set name="loginService">
+            <New class="org.eclipse.jetty.security.HashLoginService">
+                <Set name="name">miniprofiler-test</Set>
+                <Set name="userStore">
+                    <New class="org.eclipse.jetty.security.UserStore">
+                        <Call name="addUser">
+                            <Arg>alice</Arg>
+                            <Arg>
+                                <New class="org.eclipse.jetty.util.security.Password">
+                                    <Arg>secret</Arg>
+                                </New>
+                            </Arg>
+                            <Arg>
+                                <Array type="String"><Item>user</Item></Array>
+                            </Arg>
+                        </Call>
+                    </New>
+                </Set>
+            </New>
+        </Set>
+    </Get>
+</Configure>

--- a/scenario-test/jetty9-servlet/src/main/webapp/WEB-INF/web.xml
+++ b/scenario-test/jetty9-servlet/src/main/webapp/WEB-INF/web.xml
@@ -31,6 +31,35 @@
 		<url-pattern>/*</url-pattern>
 	</filter-mapping>
 
+	<servlet>
+		<servlet-name>secure</servlet-name>
+		<servlet-class>io.jdev.miniprofiler.servlettest.SecureServlet</servlet-class>
+	</servlet>
+
+	<servlet-mapping>
+		<servlet-name>secure</servlet-name>
+		<url-pattern>/secure/*</url-pattern>
+	</servlet-mapping>
+
+	<security-constraint>
+		<web-resource-collection>
+			<web-resource-name>secured</web-resource-name>
+			<url-pattern>/secure/*</url-pattern>
+		</web-resource-collection>
+		<auth-constraint>
+			<role-name>user</role-name>
+		</auth-constraint>
+	</security-constraint>
+
+	<login-config>
+		<auth-method>BASIC</auth-method>
+		<realm-name>miniprofiler-test</realm-name>
+	</login-config>
+
+	<security-role>
+		<role-name>user</role-name>
+	</security-role>
+
 	<listener>
 		<listener-class>io.jdev.miniprofiler.servlettest.Startup</listener-class>
 	</listener>

--- a/scenario-test/jetty9-servlet/src/scenarioTest/groovy/io/jdev/miniprofiler/javax/servlet/funtest/AuthenticatedServletScenarioSpec.groovy
+++ b/scenario-test/jetty9-servlet/src/scenarioTest/groovy/io/jdev/miniprofiler/javax/servlet/funtest/AuthenticatedServletScenarioSpec.groovy
@@ -1,0 +1,79 @@
+/*
+ * Copyright 2026 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.jdev.miniprofiler.javax.servlet.funtest
+
+import io.jdev.miniprofiler.integtest.TestMiniProfilerHttpClient
+import spock.lang.Shared
+import spock.lang.Specification
+
+class AuthenticatedServletScenarioSpec extends Specification {
+
+    @Shared
+    String baseUrl = System.getProperty("scenarioTest.baseUrl") ?: 'http://127.0.0.1:8080/javax-servlet/'
+
+    @Shared
+    TestMiniProfilerHttpClient client = new TestMiniProfilerHttpClient(baseUrl)
+
+    static Map<String, String> basicAuth(String user, String password) {
+        ['Authorization': 'Basic ' + Base64.encoder.encodeToString("${user}:${password}".bytes)]
+    }
+
+    Map findInResultsList(String id) {
+        def list = client.getResultsList().bodyAsJson() as List<Map>
+        list.find { it.Id == id }
+    }
+
+    void "anonymous request to public page records no user on the profile"() {
+        when:
+        def response = client.get('')
+
+        then:
+        response.statusCode() == 200
+
+        when:
+        def entry = findInResultsList(response.miniProfilerId())
+
+        then:
+        entry != null
+        entry.User == null
+    }
+
+    void "authenticated request to secured page records the principal name on the profile"() {
+        when:
+        def response = client.get('secure/hello', basicAuth('alice', 'secret'))
+
+        then:
+        response.statusCode() == 200
+        response.body() == 'hello alice'
+
+        when:
+        def entry = findInResultsList(response.miniProfilerId())
+
+        then:
+        entry != null
+        entry.User == 'alice'
+    }
+
+    void "request to secured page without credentials is rejected and not profiled"() {
+        when:
+        def response = client.get('secure/hello')
+
+        then: 'auth filter rejects before miniprofiler runs, so no profiler header is set'
+        response.statusCode() == 401
+        !response.header('X-MiniProfiler-Ids').present
+    }
+}

--- a/scenario-test/wildfly10/src/main/java/io/jdev/miniprofiler/wildfly10/funtest/SecureServlet.java
+++ b/scenario-test/wildfly10/src/main/java/io/jdev/miniprofiler/wildfly10/funtest/SecureServlet.java
@@ -1,0 +1,39 @@
+/*
+ * Copyright 2026 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.jdev.miniprofiler.wildfly10.funtest;
+
+import io.jdev.miniprofiler.MiniProfiler;
+import io.jdev.miniprofiler.Timing;
+
+import javax.servlet.ServletException;
+import javax.servlet.annotation.WebServlet;
+import javax.servlet.http.HttpServlet;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+import java.io.IOException;
+
+@WebServlet("/secure/hello")
+public class SecureServlet extends HttpServlet {
+
+    @Override
+    protected void doGet(HttpServletRequest req, HttpServletResponse resp) throws ServletException, IOException {
+        try (Timing t = MiniProfiler.current().step("secure work")) {
+            resp.setContentType("text/plain");
+            resp.getWriter().write("hello " + req.getRemoteUser());
+        }
+    }
+}

--- a/scenario-test/wildfly10/src/main/webapp/WEB-INF/web.xml
+++ b/scenario-test/wildfly10/src/main/webapp/WEB-INF/web.xml
@@ -31,4 +31,23 @@
 		<url-pattern>/*</url-pattern>
 	</filter-mapping>
 
+	<security-constraint>
+		<web-resource-collection>
+			<web-resource-name>secured</web-resource-name>
+			<url-pattern>/secure/*</url-pattern>
+		</web-resource-collection>
+		<auth-constraint>
+			<role-name>user</role-name>
+		</auth-constraint>
+	</security-constraint>
+
+	<login-config>
+		<auth-method>BASIC</auth-method>
+		<realm-name>ApplicationRealm</realm-name>
+	</login-config>
+
+	<security-role>
+		<role-name>user</role-name>
+	</security-role>
+
 </web-app>

--- a/scenario-test/wildfly10/src/scenarioTest/groovy/io/jdev/miniprofiler/wildfly10/funtest/AuthenticatedWildfly10ScenarioSpec.groovy
+++ b/scenario-test/wildfly10/src/scenarioTest/groovy/io/jdev/miniprofiler/wildfly10/funtest/AuthenticatedWildfly10ScenarioSpec.groovy
@@ -1,0 +1,78 @@
+/*
+ * Copyright 2026 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.jdev.miniprofiler.wildfly10.funtest
+
+import io.jdev.miniprofiler.integtest.TestMiniProfilerHttpClient
+import spock.lang.Shared
+import spock.lang.Specification
+
+class AuthenticatedWildfly10ScenarioSpec extends Specification {
+
+    @Shared
+    String baseUrl = System.getProperty("scenarioTest.baseUrl") ?: 'http://127.0.0.1:8080/'
+
+    @Shared
+    TestMiniProfilerHttpClient client = new TestMiniProfilerHttpClient(baseUrl)
+
+    static Map<String, String> basicAuth(String user, String password) {
+        ['Authorization': 'Basic ' + Base64.encoder.encodeToString("${user}:${password}".bytes)]
+    }
+
+    Map findInResultsList(String id) {
+        def list = client.getResultsList().bodyAsJson() as List<Map>
+        list.find { it.Id == id }
+    }
+
+    void "anonymous request to public page records no user on the profile"() {
+        when:
+        def response = client.get('')
+
+        then:
+        response.statusCode() == 200
+
+        when:
+        def entry = findInResultsList(response.miniProfilerId())
+
+        then:
+        entry != null
+        entry.User == null
+    }
+
+    void "authenticated request to secured page records the principal name on the profile"() {
+        when:
+        def response = client.get('secure/hello', basicAuth('alice', 'secret'))
+
+        then:
+        response.statusCode() == 200
+        response.body() == 'hello alice'
+
+        when:
+        def entry = findInResultsList(response.miniProfilerId())
+
+        then:
+        entry != null
+        entry.User == 'alice'
+    }
+
+    void "request to secured page without credentials is rejected"() {
+        when:
+        def response = client.get('secure/hello')
+
+        then:
+        response.statusCode() == 401
+    }
+}

--- a/scenario-test/wildfly27/src/main/java/io/jdev/miniprofiler/wildfly27/funtest/SecureServlet.java
+++ b/scenario-test/wildfly27/src/main/java/io/jdev/miniprofiler/wildfly27/funtest/SecureServlet.java
@@ -1,0 +1,39 @@
+/*
+ * Copyright 2026 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.jdev.miniprofiler.wildfly27.funtest;
+
+import io.jdev.miniprofiler.MiniProfiler;
+import io.jdev.miniprofiler.Timing;
+
+import jakarta.servlet.ServletException;
+import jakarta.servlet.annotation.WebServlet;
+import jakarta.servlet.http.HttpServlet;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import java.io.IOException;
+
+@WebServlet("/secure/hello")
+public class SecureServlet extends HttpServlet {
+
+    @Override
+    protected void doGet(HttpServletRequest req, HttpServletResponse resp) throws ServletException, IOException {
+        try (Timing t = MiniProfiler.current().step("secure work")) {
+            resp.setContentType("text/plain");
+            resp.getWriter().write("hello " + req.getRemoteUser());
+        }
+    }
+}

--- a/scenario-test/wildfly27/src/main/webapp/WEB-INF/web.xml
+++ b/scenario-test/wildfly27/src/main/webapp/WEB-INF/web.xml
@@ -31,4 +31,23 @@
 		<url-pattern>/*</url-pattern>
 	</filter-mapping>
 
+	<security-constraint>
+		<web-resource-collection>
+			<web-resource-name>secured</web-resource-name>
+			<url-pattern>/secure/*</url-pattern>
+		</web-resource-collection>
+		<auth-constraint>
+			<role-name>user</role-name>
+		</auth-constraint>
+	</security-constraint>
+
+	<login-config>
+		<auth-method>BASIC</auth-method>
+		<realm-name>ApplicationRealm</realm-name>
+	</login-config>
+
+	<security-role>
+		<role-name>user</role-name>
+	</security-role>
+
 </web-app>

--- a/scenario-test/wildfly27/src/scenarioTest/groovy/io/jdev/miniprofiler/wildfly27/funtest/AuthenticatedWildfly27ScenarioSpec.groovy
+++ b/scenario-test/wildfly27/src/scenarioTest/groovy/io/jdev/miniprofiler/wildfly27/funtest/AuthenticatedWildfly27ScenarioSpec.groovy
@@ -1,0 +1,78 @@
+/*
+ * Copyright 2026 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.jdev.miniprofiler.wildfly27.funtest
+
+import io.jdev.miniprofiler.integtest.TestMiniProfilerHttpClient
+import spock.lang.Shared
+import spock.lang.Specification
+
+class AuthenticatedWildfly27ScenarioSpec extends Specification {
+
+    @Shared
+    String baseUrl = System.getProperty("scenarioTest.baseUrl") ?: 'http://127.0.0.1:8080/'
+
+    @Shared
+    TestMiniProfilerHttpClient client = new TestMiniProfilerHttpClient(baseUrl)
+
+    static Map<String, String> basicAuth(String user, String password) {
+        ['Authorization': 'Basic ' + Base64.encoder.encodeToString("${user}:${password}".bytes)]
+    }
+
+    Map findInResultsList(String id) {
+        def list = client.getResultsList().bodyAsJson() as List<Map>
+        list.find { it.Id == id }
+    }
+
+    void "anonymous request to public page records no user on the profile"() {
+        when:
+        def response = client.get('')
+
+        then:
+        response.statusCode() == 200
+
+        when:
+        def entry = findInResultsList(response.miniProfilerId())
+
+        then:
+        entry != null
+        entry.User == null
+    }
+
+    void "authenticated request to secured page records the principal name on the profile"() {
+        when:
+        def response = client.get('secure/hello', basicAuth('alice', 'secret'))
+
+        then:
+        response.statusCode() == 200
+        response.body() == 'hello alice'
+
+        when:
+        def entry = findInResultsList(response.miniProfilerId())
+
+        then:
+        entry != null
+        entry.User == 'alice'
+    }
+
+    void "request to secured page without credentials is rejected"() {
+        when:
+        def response = client.get('secure/hello')
+
+        then:
+        response.statusCode() == 401
+    }
+}


### PR DESCRIPTION
Builds out the `UserProviderLocator` SPI added in #128 with concrete
implementations that capture the authenticated user on profile records
in servlet and Java/Jakarta EE deployments.

  - Chain providers in `UserProviderLocator.findUserProvider()` via a
    new `CompositeUserProvider`, so request-bound providers (servlet)
    fall through to broader providers (CDI Principal) on threads where
    the more specific context is missing
  - Add `ServletUserProvider` to `miniprofiler-javax-servlet` and
    `miniprofiler-jakarta-servlet`, populated from the in-flight
    `HttpServletRequest` via a thread-local set by `ProfilingFilter`;
    reads `getUserPrincipal().getName()` falling back to
    `getRemoteUser()`
  - Add `CdiPrincipalUserProvider` to `miniprofiler-javax-ee` and
    `miniprofiler-jakarta-ee`, resolving the CDI built-in
    `java.security.Principal` bean via `CDI.current()`
  - Cover the new providers with real-auth integration and scenario
    tests: embedded Jetty 9 / Jetty 12 with `HashLoginService`,
    GlassFish 4 / 7 file realms, WildFly 10 / 27 ApplicationRealm