### PR TITLE
Add copyright year maintenance tasks and refresh all headers

### DIFF
--- a/.github/workflows/gradle-build.yml
+++ b/.github/workflows/gradle-build.yml
@@ -35,7 +35,7 @@ jobs:
           geckodriver-version: 0.36.0
 
       - name: Build and run fast tests
-        run: ./gradlew assemble check --continue
+        run: ./gradlew assemble sanityCheck check --continue
 
       - name: Run slow tests
         uses: GabrielBB/xvfb-action@v1.7

--- a/.github/workflows/gradle-release.yml
+++ b/.github/workflows/gradle-release.yml
@@ -57,7 +57,7 @@ jobs:
       - name: Run checks
         env:
           CI: true
-        run: ./gradlew check -x integrationTest
+        run: ./gradlew sanityCheck check
 
       - name: Commit release version
         run: |

--- a/.github/workflows/gradle-release.yml
+++ b/.github/workflows/gradle-release.yml
@@ -57,7 +57,7 @@ jobs:
       - name: Run checks
         env:
           CI: true
-        run: ./gradlew sanityCheck check
+        run: ./gradlew sanityCheck check verifyCopyright
 
       - name: Commit release version
         run: |

--- a/LICENSE.txt
+++ b/LICENSE.txt
@@ -1,4 +1,4 @@
-Copyright 2013 the original author or authors.
+Copyright 2013-2026 the original author or authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/core/core.gradle.kts
+++ b/core/core.gradle.kts
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018 the original author or authors.
+ * Copyright 2023-2026 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/core/src/browserTest/groovy/io/jdev/miniprofiler/server/MiniProfilerServerBrowserSpec.groovy
+++ b/core/src/browserTest/groovy/io/jdev/miniprofiler/server/MiniProfilerServerBrowserSpec.groovy
@@ -1,5 +1,5 @@
 /*
- * Copyright 2026 the original author or authors.
+ * Copyright 2013-2026 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/core/src/main/java/io/jdev/miniprofiler/BaseProfilerProvider.java
+++ b/core/src/main/java/io/jdev/miniprofiler/BaseProfilerProvider.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013 the original author or authors.
+ * Copyright 2013-2026 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/core/src/main/java/io/jdev/miniprofiler/CustomTiming.java
+++ b/core/src/main/java/io/jdev/miniprofiler/CustomTiming.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017 the original author or authors.
+ * Copyright 2013-2026 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/core/src/main/java/io/jdev/miniprofiler/DefaultProfilerProvider.java
+++ b/core/src/main/java/io/jdev/miniprofiler/DefaultProfilerProvider.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013 the original author or authors.
+ * Copyright 2013-2026 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/core/src/main/java/io/jdev/miniprofiler/DelegatingProfilerProvider.java
+++ b/core/src/main/java/io/jdev/miniprofiler/DelegatingProfilerProvider.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013 the original author or authors.
+ * Copyright 2013-2026 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/core/src/main/java/io/jdev/miniprofiler/MiniProfiler.java
+++ b/core/src/main/java/io/jdev/miniprofiler/MiniProfiler.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013 the original author or authors.
+ * Copyright 2013-2026 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/core/src/main/java/io/jdev/miniprofiler/ProfileLevel.java
+++ b/core/src/main/java/io/jdev/miniprofiler/ProfileLevel.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013 the original author or authors.
+ * Copyright 2013-2026 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/core/src/main/java/io/jdev/miniprofiler/Profiler.java
+++ b/core/src/main/java/io/jdev/miniprofiler/Profiler.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013 the original author or authors.
+ * Copyright 2013-2026 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/core/src/main/java/io/jdev/miniprofiler/ProfilerProvider.java
+++ b/core/src/main/java/io/jdev/miniprofiler/ProfilerProvider.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013 the original author or authors.
+ * Copyright 2013-2026 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/core/src/main/java/io/jdev/miniprofiler/ProfilerUiConfig.java
+++ b/core/src/main/java/io/jdev/miniprofiler/ProfilerUiConfig.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016 the original author or authors.
+ * Copyright 2016-2026 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/core/src/main/java/io/jdev/miniprofiler/ScriptTagWriter.java
+++ b/core/src/main/java/io/jdev/miniprofiler/ScriptTagWriter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013 the original author or authors.
+ * Copyright 2013-2026 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/core/src/main/java/io/jdev/miniprofiler/StaticProfilerProvider.java
+++ b/core/src/main/java/io/jdev/miniprofiler/StaticProfilerProvider.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013 the original author or authors.
+ * Copyright 2013-2026 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/core/src/main/java/io/jdev/miniprofiler/StaticProfilerProviderLocator.java
+++ b/core/src/main/java/io/jdev/miniprofiler/StaticProfilerProviderLocator.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2026 the original author or authors.
+ * Copyright 2013-2026 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/core/src/main/java/io/jdev/miniprofiler/Timing.java
+++ b/core/src/main/java/io/jdev/miniprofiler/Timing.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013 the original author or authors.
+ * Copyright 2013-2025 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/core/src/main/java/io/jdev/miniprofiler/format/NoopCommandFormatter.java
+++ b/core/src/main/java/io/jdev/miniprofiler/format/NoopCommandFormatter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2026 the original author or authors.
+ * Copyright 2013-2026 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/core/src/main/java/io/jdev/miniprofiler/format/NoopCommandFormatterLocator.java
+++ b/core/src/main/java/io/jdev/miniprofiler/format/NoopCommandFormatterLocator.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2026 the original author or authors.
+ * Copyright 2013-2026 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/core/src/main/java/io/jdev/miniprofiler/intercept/ProfilingInvocationHandler.java
+++ b/core/src/main/java/io/jdev/miniprofiler/intercept/ProfilingInvocationHandler.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013 the original author or authors.
+ * Copyright 2013-2017 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/core/src/main/java/io/jdev/miniprofiler/internal/ConfigHelper.java
+++ b/core/src/main/java/io/jdev/miniprofiler/internal/ConfigHelper.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016 the original author or authors.
+ * Copyright 2016-2026 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/core/src/main/java/io/jdev/miniprofiler/internal/CustomTimingImpl.java
+++ b/core/src/main/java/io/jdev/miniprofiler/internal/CustomTimingImpl.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013 the original author or authors.
+ * Copyright 2017-2026 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/core/src/main/java/io/jdev/miniprofiler/internal/Jsonable.java
+++ b/core/src/main/java/io/jdev/miniprofiler/internal/Jsonable.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013 the original author or authors.
+ * Copyright 2013-2023 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/core/src/main/java/io/jdev/miniprofiler/internal/NullCustomTiming.java
+++ b/core/src/main/java/io/jdev/miniprofiler/internal/NullCustomTiming.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017 the original author or authors.
+ * Copyright 2013-2017 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/core/src/main/java/io/jdev/miniprofiler/internal/NullProfiler.java
+++ b/core/src/main/java/io/jdev/miniprofiler/internal/NullProfiler.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013 the original author or authors.
+ * Copyright 2013-2026 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/core/src/main/java/io/jdev/miniprofiler/internal/NullTiming.java
+++ b/core/src/main/java/io/jdev/miniprofiler/internal/NullTiming.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013 the original author or authors.
+ * Copyright 2013-2025 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/core/src/main/java/io/jdev/miniprofiler/internal/ProfilerImpl.java
+++ b/core/src/main/java/io/jdev/miniprofiler/internal/ProfilerImpl.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013 the original author or authors.
+ * Copyright 2013-2026 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/core/src/main/java/io/jdev/miniprofiler/internal/TimingImpl.java
+++ b/core/src/main/java/io/jdev/miniprofiler/internal/TimingImpl.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013 the original author or authors.
+ * Copyright 2013-2026 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/core/src/main/java/io/jdev/miniprofiler/internal/TimingInternal.java
+++ b/core/src/main/java/io/jdev/miniprofiler/internal/TimingInternal.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017 the original author or authors.
+ * Copyright 2013-2017 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/core/src/main/java/io/jdev/miniprofiler/server/Pages.java
+++ b/core/src/main/java/io/jdev/miniprofiler/server/Pages.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2023 the original author or authors.
+ * Copyright 2023-2026 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/core/src/main/java/io/jdev/miniprofiler/server/ResourceHelper.java
+++ b/core/src/main/java/io/jdev/miniprofiler/server/ResourceHelper.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013 the original author or authors.
+ * Copyright 2013-2026 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/core/src/main/java/io/jdev/miniprofiler/server/ResultsRequest.java
+++ b/core/src/main/java/io/jdev/miniprofiler/server/ResultsRequest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 the original author or authors.
+ * Copyright 2022-2026 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/core/src/main/java/io/jdev/miniprofiler/sql/DriverUtil.java
+++ b/core/src/main/java/io/jdev/miniprofiler/sql/DriverUtil.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014 the original author or authors.
+ * Copyright 2014-2026 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/core/src/main/java/io/jdev/miniprofiler/sql/ProfilingDataSource.java
+++ b/core/src/main/java/io/jdev/miniprofiler/sql/ProfilingDataSource.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013 the original author or authors.
+ * Copyright 2013-2026 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/core/src/main/java/io/jdev/miniprofiler/sql/ProfilingSpyLogDelegator.java
+++ b/core/src/main/java/io/jdev/miniprofiler/sql/ProfilingSpyLogDelegator.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013 the original author or authors.
+ * Copyright 2013-2026 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/core/src/main/java/io/jdev/miniprofiler/sql/SqlCommandFormatter.java
+++ b/core/src/main/java/io/jdev/miniprofiler/sql/SqlCommandFormatter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2026 the original author or authors.
+ * Copyright 2013-2026 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/core/src/main/java/io/jdev/miniprofiler/sql/SqlCommandFormatterLocator.java
+++ b/core/src/main/java/io/jdev/miniprofiler/sql/SqlCommandFormatterLocator.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2026 the original author or authors.
+ * Copyright 2013-2026 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/core/src/main/java/io/jdev/miniprofiler/storage/BaseStorage.java
+++ b/core/src/main/java/io/jdev/miniprofiler/storage/BaseStorage.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013 the original author or authors.
+ * Copyright 2013-2026 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/core/src/main/java/io/jdev/miniprofiler/storage/MapStorage.java
+++ b/core/src/main/java/io/jdev/miniprofiler/storage/MapStorage.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013 the original author or authors.
+ * Copyright 2013-2026 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/core/src/main/java/io/jdev/miniprofiler/storage/MapStorageLocator.java
+++ b/core/src/main/java/io/jdev/miniprofiler/storage/MapStorageLocator.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2026 the original author or authors.
+ * Copyright 2013-2026 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/core/src/main/java/io/jdev/miniprofiler/storage/Storage.java
+++ b/core/src/main/java/io/jdev/miniprofiler/storage/Storage.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013 the original author or authors.
+ * Copyright 2013-2026 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/core/src/main/java/io/jdev/miniprofiler/user/UnknownUserProvider.java
+++ b/core/src/main/java/io/jdev/miniprofiler/user/UnknownUserProvider.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2026 the original author or authors.
+ * Copyright 2013-2026 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/core/src/main/java/io/jdev/miniprofiler/user/UnknownUserProviderLocator.java
+++ b/core/src/main/java/io/jdev/miniprofiler/user/UnknownUserProviderLocator.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2026 the original author or authors.
+ * Copyright 2013-2026 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/core/src/main/java/io/jdev/miniprofiler/user/UserProvider.java
+++ b/core/src/main/java/io/jdev/miniprofiler/user/UserProvider.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013 the original author or authors.
+ * Copyright 2013-2015 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/core/src/test/groovy/io/jdev/miniprofiler/DefaultProfilerProviderSpec.groovy
+++ b/core/src/test/groovy/io/jdev/miniprofiler/DefaultProfilerProviderSpec.groovy
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013 the original author or authors.
+ * Copyright 2013-2017 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/core/src/test/groovy/io/jdev/miniprofiler/MiniProfilerIntegrationSpec.groovy
+++ b/core/src/test/groovy/io/jdev/miniprofiler/MiniProfilerIntegrationSpec.groovy
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013 the original author or authors.
+ * Copyright 2013-2026 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/core/src/test/groovy/io/jdev/miniprofiler/MiniProfilerSpec.groovy
+++ b/core/src/test/groovy/io/jdev/miniprofiler/MiniProfilerSpec.groovy
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013 the original author or authors.
+ * Copyright 2013-2023 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/core/src/test/groovy/io/jdev/miniprofiler/ProfilerTextSpec.groovy
+++ b/core/src/test/groovy/io/jdev/miniprofiler/ProfilerTextSpec.groovy
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015 the original author or authors.
+ * Copyright 2015-2025 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/core/src/test/groovy/io/jdev/miniprofiler/ProfilerUiConfigSpec.groovy
+++ b/core/src/test/groovy/io/jdev/miniprofiler/ProfilerUiConfigSpec.groovy
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016 the original author or authors.
+ * Copyright 2016-2022 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/core/src/test/groovy/io/jdev/miniprofiler/ScriptTagWriterSpec.groovy
+++ b/core/src/test/groovy/io/jdev/miniprofiler/ScriptTagWriterSpec.groovy
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016 the original author or authors.
+ * Copyright 2016-2026 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/core/src/test/groovy/io/jdev/miniprofiler/StaticProfilerProviderSpec.groovy
+++ b/core/src/test/groovy/io/jdev/miniprofiler/StaticProfilerProviderSpec.groovy
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013 the original author or authors.
+ * Copyright 2013-2017 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/core/src/test/groovy/io/jdev/miniprofiler/intercept/ProfilingInvocationHandlerSpec.groovy
+++ b/core/src/test/groovy/io/jdev/miniprofiler/intercept/ProfilingInvocationHandlerSpec.groovy
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013 the original author or authors.
+ * Copyright 2013-2015 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/core/src/test/groovy/io/jdev/miniprofiler/intercept/TestInterface.groovy
+++ b/core/src/test/groovy/io/jdev/miniprofiler/intercept/TestInterface.groovy
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013 the original author or authors.
+ * Copyright 2013-2015 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/core/src/test/groovy/io/jdev/miniprofiler/internal/CustomTimingImplSpec.groovy
+++ b/core/src/test/groovy/io/jdev/miniprofiler/internal/CustomTimingImplSpec.groovy
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013 the original author or authors.
+ * Copyright 2017-2026 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/core/src/test/groovy/io/jdev/miniprofiler/internal/ProfilerImplSpec.groovy
+++ b/core/src/test/groovy/io/jdev/miniprofiler/internal/ProfilerImplSpec.groovy
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016 the original author or authors.
+ * Copyright 2016-2026 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/core/src/test/groovy/io/jdev/miniprofiler/internal/TimingImplSpec.groovy
+++ b/core/src/test/groovy/io/jdev/miniprofiler/internal/TimingImplSpec.groovy
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017 the original author or authors.
+ * Copyright 2017-2023 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/core/src/test/groovy/io/jdev/miniprofiler/storage/MapStorageSpec.groovy
+++ b/core/src/test/groovy/io/jdev/miniprofiler/storage/MapStorageSpec.groovy
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013 the original author or authors.
+ * Copyright 2013-2026 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/core/src/test/java/io/jdev/miniprofiler/internal/AutoClosableTest.java
+++ b/core/src/test/java/io/jdev/miniprofiler/internal/AutoClosableTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013 the original author or authors.
+ * Copyright 2013-2017 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/doc/manual/manual.gradle.kts
+++ b/doc/manual/manual.gradle.kts
@@ -2,7 +2,7 @@ import java.awt.Desktop.getDesktop
 import org.gradle.jvm.toolchain.JavaToolchainService
 
 /*
- * Copyright 2015 the original author or authors.
+ * Copyright 2023-2026 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/eclipselink/eclipselink.gradle.kts
+++ b/eclipselink/eclipselink.gradle.kts
@@ -1,5 +1,5 @@
 /*
- * Copyright 2026 the original author or authors.
+ * Copyright 2014-2026 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/eclipselink/src/main/java/io/jdev/miniprofiler/eclipselink/ProfilingConnector.java
+++ b/eclipselink/src/main/java/io/jdev/miniprofiler/eclipselink/ProfilingConnector.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014 the original author or authors.
+ * Copyright 2014-2026 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/eclipselink/src/main/java/io/jdev/miniprofiler/eclipselink/ProfilingSessionCustomizer.java
+++ b/eclipselink/src/main/java/io/jdev/miniprofiler/eclipselink/ProfilingSessionCustomizer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014 the original author or authors.
+ * Copyright 2014-2026 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/eclipselink/src/main/java/io/jdev/miniprofiler/eclipselink/SessionCustomizerSupport.java
+++ b/eclipselink/src/main/java/io/jdev/miniprofiler/eclipselink/SessionCustomizerSupport.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2026 the original author or authors.
+ * Copyright 2014-2026 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/gradle/checkstyle/checkstyle-groovy.xml
+++ b/gradle/checkstyle/checkstyle-groovy.xml
@@ -1,5 +1,5 @@
 <!--
-  ~ Copyright 2009 the original author or authors.
+  ~ Copyright 2015 the original author or authors.
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/gradle/checkstyle/checkstyle.xml
+++ b/gradle/checkstyle/checkstyle.xml
@@ -1,5 +1,5 @@
 <!--
-  ~ Copyright 2010 the original author or authors.
+  ~ Copyright 2015-2026 the original author or authors.
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/gradle/codenarc/codenarc.groovy
+++ b/gradle/codenarc/codenarc.groovy
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014 the original author or authors.
+ * Copyright 2015 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/gradle/codenarc/codenarcTest.groovy
+++ b/gradle/codenarc/codenarcTest.groovy
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014 the original author or authors.
+ * Copyright 2015 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,4 +1,4 @@
-# Copyright 2023 the original author or authors.
+# Copyright 2023-2026 the original author or authors.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/gradle/plugins/build-parameters/build.gradle.kts
+++ b/gradle/plugins/build-parameters/build.gradle.kts
@@ -1,5 +1,5 @@
 /*
- * Copyright 2023 the original author or authors.
+ * Copyright 2023-2026 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/gradle/plugins/build.gradle.kts
+++ b/gradle/plugins/build.gradle.kts
@@ -1,5 +1,5 @@
 /*
- * Copyright 2023 the original author or authors.
+ * Copyright 2023-2026 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/gradle/plugins/settings.gradle.kts
+++ b/gradle/plugins/settings.gradle.kts
@@ -1,5 +1,5 @@
 /*
- * Copyright 2023 the original author or authors.
+ * Copyright 2013-2026 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/gradle/plugins/src/main/kotlin/CopyrightTask.kt
+++ b/gradle/plugins/src/main/kotlin/CopyrightTask.kt
@@ -1,0 +1,343 @@
+/*
+ * Copyright 2026 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import org.gradle.api.Action
+import org.gradle.api.DefaultTask
+import org.gradle.api.GradleException
+import org.gradle.api.file.DirectoryProperty
+import org.gradle.api.file.RegularFileProperty
+import org.gradle.api.provider.ListProperty
+import org.gradle.api.provider.Property
+import org.gradle.api.tasks.Internal
+import org.gradle.api.tasks.TaskAction
+import org.gradle.api.tasks.options.Option
+import org.gradle.work.DisableCachingByDefault
+import org.gradle.workers.WorkAction
+import org.gradle.workers.WorkParameters
+import org.gradle.workers.WorkerExecutor
+import java.io.ByteArrayOutputStream
+import java.io.File
+import javax.inject.Inject
+
+/**
+ * Scans tracked files under [scanDirectory] for a `Copyright YYYY[-YYYY] the original author or
+ * authors` header and computes the correct end year from git history. Subclasses decide what to do
+ * when a year is out of date: [UpdateCopyrightTask] rewrites the file, [VerifyCopyrightTask] fails.
+ *
+ * Files whose path lies inside any entry of [excludedDirectories] are ignored, which lets the root
+ * project's task skip everything owned by subprojects (each of which registers its own task).
+ *
+ * Per-file `git log --follow` calls are dispatched through Gradle's [WorkerExecutor] with
+ * `noIsolation()`, so multiple subprocesses run concurrently within the task.
+ */
+@DisableCachingByDefault(because = "Reads git history on every invocation.")
+abstract class CopyrightTask : DefaultTask() {
+
+    /** The git repository root. Used as the working directory for all `git` invocations. */
+    @get:Internal
+    abstract val repositoryRoot: DirectoryProperty
+
+    /** The directory this task is responsible for; only files under it are considered. */
+    @get:Internal
+    abstract val scanDirectory: DirectoryProperty
+
+    /** Subdirectories of [scanDirectory] that belong to other (sub)projects and must be skipped. */
+    @get:Internal
+    abstract val excludedDirectories: ListProperty<File>
+
+    @get:Inject
+    protected abstract val workerExecutor: WorkerExecutor
+
+    protected abstract fun onOutOfDate(file: File, updatedText: String)
+
+    protected abstract fun onFinish(
+        outOfDate: List<String>,
+        upToDate: List<String>,
+        skipped: List<String>,
+    )
+
+    @TaskAction
+    fun run() {
+        val repoRoot = repositoryRoot.get().asFile
+        val scanPrefix = repoRoot.relativeRepoPath(scanDirectory.get().asFile)
+        val excludedPrefixes = excludedDirectories.get().map { repoRoot.relativeRepoPath(it) }
+
+        val tracked = CopyrightGit.run(repoRoot, listOf("ls-files"))
+            .lineSequence()
+            .filter { it.isNotBlank() }
+            .toList()
+
+        // Phase 1: scan headers on the main thread — this is all in-memory file IO and is cheap.
+        val candidates = mutableListOf<Candidate>()
+        for (relative in tracked) {
+            if (!relative.isUnder(scanPrefix)) continue
+            if (excludedPrefixes.any { relative.isUnder(it) }) continue
+            val file = repoRoot.resolve(relative)
+            if (!file.isFile) continue
+            val original = try {
+                file.readText(Charsets.UTF_8)
+            } catch (_: Exception) {
+                continue
+            }
+            val match = COPYRIGHT_PATTERN.find(original.take(HEAD_CHARS)) ?: continue
+            val start = match.groupValues[1].toInt()
+            val existingEnd = match.groupValues[2].takeIf { it.isNotEmpty() }?.toInt()
+            candidates += Candidate(
+                relative = relative,
+                file = file,
+                original = original,
+                matchRange = match.range,
+                matchText = match.value,
+                start = start,
+                currentEnd = existingEnd ?: start,
+            )
+        }
+
+        // Phase 2: each candidate's `git log --follow` runs in a worker thread; results are
+        // written to per-file stub files in the task's temporary directory.
+        val yearsDir = File(temporaryDir, "years").apply {
+            deleteRecursively()
+            mkdirs()
+        }
+        val yearFiles = LinkedHashMap<String, File>()
+        val queue = workerExecutor.noIsolation()
+        for ((index, candidate) in candidates.withIndex()) {
+            val yearFile = File(yearsDir, "%06d.txt".format(index))
+            yearFiles[candidate.relative] = yearFile
+            val relativePath = candidate.relative
+            queue.submit(
+                SubstantiveYearRangeWorkAction::class.java,
+                object : Action<SubstantiveYearRangeWorkParameters> {
+                    override fun execute(params: SubstantiveYearRangeWorkParameters) {
+                        params.repositoryRoot.set(repoRoot)
+                        params.relativePath.set(relativePath)
+                        params.outputFile.set(yearFile)
+                    }
+                },
+            )
+        }
+        queue.await()
+
+        // Phase 3: assemble results on the main thread.
+        val outOfDate = mutableListOf<String>()
+        val upToDate = mutableListOf<String>()
+        val skipped = mutableListOf<String>()
+        for (candidate in candidates) {
+            val content = yearFiles.getValue(candidate.relative).readText().trim()
+            if (content.isEmpty()) {
+                skipped += "${candidate.relative} (no non-trivial commits)"
+                continue
+            }
+            val (firstYear, lastYear) = content.split(',').let { it[0].toInt() to it[1].toInt() }
+            if (firstYear == candidate.start && lastYear == candidate.currentEnd) {
+                upToDate += candidate.relative
+                continue
+            }
+            val replacement = formatReplacement(firstYear, lastYear)
+            val updatedText = candidate.original.replaceRange(candidate.matchRange, replacement)
+            outOfDate += "${candidate.relative}: ${candidate.matchText} -> $replacement"
+            onOutOfDate(candidate.file, updatedText)
+        }
+
+        onFinish(outOfDate, upToDate, skipped)
+    }
+
+    /** Returns [other] expressed as a forward-slash path relative to this repo root, or an empty
+     *  string when it is the repo root itself. */
+    private fun File.relativeRepoPath(other: File): String =
+        this.toPath().toAbsolutePath().normalize()
+            .relativize(other.toPath().toAbsolutePath().normalize())
+            .toString()
+            .replace(File.separatorChar, '/')
+
+    /** True when this path is equal to [prefix] or lies below it, using `/` as the separator. */
+    private fun String.isUnder(prefix: String): Boolean {
+        if (prefix.isEmpty()) return true
+        return this == prefix || this.startsWith("$prefix/")
+    }
+
+    private data class Candidate(
+        val relative: String,
+        val file: File,
+        val original: String,
+        val matchRange: IntRange,
+        val matchText: String,
+        val start: Int,
+        val currentEnd: Int,
+    )
+
+    private fun formatReplacement(firstYear: Int, lastYear: Int): String =
+        if (firstYear == lastYear) {
+            "Copyright $firstYear the original author or authors"
+        } else {
+            "Copyright $firstYear-$lastYear the original author or authors"
+        }
+
+    companion object {
+        private const val HEAD_CHARS = 2048
+
+        /** Matches `Copyright YYYY` or `Copyright YYYY-YYYY` (hyphen or en-dash) followed by the
+         *  standard project header text. Third-party headers (e.g. "Copyright 2007-2012 Arthur Blake")
+         *  are intentionally skipped. */
+        private val COPYRIGHT_PATTERN =
+            Regex("""Copyright (\d{4})(?:[\u2013\-](\d{4}))? the original author or authors""")
+    }
+}
+
+/** Rewrites stale copyright headers in place. */
+@DisableCachingByDefault(because = "Mutates source files.")
+abstract class UpdateCopyrightTask : CopyrightTask() {
+
+    @get:Internal
+    var preview: Boolean = false
+
+    @Option(option = "preview", description = "Report intended changes without modifying files.")
+    fun setPreviewOption(value: Boolean) {
+        preview = value
+    }
+
+    override fun onOutOfDate(file: File, updatedText: String) {
+        if (!preview) {
+            file.writeText(updatedText, Charsets.UTF_8)
+        }
+    }
+
+    override fun onFinish(outOfDate: List<String>, upToDate: List<String>, skipped: List<String>) {
+        logger.lifecycle("Updated: ${outOfDate.size}${if (preview) " (preview)" else ""}")
+        outOfDate.forEach { logger.lifecycle("  $it") }
+        logger.lifecycle("Unchanged: ${upToDate.size}")
+        logger.lifecycle("Skipped: ${skipped.size}")
+        skipped.forEach { logger.lifecycle("  $it") }
+    }
+}
+
+/** Fails the build if any file's copyright year is behind the last substantive change. */
+@DisableCachingByDefault(because = "Reads git history on every invocation.")
+abstract class VerifyCopyrightTask : CopyrightTask() {
+
+    override fun onOutOfDate(file: File, updatedText: String) {
+        // No-op: verification only reports; it never writes.
+    }
+
+    override fun onFinish(outOfDate: List<String>, upToDate: List<String>, skipped: List<String>) {
+        logger.lifecycle("Checked ${upToDate.size + outOfDate.size} file(s) for copyright year drift.")
+        if (skipped.isNotEmpty()) {
+            logger.lifecycle("Skipped: ${skipped.size}")
+            skipped.forEach { logger.lifecycle("  $it") }
+        }
+        if (outOfDate.isNotEmpty()) {
+            logger.error("${outOfDate.size} file(s) have out-of-date copyright years:")
+            outOfDate.forEach { logger.error("  $it") }
+            throw GradleException(
+                "Copyright headers are out of date. Run ':updateCopyright' to fix."
+            )
+        }
+    }
+}
+
+/** Parameters for a per-file `git log --follow` subprocess dispatched via the Worker API. */
+interface SubstantiveYearRangeWorkParameters : WorkParameters {
+    val repositoryRoot: DirectoryProperty
+    val relativePath: Property<String>
+    val outputFile: RegularFileProperty
+}
+
+/** Worker action that computes `firstYear,lastYear` for a single file and writes it (or an empty
+ *  string, if no qualifying commits exist) to [SubstantiveYearRangeWorkParameters.outputFile]. */
+abstract class SubstantiveYearRangeWorkAction : WorkAction<SubstantiveYearRangeWorkParameters> {
+    override fun execute() {
+        val repoRoot = parameters.repositoryRoot.get().asFile
+        val relative = parameters.relativePath.get()
+        val range = CopyrightGit.substantiveYearRange(repoRoot, relative)
+        parameters.outputFile.get().asFile.apply {
+            parentFile.mkdirs()
+            writeText(range?.let { (first, last) -> "$first,$last" } ?: "")
+        }
+    }
+}
+
+/** Helpers that shell out to git. Kept as a top-level object so both [CopyrightTask] and the
+ *  [LastSubstantiveYearWorkAction] workers can use the same implementation. */
+internal object CopyrightGit {
+
+    private const val COMMIT_MARKER = "|COMMIT|"
+
+    /** Matches on whole words so that class names like `CommandFormatter` or tool names
+     *  like `checkstyle` do not cause a substantive commit to be mistaken for a cosmetic one. */
+    private val TRIVIAL_SUBJECT =
+        Regex(
+            """\b(?:format|lint|style|whitespace|prettier|typo|reformat|cleanup|cosmetic)\b""",
+            RegexOption.IGNORE_CASE,
+        )
+
+    /** Returns `(firstYear, lastYear)` covering the substantive-change history of [relative], or
+     *  `null` if the file has no non-trivial, non-rename commits. `git log` lists newest first, so
+     *  the first accepted entry gives `lastYear` and the final one gives `firstYear`. */
+    fun substantiveYearRange(repoRoot: File, relative: String): Pair<Int, Int>? {
+        val output = run(
+            repoRoot,
+            listOf(
+                "log", "--follow",
+                "--format=$COMMIT_MARKER%cd|%s",
+                "--date=format:%Y",
+                "--name-status", "--find-renames",
+                "--", relative,
+            ),
+        )
+
+        var currentYear: Int? = null
+        var currentTrivial = false
+        var lastYear: Int? = null
+        var firstYear: Int? = null
+
+        for (line in output.lineSequence()) {
+            if (line.isBlank()) continue
+            if (line.startsWith(COMMIT_MARKER)) {
+                val rest = line.removePrefix(COMMIT_MARKER)
+                val sep = rest.indexOf('|')
+                if (sep < 0) {
+                    currentYear = null
+                    continue
+                }
+                currentYear = rest.substring(0, sep).toIntOrNull()
+                currentTrivial = TRIVIAL_SUBJECT.containsMatchIn(rest.substring(sep + 1))
+                continue
+            }
+            val year = currentYear ?: continue
+            if (currentTrivial) continue
+            // Skip pure renames/copies (R100, C100) where the file's content did not change.
+            if (line.startsWith("R100\t") || line.startsWith("C100\t")) continue
+            if (lastYear == null) lastYear = year
+            firstYear = year
+        }
+        return if (lastYear != null && firstYear != null) firstYear to lastYear else null
+    }
+
+    fun run(dir: File, args: List<String>): String {
+        val process = ProcessBuilder(listOf("git") + args)
+            .directory(dir)
+            .redirectErrorStream(false)
+            .start()
+        val stdout = ByteArrayOutputStream()
+        process.inputStream.copyTo(stdout)
+        val exit = process.waitFor()
+        if (exit != 0) {
+            val err = process.errorStream.bufferedReader().readText()
+            throw RuntimeException("git ${args.joinToString(" ")} failed ($exit): $err")
+        }
+        return stdout.toString(Charsets.UTF_8)
+    }
+}

--- a/gradle/plugins/src/main/kotlin/CopyrightTask.kt
+++ b/gradle/plugins/src/main/kotlin/CopyrightTask.kt
@@ -58,6 +58,13 @@ abstract class CopyrightTask : DefaultTask() {
     @get:Internal
     abstract val excludedDirectories: ListProperty<File>
 
+    /** When true, only the end (last) year is checked: a file is treated as out of date solely
+     *  when its declared end year is behind the latest substantive commit. The start year is
+     *  preserved as written. Intended for shallow CI clones where the file's true first commit
+     *  isn't reachable. */
+    @get:Internal
+    abstract val upperBoundOnly: Property<Boolean>
+
     @get:Inject
     protected abstract val workerExecutor: WorkerExecutor
 
@@ -132,6 +139,7 @@ abstract class CopyrightTask : DefaultTask() {
         queue.await()
 
         // Phase 3: assemble results on the main thread.
+        val lenient = upperBoundOnly.getOrElse(false)
         val outOfDate = mutableListOf<String>()
         val upToDate = mutableListOf<String>()
         val skipped = mutableListOf<String>()
@@ -142,11 +150,18 @@ abstract class CopyrightTask : DefaultTask() {
                 continue
             }
             val (firstYear, lastYear) = content.split(',').let { it[0].toInt() to it[1].toInt() }
-            if (firstYear == candidate.start && lastYear == candidate.currentEnd) {
+            val driftedStart = !lenient && firstYear != candidate.start
+            // In strict mode the end year must match exactly. In lenient mode (shallow CI clones)
+            // we only flag headers that are *behind* the most recent commit — claiming a later
+            // year than git can see is permitted because git can't see far enough to refute it.
+            val driftedEnd = if (lenient) lastYear > candidate.currentEnd else lastYear != candidate.currentEnd
+            if (!driftedStart && !driftedEnd) {
                 upToDate += candidate.relative
                 continue
             }
-            val replacement = formatReplacement(firstYear, lastYear)
+            val newStart = if (lenient) candidate.start else firstYear
+            val newEnd = if (lenient) maxOf(lastYear, candidate.currentEnd) else lastYear
+            val replacement = formatReplacement(newStart, newEnd)
             val updatedText = candidate.original.replaceRange(candidate.matchRange, replacement)
             outOfDate += "${candidate.relative}: ${candidate.matchText} -> $replacement"
             onOutOfDate(candidate.file, updatedText)
@@ -209,6 +224,15 @@ abstract class UpdateCopyrightTask : CopyrightTask() {
         preview = value
     }
 
+    @Option(
+        option = "upper-bound-only",
+        description = "Only update the end (last) year; preserve the existing start year. " +
+            "Useful in CI with shallow clones.",
+    )
+    fun setUpperBoundOnlyOption(value: Boolean) {
+        upperBoundOnly.set(value)
+    }
+
     override fun onOutOfDate(file: File, updatedText: String) {
         if (!preview) {
             file.writeText(updatedText, Charsets.UTF_8)
@@ -227,6 +251,15 @@ abstract class UpdateCopyrightTask : CopyrightTask() {
 /** Fails the build if any file's copyright year is behind the last substantive change. */
 @DisableCachingByDefault(because = "Reads git history on every invocation.")
 abstract class VerifyCopyrightTask : CopyrightTask() {
+
+    @Option(
+        option = "upper-bound-only",
+        description = "Only validate the end (last) year; skip first-year checks. " +
+            "Useful in CI with shallow clones.",
+    )
+    fun setUpperBoundOnlyOption(value: Boolean) {
+        upperBoundOnly.set(value)
+    }
 
     override fun onOutOfDate(file: File, updatedText: String) {
         // No-op: verification only reports; it never writes.
@@ -276,10 +309,12 @@ internal object CopyrightGit {
     private const val COMMIT_MARKER = "|COMMIT|"
 
     /** Matches on whole words so that class names like `CommandFormatter` or tool names
-     *  like `checkstyle` do not cause a substantive commit to be mistaken for a cosmetic one. */
+     *  like `checkstyle` do not cause a substantive commit to be mistaken for a cosmetic one.
+     *  `copyright` is included so that the update task's own bumping commits don't perpetually
+     *  show up as the file's most recent substantive change. */
     private val TRIVIAL_SUBJECT =
         Regex(
-            """\b(?:format|lint|style|whitespace|prettier|typo|reformat|cleanup|cosmetic)\b""",
+            """\b(?:format|lint|style|whitespace|prettier|typo|reformat|cleanup|cosmetic|copyright)\b""",
             RegexOption.IGNORE_CASE,
         )
 

--- a/gradle/plugins/src/main/kotlin/build.base.gradle.kts
+++ b/gradle/plugins/src/main/kotlin/build.base.gradle.kts
@@ -1,5 +1,5 @@
 /*
- * Copyright 2026 the original author or authors.
+ * Copyright 2013-2026 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/gradle/plugins/src/main/kotlin/build.browser-test.gradle.kts
+++ b/gradle/plugins/src/main/kotlin/build.browser-test.gradle.kts
@@ -1,5 +1,5 @@
 /*
- * Copyright 2026 the original author or authors.
+ * Copyright 2013-2026 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/gradle/plugins/src/main/kotlin/build.build-scan.gradle.kts
+++ b/gradle/plugins/src/main/kotlin/build.build-scan.gradle.kts
@@ -1,5 +1,5 @@
 /*
- * Copyright 2023 the original author or authors.
+ * Copyright 2013-2026 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/gradle/plugins/src/main/kotlin/build.checkstyle.gradle.kts
+++ b/gradle/plugins/src/main/kotlin/build.checkstyle.gradle.kts
@@ -1,5 +1,5 @@
 /*
- * Copyright 2023 the original author or authors.
+ * Copyright 2023-2026 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/gradle/plugins/src/main/kotlin/build.codenarc.gradle.kts
+++ b/gradle/plugins/src/main/kotlin/build.codenarc.gradle.kts
@@ -1,5 +1,5 @@
 /*
- * Copyright 2023 the original author or authors.
+ * Copyright 2023-2026 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/gradle/plugins/src/main/kotlin/build.copyright.gradle.kts
+++ b/gradle/plugins/src/main/kotlin/build.copyright.gradle.kts
@@ -1,0 +1,64 @@
+/*
+ * Copyright 2026 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import java.io.File
+
+plugins {
+    id("build.base")
+}
+
+// Every project (root + subprojects) gets its own pair of tasks scoped to its own directory.
+// For any project, we exclude the project directories of every descendant project, so that files
+// in nested subprojects are handled exclusively by those subprojects' tasks — no double-counting,
+// and running e.g. `:verifyCopyright` on the root aggregates naturally via Gradle's cross-project
+// task invocation.
+val thisProject = project
+val thisProjectDir: File = project.projectDir
+
+val descendantProjectDirs = provider {
+    val thisPath = thisProjectDir.toPath().toAbsolutePath().normalize()
+    rootProject.allprojects
+        .asSequence()
+        .filter { it !== thisProject }
+        .map { it.projectDir }
+        .filter { dir ->
+            val otherPath = dir.toPath().toAbsolutePath().normalize()
+            otherPath.startsWith(thisPath) && otherPath != thisPath
+        }
+        .toList()
+}
+
+tasks.register<UpdateCopyrightTask>("updateCopyright") {
+    group = "documentation"
+    description = "Updates file-header copyright years from git history for this project's directory."
+    repositoryRoot.set(rootProject.layout.projectDirectory)
+    scanDirectory.set(layout.projectDirectory)
+    excludedDirectories.set(descendantProjectDirs)
+    notCompatibleWithConfigurationCache("Shells out to git during execution.")
+}
+
+val verifyCopyright = tasks.register<VerifyCopyrightTask>("verifyCopyright") {
+    group = "verification"
+    description = "Fails if any file under this project has an out-of-date copyright year."
+    repositoryRoot.set(rootProject.layout.projectDirectory)
+    scanDirectory.set(layout.projectDirectory)
+    excludedDirectories.set(descendantProjectDirs)
+    notCompatibleWithConfigurationCache("Shells out to git during execution.")
+}
+
+tasks.named("fullCheck") {
+    dependsOn(verifyCopyright)
+}

--- a/gradle/plugins/src/main/kotlin/build.groovy-module.gradle.kts
+++ b/gradle/plugins/src/main/kotlin/build.groovy-module.gradle.kts
@@ -1,5 +1,5 @@
 /*
- * Copyright 2026 the original author or authors.
+ * Copyright 2013-2026 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/gradle/plugins/src/main/kotlin/build.java-module.gradle.kts
+++ b/gradle/plugins/src/main/kotlin/build.java-module.gradle.kts
@@ -1,5 +1,5 @@
 /*
- * Copyright 2023 the original author or authors.
+ * Copyright 2023-2026 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/gradle/plugins/src/main/kotlin/build.nexus-publish.gradle.kts
+++ b/gradle/plugins/src/main/kotlin/build.nexus-publish.gradle.kts
@@ -1,5 +1,5 @@
 /*
- * Copyright 2023 the original author or authors.
+ * Copyright 2013-2026 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/gradle/plugins/src/main/kotlin/build.publish.gradle.kts
+++ b/gradle/plugins/src/main/kotlin/build.publish.gradle.kts
@@ -1,5 +1,5 @@
 /*
- * Copyright 2023 the original author or authors.
+ * Copyright 2023-2026 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/gradle/plugins/src/main/kotlin/build.scenario-test.gradle.kts
+++ b/gradle/plugins/src/main/kotlin/build.scenario-test.gradle.kts
@@ -1,5 +1,5 @@
 /*
- * Copyright 2026 the original author or authors.
+ * Copyright 2013-2026 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/gradlew.bat
+++ b/gradlew.bat
@@ -1,5 +1,5 @@
 @rem
-@rem Copyright 2015 the original author or authors.
+@rem Copyright 2013-2026 the original author or authors.
 @rem
 @rem Licensed under the Apache License, Version 2.0 (the "License");
 @rem you may not use this file except in compliance with the License.

--- a/hibernate/hibernate.gradle.kts
+++ b/hibernate/hibernate.gradle.kts
@@ -1,5 +1,5 @@
 /*
- * Copyright 2026 the original author or authors.
+ * Copyright 2014-2026 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hibernate/src/main/java/io/jdev/miniprofiler/hibernate/ProfilingDatasourceConnectionProvider.java
+++ b/hibernate/src/main/java/io/jdev/miniprofiler/hibernate/ProfilingDatasourceConnectionProvider.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014 the original author or authors.
+ * Copyright 2014-2026 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/jakarta-ee/jakarta-ee.gradle.kts
+++ b/jakarta-ee/jakarta-ee.gradle.kts
@@ -1,5 +1,5 @@
 /*
- * Copyright 2026 the original author or authors.
+ * Copyright 2014-2026 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/jakarta-ee/src/integrationTest/java/io/jdev/miniprofiler/jakarta/ee/ProfiledClassLevelService.java
+++ b/jakarta-ee/src/integrationTest/java/io/jdev/miniprofiler/jakarta/ee/ProfiledClassLevelService.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2026 the original author or authors.
+ * Copyright 2013-2026 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/jakarta-ee/src/integrationTest/java/io/jdev/miniprofiler/jakarta/ee/ProfiledService.java
+++ b/jakarta-ee/src/integrationTest/java/io/jdev/miniprofiler/jakarta/ee/ProfiledService.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2026 the original author or authors.
+ * Copyright 2013-2026 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/jakarta-ee/src/main/java/io/jdev/miniprofiler/jakarta/ee/DefaultCdiProfilerProvider.java
+++ b/jakarta-ee/src/main/java/io/jdev/miniprofiler/jakarta/ee/DefaultCdiProfilerProvider.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2026 the original author or authors.
+ * Copyright 2013-2026 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/jakarta-ee/src/main/java/io/jdev/miniprofiler/jakarta/ee/Profiled.java
+++ b/jakarta-ee/src/main/java/io/jdev/miniprofiler/jakarta/ee/Profiled.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2026 the original author or authors.
+ * Copyright 2013-2026 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/jakarta-ee/src/main/java/io/jdev/miniprofiler/jakarta/ee/ProfilingEJBInterceptor.java
+++ b/jakarta-ee/src/main/java/io/jdev/miniprofiler/jakarta/ee/ProfilingEJBInterceptor.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2026 the original author or authors.
+ * Copyright 2014-2026 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/jakarta-ee/src/scenarioTestFixtures/groovy/io/jdev/miniprofiler/scenariotest/Glassfish7ContainerManager.groovy
+++ b/jakarta-ee/src/scenarioTestFixtures/groovy/io/jdev/miniprofiler/scenariotest/Glassfish7ContainerManager.groovy
@@ -1,5 +1,5 @@
 /*
- * Copyright 2026 the original author or authors.
+ * Copyright 2013-2026 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/jakarta-ee/src/scenarioTestFixtures/groovy/io/jdev/miniprofiler/scenariotest/Wildfly27ContainerManager.groovy
+++ b/jakarta-ee/src/scenarioTestFixtures/groovy/io/jdev/miniprofiler/scenariotest/Wildfly27ContainerManager.groovy
@@ -1,5 +1,5 @@
 /*
- * Copyright 2026 the original author or authors.
+ * Copyright 2013-2026 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/jakarta-ee/src/test/groovy/io/jdev/miniprofiler/jakarta/ee/ProfilingEJBInterceptorSpec.groovy
+++ b/jakarta-ee/src/test/groovy/io/jdev/miniprofiler/jakarta/ee/ProfilingEJBInterceptorSpec.groovy
@@ -1,5 +1,5 @@
 /*
- * Copyright 2026 the original author or authors.
+ * Copyright 2014-2026 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/jakarta-servlet/jakarta-servlet.gradle.kts
+++ b/jakarta-servlet/jakarta-servlet.gradle.kts
@@ -1,5 +1,5 @@
 /*
- * Copyright 2026 the original author or authors.
+ * Copyright 2014-2026 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/jakarta-servlet/src/browserTest/groovy/io/jdev/miniprofiler/jakarta/servlet/JakartaServletFilterBrowserSpec.groovy
+++ b/jakarta-servlet/src/browserTest/groovy/io/jdev/miniprofiler/jakarta/servlet/JakartaServletFilterBrowserSpec.groovy
@@ -1,5 +1,5 @@
 /*
- * Copyright 2026 the original author or authors.
+ * Copyright 2013-2026 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/jakarta-servlet/src/integrationTest/groovy/io/jdev/miniprofiler/jakarta/servlet/ProfilingFilterIntegrationSpec.groovy
+++ b/jakarta-servlet/src/integrationTest/groovy/io/jdev/miniprofiler/jakarta/servlet/ProfilingFilterIntegrationSpec.groovy
@@ -1,5 +1,5 @@
 /*
- * Copyright 2026 the original author or authors.
+ * Copyright 2013-2026 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/jakarta-servlet/src/main/java/io/jdev/miniprofiler/jakarta/servlet/ProfilingFilter.java
+++ b/jakarta-servlet/src/main/java/io/jdev/miniprofiler/jakarta/servlet/ProfilingFilter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2026 the original author or authors.
+ * Copyright 2013-2026 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/jakarta-servlet/src/main/java/io/jdev/miniprofiler/jakarta/servlet/ServletUserProviderLocator.java
+++ b/jakarta-servlet/src/main/java/io/jdev/miniprofiler/jakarta/servlet/ServletUserProviderLocator.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2026 the original author or authors.
+ * Copyright 2013-2026 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/jakarta-servlet/src/main/java/io/jdev/miniprofiler/jakarta/servlet/jsp/ScriptTag.java
+++ b/jakarta-servlet/src/main/java/io/jdev/miniprofiler/jakarta/servlet/jsp/ScriptTag.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2026 the original author or authors.
+ * Copyright 2018-2026 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/jakarta-servlet/src/main/resources/META-INF/miniprofiler.tld
+++ b/jakarta-servlet/src/main/resources/META-INF/miniprofiler.tld
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-  ~ Copyright 2026 the original author or authors.
+  ~ Copyright 2018-2026 the original author or authors.
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/jakarta-servlet/src/scenarioTestFixtures/groovy/io/jdev/miniprofiler/scenariotest/Jetty12ContainerManager.groovy
+++ b/jakarta-servlet/src/scenarioTestFixtures/groovy/io/jdev/miniprofiler/scenariotest/Jetty12ContainerManager.groovy
@@ -1,5 +1,5 @@
 /*
- * Copyright 2026 the original author or authors.
+ * Copyright 2013-2026 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/jakarta-servlet/src/test/groovy/io/jdev/miniprofiler/jakarta/servlet/ProfilingFilterSpec.groovy
+++ b/jakarta-servlet/src/test/groovy/io/jdev/miniprofiler/jakarta/servlet/ProfilingFilterSpec.groovy
@@ -1,5 +1,5 @@
 /*
- * Copyright 2026 the original author or authors.
+ * Copyright 2014-2026 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/jakarta-servlet/src/test/groovy/io/jdev/miniprofiler/jakarta/servlet/jsp/ScriptTagSpec.groovy
+++ b/jakarta-servlet/src/test/groovy/io/jdev/miniprofiler/jakarta/servlet/jsp/ScriptTagSpec.groovy
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018 the original author or authors.
+ * Copyright 2018-2026 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/jakarta-servlet/src/test/groovy/io/jdev/miniprofiler/test/TestStorage.groovy
+++ b/jakarta-servlet/src/test/groovy/io/jdev/miniprofiler/test/TestStorage.groovy
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014 the original author or authors.
+ * Copyright 2013-2017 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/javax-ee/javax-ee.gradle.kts
+++ b/javax-ee/javax-ee.gradle.kts
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018 the original author or authors.
+ * Copyright 2014-2026 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/javax-ee/src/integrationTest/java/io/jdev/miniprofiler/javax/ee/ProfiledClassLevelService.java
+++ b/javax-ee/src/integrationTest/java/io/jdev/miniprofiler/javax/ee/ProfiledClassLevelService.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2026 the original author or authors.
+ * Copyright 2013-2026 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/javax-ee/src/integrationTest/java/io/jdev/miniprofiler/javax/ee/ProfiledService.java
+++ b/javax-ee/src/integrationTest/java/io/jdev/miniprofiler/javax/ee/ProfiledService.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2026 the original author or authors.
+ * Copyright 2013-2026 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/javax-ee/src/main/java/io/jdev/miniprofiler/javax/ee/DefaultCdiProfilerProvider.java
+++ b/javax-ee/src/main/java/io/jdev/miniprofiler/javax/ee/DefaultCdiProfilerProvider.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014 the original author or authors.
+ * Copyright 2013-2026 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/javax-ee/src/main/java/io/jdev/miniprofiler/javax/ee/Profiled.java
+++ b/javax-ee/src/main/java/io/jdev/miniprofiler/javax/ee/Profiled.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014 the original author or authors.
+ * Copyright 2013-2026 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/javax-ee/src/main/java/io/jdev/miniprofiler/javax/ee/ProfilingEJBInterceptor.java
+++ b/javax-ee/src/main/java/io/jdev/miniprofiler/javax/ee/ProfilingEJBInterceptor.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014 the original author or authors.
+ * Copyright 2014-2026 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/javax-ee/src/scenarioTestFixtures/groovy/io/jdev/miniprofiler/scenariotest/Glassfish4ContainerManager.groovy
+++ b/javax-ee/src/scenarioTestFixtures/groovy/io/jdev/miniprofiler/scenariotest/Glassfish4ContainerManager.groovy
@@ -1,5 +1,5 @@
 /*
- * Copyright 2026 the original author or authors.
+ * Copyright 2013-2026 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/javax-ee/src/scenarioTestFixtures/groovy/io/jdev/miniprofiler/scenariotest/Wildfly10ContainerManager.groovy
+++ b/javax-ee/src/scenarioTestFixtures/groovy/io/jdev/miniprofiler/scenariotest/Wildfly10ContainerManager.groovy
@@ -1,5 +1,5 @@
 /*
- * Copyright 2026 the original author or authors.
+ * Copyright 2013-2026 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/javax-ee/src/test/groovy/io/jdev/miniprofiler/javax/ee/ProfilingEJBInterceptorSpec.groovy
+++ b/javax-ee/src/test/groovy/io/jdev/miniprofiler/javax/ee/ProfilingEJBInterceptorSpec.groovy
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014 the original author or authors.
+ * Copyright 2014-2026 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/javax-servlet/javax-servlet.gradle.kts
+++ b/javax-servlet/javax-servlet.gradle.kts
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015 the original author or authors.
+ * Copyright 2014-2026 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/javax-servlet/src/browserTest/groovy/io/jdev/miniprofiler/javax/servlet/JavaxServletFilterBrowserSpec.groovy
+++ b/javax-servlet/src/browserTest/groovy/io/jdev/miniprofiler/javax/servlet/JavaxServletFilterBrowserSpec.groovy
@@ -1,5 +1,5 @@
 /*
- * Copyright 2026 the original author or authors.
+ * Copyright 2013-2026 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/javax-servlet/src/integrationTest/groovy/io/jdev/miniprofiler/javax/servlet/ProfilingFilterIntegrationSpec.groovy
+++ b/javax-servlet/src/integrationTest/groovy/io/jdev/miniprofiler/javax/servlet/ProfilingFilterIntegrationSpec.groovy
@@ -1,5 +1,5 @@
 /*
- * Copyright 2026 the original author or authors.
+ * Copyright 2013-2026 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/javax-servlet/src/main/java/io/jdev/miniprofiler/javax/servlet/ProfilingFilter.java
+++ b/javax-servlet/src/main/java/io/jdev/miniprofiler/javax/servlet/ProfilingFilter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013 the original author or authors.
+ * Copyright 2013-2026 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/javax-servlet/src/main/java/io/jdev/miniprofiler/javax/servlet/ServletUserProviderLocator.java
+++ b/javax-servlet/src/main/java/io/jdev/miniprofiler/javax/servlet/ServletUserProviderLocator.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2026 the original author or authors.
+ * Copyright 2013-2026 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/javax-servlet/src/main/java/io/jdev/miniprofiler/javax/servlet/jsp/ScriptTag.java
+++ b/javax-servlet/src/main/java/io/jdev/miniprofiler/javax/servlet/jsp/ScriptTag.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018 the original author or authors.
+ * Copyright 2018-2026 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/javax-servlet/src/main/resources/META-INF/miniprofiler.tld
+++ b/javax-servlet/src/main/resources/META-INF/miniprofiler.tld
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-  ~ Copyright 2018 the original author or authors.
+  ~ Copyright 2018-2026 the original author or authors.
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/javax-servlet/src/scenarioTestFixtures/groovy/io/jdev/miniprofiler/scenariotest/Jetty9ContainerManager.groovy
+++ b/javax-servlet/src/scenarioTestFixtures/groovy/io/jdev/miniprofiler/scenariotest/Jetty9ContainerManager.groovy
@@ -1,5 +1,5 @@
 /*
- * Copyright 2026 the original author or authors.
+ * Copyright 2013-2026 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/javax-servlet/src/test/groovy/io/jdev/miniprofiler/javax/servlet/ProfilingFilterSpec.groovy
+++ b/javax-servlet/src/test/groovy/io/jdev/miniprofiler/javax/servlet/ProfilingFilterSpec.groovy
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014 the original author or authors.
+ * Copyright 2014-2026 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/javax-servlet/src/test/groovy/io/jdev/miniprofiler/javax/servlet/jsp/ScriptTagSpec.groovy
+++ b/javax-servlet/src/test/groovy/io/jdev/miniprofiler/javax/servlet/jsp/ScriptTagSpec.groovy
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018 the original author or authors.
+ * Copyright 2018-2026 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/javax-servlet/src/test/groovy/io/jdev/miniprofiler/test/TestStorage.groovy
+++ b/javax-servlet/src/test/groovy/io/jdev/miniprofiler/test/TestStorage.groovy
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014 the original author or authors.
+ * Copyright 2013-2017 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/jooq/jooq.gradle.kts
+++ b/jooq/jooq.gradle.kts
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017 the original author or authors.
+ * Copyright 2013-2026 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/jooq/src/main/java/io/jdev/miniprofiler/jooq/MiniProfilerExecuteListener.java
+++ b/jooq/src/main/java/io/jdev/miniprofiler/jooq/MiniProfilerExecuteListener.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017 the original author or authors.
+ * Copyright 2017-2026 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/jooq/src/main/java/io/jdev/miniprofiler/jooq/MiniProfilerExecuteListenerProvider.java
+++ b/jooq/src/main/java/io/jdev/miniprofiler/jooq/MiniProfilerExecuteListenerProvider.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017 the original author or authors.
+ * Copyright 2017-2026 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/jooq/src/main/java/io/jdev/miniprofiler/jooq/MiniProfilerJooqUtil.java
+++ b/jooq/src/main/java/io/jdev/miniprofiler/jooq/MiniProfilerJooqUtil.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018 the original author or authors.
+ * Copyright 2018-2026 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/jooq/src/test/groovy/io/jdev/miniprofiler/jooq/MiniProfilerExecuteListenerSpec.groovy
+++ b/jooq/src/test/groovy/io/jdev/miniprofiler/jooq/MiniProfilerExecuteListenerSpec.groovy
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017 the original author or authors.
+ * Copyright 2017-2026 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/jooq/src/test/groovy/io/jdev/miniprofiler/jooq/MiniProfilerJooqUtilSpec.groovy
+++ b/jooq/src/test/groovy/io/jdev/miniprofiler/jooq/MiniProfilerJooqUtilSpec.groovy
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018 the original author or authors.
+ * Copyright 2026 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/miniprofiler-jvm.gradle.kts
+++ b/miniprofiler-jvm.gradle.kts
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018 the original author or authors.
+ * Copyright 2013-2026 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/miniprofiler-jvm.gradle.kts
+++ b/miniprofiler-jvm.gradle.kts
@@ -22,4 +22,6 @@ plugins {
 allprojects {
     group = "io.jdev.miniprofiler"
     version = "0.12.0-SNAPSHOT"
+
+    apply(plugin = "build.copyright")
 }

--- a/ratpack/ratpack.gradle.kts
+++ b/ratpack/ratpack.gradle.kts
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015 the original author or authors.
+ * Copyright 2013-2026 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/ratpack/src/browserTest/groovy/io/jdev/miniprofiler/ratpack/RatpackBrowserSpec.groovy
+++ b/ratpack/src/browserTest/groovy/io/jdev/miniprofiler/ratpack/RatpackBrowserSpec.groovy
@@ -1,5 +1,5 @@
 /*
- * Copyright 2026 the original author or authors.
+ * Copyright 2013-2026 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/ratpack/src/main/java/io/jdev/miniprofiler/ratpack/AsyncStorage.java
+++ b/ratpack/src/main/java/io/jdev/miniprofiler/ratpack/AsyncStorage.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013 the original author or authors.
+ * Copyright 2023-2026 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/ratpack/src/main/java/io/jdev/miniprofiler/ratpack/DiscardMiniProfilerHandler.java
+++ b/ratpack/src/main/java/io/jdev/miniprofiler/ratpack/DiscardMiniProfilerHandler.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015 the original author or authors.
+ * Copyright 2015-2026 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/ratpack/src/main/java/io/jdev/miniprofiler/ratpack/EagerMiniProfilerExecInitializer.java
+++ b/ratpack/src/main/java/io/jdev/miniprofiler/ratpack/EagerMiniProfilerExecInitializer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016 the original author or authors.
+ * Copyright 2016-2026 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/ratpack/src/main/java/io/jdev/miniprofiler/ratpack/MiniProfilerAjaxHeaderHandler.java
+++ b/ratpack/src/main/java/io/jdev/miniprofiler/ratpack/MiniProfilerAjaxHeaderHandler.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015 the original author or authors.
+ * Copyright 2015-2026 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/ratpack/src/main/java/io/jdev/miniprofiler/ratpack/MiniProfilerExecInitializer.java
+++ b/ratpack/src/main/java/io/jdev/miniprofiler/ratpack/MiniProfilerExecInitializer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015 the original author or authors.
+ * Copyright 2015-2026 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/ratpack/src/main/java/io/jdev/miniprofiler/ratpack/MiniProfilerH2Module.java
+++ b/ratpack/src/main/java/io/jdev/miniprofiler/ratpack/MiniProfilerH2Module.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015 the original author or authors.
+ * Copyright 2013-2026 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/ratpack/src/main/java/io/jdev/miniprofiler/ratpack/MiniProfilerHandlerChain.java
+++ b/ratpack/src/main/java/io/jdev/miniprofiler/ratpack/MiniProfilerHandlerChain.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015 the original author or authors.
+ * Copyright 2013-2026 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/ratpack/src/main/java/io/jdev/miniprofiler/ratpack/MiniProfilerHikariModule.java
+++ b/ratpack/src/main/java/io/jdev/miniprofiler/ratpack/MiniProfilerHikariModule.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015 the original author or authors.
+ * Copyright 2015-2026 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/ratpack/src/main/java/io/jdev/miniprofiler/ratpack/MiniProfilerModule.java
+++ b/ratpack/src/main/java/io/jdev/miniprofiler/ratpack/MiniProfilerModule.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015 the original author or authors.
+ * Copyright 2015-2026 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/ratpack/src/main/java/io/jdev/miniprofiler/ratpack/MiniProfilerRatpackUtil.java
+++ b/ratpack/src/main/java/io/jdev/miniprofiler/ratpack/MiniProfilerRatpackUtil.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016 the original author or authors.
+ * Copyright 2016-2026 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/ratpack/src/main/java/io/jdev/miniprofiler/ratpack/MiniProfilerResourceHandler.java
+++ b/ratpack/src/main/java/io/jdev/miniprofiler/ratpack/MiniProfilerResourceHandler.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015 the original author or authors.
+ * Copyright 2015-2026 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/ratpack/src/main/java/io/jdev/miniprofiler/ratpack/MiniProfilerResultsHandler.java
+++ b/ratpack/src/main/java/io/jdev/miniprofiler/ratpack/MiniProfilerResultsHandler.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015 the original author or authors.
+ * Copyright 2015-2026 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/ratpack/src/main/java/io/jdev/miniprofiler/ratpack/MiniProfilerStartProfilingHandler.java
+++ b/ratpack/src/main/java/io/jdev/miniprofiler/ratpack/MiniProfilerStartProfilingHandler.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016 the original author or authors.
+ * Copyright 2016-2026 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/ratpack/src/main/java/io/jdev/miniprofiler/ratpack/MiniProfilerStartProfilingHandlers.java
+++ b/ratpack/src/main/java/io/jdev/miniprofiler/ratpack/MiniProfilerStartProfilingHandlers.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016 the original author or authors.
+ * Copyright 2013-2026 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/ratpack/src/main/java/io/jdev/miniprofiler/ratpack/ProfilerStoreOption.java
+++ b/ratpack/src/main/java/io/jdev/miniprofiler/ratpack/ProfilerStoreOption.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015 the original author or authors.
+ * Copyright 2013-2026 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/ratpack/src/main/java/io/jdev/miniprofiler/ratpack/RatpackContextProfilerProvider.java
+++ b/ratpack/src/main/java/io/jdev/miniprofiler/ratpack/RatpackContextProfilerProvider.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015 the original author or authors.
+ * Copyright 2015-2026 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/ratpack/src/main/java/io/jdev/miniprofiler/ratpack/StoreMiniProfilerHandler.java
+++ b/ratpack/src/main/java/io/jdev/miniprofiler/ratpack/StoreMiniProfilerHandler.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015 the original author or authors.
+ * Copyright 2015-2026 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/ratpack/src/test/groovy/io/jdev/miniprofiler/ratpack/EagerMiniProfilerExecInterceptorSpec.groovy
+++ b/ratpack/src/test/groovy/io/jdev/miniprofiler/ratpack/EagerMiniProfilerExecInterceptorSpec.groovy
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015 the original author or authors.
+ * Copyright 2015-2017 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/ratpack/src/test/groovy/io/jdev/miniprofiler/ratpack/MiniProfilerExecInitializerSpec.groovy
+++ b/ratpack/src/test/groovy/io/jdev/miniprofiler/ratpack/MiniProfilerExecInitializerSpec.groovy
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015 the original author or authors.
+ * Copyright 2015-2026 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/ratpack/src/test/groovy/io/jdev/miniprofiler/ratpack/MiniProfilerRatpackUtilSpec.groovy
+++ b/ratpack/src/test/groovy/io/jdev/miniprofiler/ratpack/MiniProfilerRatpackUtilSpec.groovy
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016 the original author or authors.
+ * Copyright 2016-2026 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/ratpack/src/test/groovy/io/jdev/miniprofiler/ratpack/MiniProfilerResultsHandlerSpec.groovy
+++ b/ratpack/src/test/groovy/io/jdev/miniprofiler/ratpack/MiniProfilerResultsHandlerSpec.groovy
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015 the original author or authors.
+ * Copyright 2015-2023 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/ratpack/src/test/groovy/io/jdev/miniprofiler/ratpack/ModuleSpecs.groovy
+++ b/ratpack/src/test/groovy/io/jdev/miniprofiler/ratpack/ModuleSpecs.groovy
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015 the original author or authors.
+ * Copyright 2015-2026 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/ratpack/src/test/groovy/io/jdev/miniprofiler/ratpack/RatpackIntegSpec.groovy
+++ b/ratpack/src/test/groovy/io/jdev/miniprofiler/ratpack/RatpackIntegSpec.groovy
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015 the original author or authors.
+ * Copyright 2015-2018 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/scenario-test/glassfish4/glassfish4.gradle.kts
+++ b/scenario-test/glassfish4/glassfish4.gradle.kts
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018 the original author or authors.
+ * Copyright 2014-2026 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/scenario-test/glassfish4/src/main/java/io/jdev/miniprofiler/glassfish4/funtest/IndexServlet.java
+++ b/scenario-test/glassfish4/src/main/java/io/jdev/miniprofiler/glassfish4/funtest/IndexServlet.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014 the original author or authors.
+ * Copyright 2014-2015 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/scenario-test/glassfish4/src/main/java/io/jdev/miniprofiler/glassfish4/funtest/Person.java
+++ b/scenario-test/glassfish4/src/main/java/io/jdev/miniprofiler/glassfish4/funtest/Person.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014 the original author or authors.
+ * Copyright 2014-2015 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/scenario-test/glassfish4/src/main/java/io/jdev/miniprofiler/glassfish4/funtest/PersonService.java
+++ b/scenario-test/glassfish4/src/main/java/io/jdev/miniprofiler/glassfish4/funtest/PersonService.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014 the original author or authors.
+ * Copyright 2013-2015 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/scenario-test/glassfish4/src/main/java/io/jdev/miniprofiler/glassfish4/funtest/PersonServiceImpl.java
+++ b/scenario-test/glassfish4/src/main/java/io/jdev/miniprofiler/glassfish4/funtest/PersonServiceImpl.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014 the original author or authors.
+ * Copyright 2014-2026 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/scenario-test/glassfish4/src/main/java/io/jdev/miniprofiler/glassfish4/funtest/SecureServlet.java
+++ b/scenario-test/glassfish4/src/main/java/io/jdev/miniprofiler/glassfish4/funtest/SecureServlet.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2026 the original author or authors.
+ * Copyright 2014-2026 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/scenario-test/glassfish4/src/main/java/io/jdev/miniprofiler/glassfish4/funtest/Startup.java
+++ b/scenario-test/glassfish4/src/main/java/io/jdev/miniprofiler/glassfish4/funtest/Startup.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014 the original author or authors.
+ * Copyright 2013-2015 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/scenario-test/glassfish4/src/main/resources/META-INF/persistence.xml
+++ b/scenario-test/glassfish4/src/main/resources/META-INF/persistence.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-  ~ Copyright 2014 the original author or authors.
+  ~ Copyright 2014-2026 the original author or authors.
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/scenario-test/glassfish4/src/main/webapp/WEB-INF/glassfish-web.xml
+++ b/scenario-test/glassfish4/src/main/webapp/WEB-INF/glassfish-web.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-  ~ Copyright 2026 the original author or authors.
+  ~ Copyright 2013-2026 the original author or authors.
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/scenario-test/glassfish4/src/main/webapp/WEB-INF/web.xml
+++ b/scenario-test/glassfish4/src/main/webapp/WEB-INF/web.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" ?>
 <!--
-  ~ Copyright 2013 the original author or authors.
+  ~ Copyright 2013-2026 the original author or authors.
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/scenario-test/glassfish7/glassfish7.gradle.kts
+++ b/scenario-test/glassfish7/glassfish7.gradle.kts
@@ -1,5 +1,5 @@
 /*
- * Copyright 2026 the original author or authors.
+ * Copyright 2023-2026 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/scenario-test/glassfish7/src/main/java/io/jdev/miniprofiler/glassfish7/funtest/IndexServlet.java
+++ b/scenario-test/glassfish7/src/main/java/io/jdev/miniprofiler/glassfish7/funtest/IndexServlet.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2026 the original author or authors.
+ * Copyright 2014-2026 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/scenario-test/glassfish7/src/main/java/io/jdev/miniprofiler/glassfish7/funtest/Person.java
+++ b/scenario-test/glassfish7/src/main/java/io/jdev/miniprofiler/glassfish7/funtest/Person.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2026 the original author or authors.
+ * Copyright 2014-2026 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/scenario-test/glassfish7/src/main/java/io/jdev/miniprofiler/glassfish7/funtest/PersonService.java
+++ b/scenario-test/glassfish7/src/main/java/io/jdev/miniprofiler/glassfish7/funtest/PersonService.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2026 the original author or authors.
+ * Copyright 2013-2026 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/scenario-test/glassfish7/src/main/java/io/jdev/miniprofiler/glassfish7/funtest/PersonServiceImpl.java
+++ b/scenario-test/glassfish7/src/main/java/io/jdev/miniprofiler/glassfish7/funtest/PersonServiceImpl.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2026 the original author or authors.
+ * Copyright 2014-2026 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/scenario-test/glassfish7/src/main/java/io/jdev/miniprofiler/glassfish7/funtest/Startup.java
+++ b/scenario-test/glassfish7/src/main/java/io/jdev/miniprofiler/glassfish7/funtest/Startup.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2026 the original author or authors.
+ * Copyright 2013-2026 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/scenario-test/glassfish7/src/main/resources/META-INF/persistence.xml
+++ b/scenario-test/glassfish7/src/main/resources/META-INF/persistence.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-  ~ Copyright 2026 the original author or authors.
+  ~ Copyright 2014-2026 the original author or authors.
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/scenario-test/glassfish7/src/main/webapp/WEB-INF/glassfish-web.xml
+++ b/scenario-test/glassfish7/src/main/webapp/WEB-INF/glassfish-web.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-  ~ Copyright 2026 the original author or authors.
+  ~ Copyright 2013-2026 the original author or authors.
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/scenario-test/glassfish7/src/main/webapp/WEB-INF/web.xml
+++ b/scenario-test/glassfish7/src/main/webapp/WEB-INF/web.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" ?>
 <!--
-  ~ Copyright 2026 the original author or authors.
+  ~ Copyright 2013-2026 the original author or authors.
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/scenario-test/jetty12-servlet/jetty12-servlet.gradle.kts
+++ b/scenario-test/jetty12-servlet/jetty12-servlet.gradle.kts
@@ -1,5 +1,5 @@
 /*
- * Copyright 2026 the original author or authors.
+ * Copyright 2013-2026 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/scenario-test/jetty12-servlet/src/main/java/io/jdev/miniprofiler/servlettest/Startup.java
+++ b/scenario-test/jetty12-servlet/src/main/java/io/jdev/miniprofiler/servlettest/Startup.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2026 the original author or authors.
+ * Copyright 2013-2026 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/scenario-test/jetty12-servlet/src/main/resources/miniprofiler.properties
+++ b/scenario-test/jetty12-servlet/src/main/resources/miniprofiler.properties
@@ -1,5 +1,5 @@
 #
-# Copyright 2016 the original author or authors.
+# Copyright 2016-2026 the original author or authors.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/scenario-test/jetty12-servlet/src/main/webapp/WEB-INF/web.xml
+++ b/scenario-test/jetty12-servlet/src/main/webapp/WEB-INF/web.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" ?>
 <!--
-  ~ Copyright 2026 the original author or authors.
+  ~ Copyright 2013-2026 the original author or authors.
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/scenario-test/jetty9-servlet/jetty9-servlet.gradle.kts
+++ b/scenario-test/jetty9-servlet/jetty9-servlet.gradle.kts
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015 the original author or authors.
+ * Copyright 2013-2026 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/scenario-test/jetty9-servlet/src/main/java/io/jdev/miniprofiler/servlettest/SecureServlet.java
+++ b/scenario-test/jetty9-servlet/src/main/java/io/jdev/miniprofiler/servlettest/SecureServlet.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2026 the original author or authors.
+ * Copyright 2014-2026 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/scenario-test/jetty9-servlet/src/main/java/io/jdev/miniprofiler/servlettest/Startup.java
+++ b/scenario-test/jetty9-servlet/src/main/java/io/jdev/miniprofiler/servlettest/Startup.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013 the original author or authors.
+ * Copyright 2013-2026 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/scenario-test/jetty9-servlet/src/main/resources/miniprofiler.properties
+++ b/scenario-test/jetty9-servlet/src/main/resources/miniprofiler.properties
@@ -1,5 +1,5 @@
 #
-# Copyright 2016 the original author or authors.
+# Copyright 2016-2026 the original author or authors.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/scenario-test/jetty9-servlet/src/main/webapp/WEB-INF/web.xml
+++ b/scenario-test/jetty9-servlet/src/main/webapp/WEB-INF/web.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" ?>
 <!--
-  ~ Copyright 2013 the original author or authors.
+  ~ Copyright 2013-2026 the original author or authors.
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/scenario-test/ratpack1/ratpack1.gradle.kts
+++ b/scenario-test/ratpack1/ratpack1.gradle.kts
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015 the original author or authors.
+ * Copyright 2013-2026 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/scenario-test/ratpack1/src/main/java/io/jdev/miniprofiler/ratpack/funtest/Main.java
+++ b/scenario-test/ratpack1/src/main/java/io/jdev/miniprofiler/ratpack/funtest/Main.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015 the original author or authors.
+ * Copyright 2015-2026 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/scenario-test/ratpack1/src/main/java/io/jdev/miniprofiler/ratpack/funtest/TestHandler.java
+++ b/scenario-test/ratpack1/src/main/java/io/jdev/miniprofiler/ratpack/funtest/TestHandler.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015 the original author or authors.
+ * Copyright 2015-2026 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/scenario-test/ratpack1/src/ratpack/handlebars/index.html.hbs
+++ b/scenario-test/ratpack1/src/ratpack/handlebars/index.html.hbs
@@ -1,5 +1,5 @@
 <!--
-* Copyright 2015 the original author or authors.
+* Copyright 2015-2026 the original author or authors.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.

--- a/scenario-test/wildfly10/src/main/java/io/jdev/miniprofiler/wildfly10/funtest/IndexServlet.java
+++ b/scenario-test/wildfly10/src/main/java/io/jdev/miniprofiler/wildfly10/funtest/IndexServlet.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014 the original author or authors.
+ * Copyright 2014-2026 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/scenario-test/wildfly10/src/main/java/io/jdev/miniprofiler/wildfly10/funtest/Person.java
+++ b/scenario-test/wildfly10/src/main/java/io/jdev/miniprofiler/wildfly10/funtest/Person.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014 the original author or authors.
+ * Copyright 2014-2026 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/scenario-test/wildfly10/src/main/java/io/jdev/miniprofiler/wildfly10/funtest/PersonService.java
+++ b/scenario-test/wildfly10/src/main/java/io/jdev/miniprofiler/wildfly10/funtest/PersonService.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014 the original author or authors.
+ * Copyright 2013-2026 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/scenario-test/wildfly10/src/main/java/io/jdev/miniprofiler/wildfly10/funtest/PersonServiceImpl.java
+++ b/scenario-test/wildfly10/src/main/java/io/jdev/miniprofiler/wildfly10/funtest/PersonServiceImpl.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014 the original author or authors.
+ * Copyright 2014-2026 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/scenario-test/wildfly10/src/main/java/io/jdev/miniprofiler/wildfly10/funtest/SecureServlet.java
+++ b/scenario-test/wildfly10/src/main/java/io/jdev/miniprofiler/wildfly10/funtest/SecureServlet.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2026 the original author or authors.
+ * Copyright 2014-2026 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/scenario-test/wildfly10/src/main/java/io/jdev/miniprofiler/wildfly10/funtest/Startup.java
+++ b/scenario-test/wildfly10/src/main/java/io/jdev/miniprofiler/wildfly10/funtest/Startup.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014 the original author or authors.
+ * Copyright 2013-2026 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/scenario-test/wildfly10/src/main/resources/META-INF/persistence.xml
+++ b/scenario-test/wildfly10/src/main/resources/META-INF/persistence.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-  ~ Copyright 2014 the original author or authors.
+  ~ Copyright 2014-2026 the original author or authors.
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/scenario-test/wildfly10/src/main/webapp/WEB-INF/jboss-web.xml
+++ b/scenario-test/wildfly10/src/main/webapp/WEB-INF/jboss-web.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-  ~ Copyright 2026 the original author or authors.
+  ~ Copyright 2013-2026 the original author or authors.
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/scenario-test/wildfly10/src/main/webapp/WEB-INF/web.xml
+++ b/scenario-test/wildfly10/src/main/webapp/WEB-INF/web.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" ?>
 <!--
-  ~ Copyright 2013 the original author or authors.
+  ~ Copyright 2013-2026 the original author or authors.
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/scenario-test/wildfly10/wildfly10.gradle.kts
+++ b/scenario-test/wildfly10/wildfly10.gradle.kts
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018 the original author or authors.
+ * Copyright 2014-2026 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/scenario-test/wildfly27/src/main/java/io/jdev/miniprofiler/wildfly27/funtest/IndexServlet.java
+++ b/scenario-test/wildfly27/src/main/java/io/jdev/miniprofiler/wildfly27/funtest/IndexServlet.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2026 the original author or authors.
+ * Copyright 2014-2026 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/scenario-test/wildfly27/src/main/java/io/jdev/miniprofiler/wildfly27/funtest/Person.java
+++ b/scenario-test/wildfly27/src/main/java/io/jdev/miniprofiler/wildfly27/funtest/Person.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2026 the original author or authors.
+ * Copyright 2014-2026 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/scenario-test/wildfly27/src/main/java/io/jdev/miniprofiler/wildfly27/funtest/PersonService.java
+++ b/scenario-test/wildfly27/src/main/java/io/jdev/miniprofiler/wildfly27/funtest/PersonService.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2026 the original author or authors.
+ * Copyright 2013-2026 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/scenario-test/wildfly27/src/main/java/io/jdev/miniprofiler/wildfly27/funtest/PersonServiceImpl.java
+++ b/scenario-test/wildfly27/src/main/java/io/jdev/miniprofiler/wildfly27/funtest/PersonServiceImpl.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2026 the original author or authors.
+ * Copyright 2014-2026 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/scenario-test/wildfly27/src/main/java/io/jdev/miniprofiler/wildfly27/funtest/Startup.java
+++ b/scenario-test/wildfly27/src/main/java/io/jdev/miniprofiler/wildfly27/funtest/Startup.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2026 the original author or authors.
+ * Copyright 2013-2026 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/scenario-test/wildfly27/src/main/resources/META-INF/persistence.xml
+++ b/scenario-test/wildfly27/src/main/resources/META-INF/persistence.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-  ~ Copyright 2026 the original author or authors.
+  ~ Copyright 2014-2026 the original author or authors.
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/scenario-test/wildfly27/src/main/webapp/WEB-INF/jboss-web.xml
+++ b/scenario-test/wildfly27/src/main/webapp/WEB-INF/jboss-web.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-  ~ Copyright 2026 the original author or authors.
+  ~ Copyright 2013-2026 the original author or authors.
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/scenario-test/wildfly27/src/main/webapp/WEB-INF/web.xml
+++ b/scenario-test/wildfly27/src/main/webapp/WEB-INF/web.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" ?>
 <!--
-  ~ Copyright 2026 the original author or authors.
+  ~ Copyright 2013-2026 the original author or authors.
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/scenario-test/wildfly27/wildfly27.gradle.kts
+++ b/scenario-test/wildfly27/wildfly27.gradle.kts
@@ -1,5 +1,5 @@
 /*
- * Copyright 2026 the original author or authors.
+ * Copyright 2023-2026 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test-geb-groovy4/test-geb-groovy4.gradle.kts
+++ b/test-geb-groovy4/test-geb-groovy4.gradle.kts
@@ -1,5 +1,5 @@
 /*
- * Copyright 2026 the original author or authors.
+ * Copyright 2013-2026 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test-geb/src/browserTest/groovy/io/jdev/miniprofiler/test/geb/ProfilerTestPage.groovy
+++ b/test-geb/src/browserTest/groovy/io/jdev/miniprofiler/test/geb/ProfilerTestPage.groovy
@@ -1,5 +1,5 @@
 /*
- * Copyright 2026 the original author or authors.
+ * Copyright 2013-2026 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test-geb/src/browserTest/resources/GebConfig.groovy
+++ b/test-geb/src/browserTest/resources/GebConfig.groovy
@@ -1,5 +1,5 @@
 /*
- * Copyright 2026 the original author or authors.
+ * Copyright 2013-2026 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test-geb/src/main/groovy/io/jdev/miniprofiler/test/geb/MiniProfilerButtonModule.groovy
+++ b/test-geb/src/main/groovy/io/jdev/miniprofiler/test/geb/MiniProfilerButtonModule.groovy
@@ -1,5 +1,5 @@
 /*
- * Copyright 2023 the original author or authors.
+ * Copyright 2013-2026 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test-geb/src/main/groovy/io/jdev/miniprofiler/test/geb/MiniProfilerGapModule.groovy
+++ b/test-geb/src/main/groovy/io/jdev/miniprofiler/test/geb/MiniProfilerGapModule.groovy
@@ -1,5 +1,5 @@
 /*
- * Copyright 2023 the original author or authors.
+ * Copyright 2013-2026 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test-geb/src/main/groovy/io/jdev/miniprofiler/test/geb/MiniProfilerModule.groovy
+++ b/test-geb/src/main/groovy/io/jdev/miniprofiler/test/geb/MiniProfilerModule.groovy
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013 the original author or authors.
+ * Copyright 2013-2026 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test-geb/src/main/groovy/io/jdev/miniprofiler/test/geb/MiniProfilerPopupModule.groovy
+++ b/test-geb/src/main/groovy/io/jdev/miniprofiler/test/geb/MiniProfilerPopupModule.groovy
@@ -1,5 +1,5 @@
 /*
- * Copyright 2023 the original author or authors.
+ * Copyright 2023-2026 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test-geb/src/main/groovy/io/jdev/miniprofiler/test/geb/MiniProfilerQueriesPopupModule.groovy
+++ b/test-geb/src/main/groovy/io/jdev/miniprofiler/test/geb/MiniProfilerQueriesPopupModule.groovy
@@ -1,5 +1,5 @@
 /*
- * Copyright 2023 the original author or authors.
+ * Copyright 2023-2026 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test-geb/src/main/groovy/io/jdev/miniprofiler/test/geb/MiniProfilerQueryModule.groovy
+++ b/test-geb/src/main/groovy/io/jdev/miniprofiler/test/geb/MiniProfilerQueryModule.groovy
@@ -1,5 +1,5 @@
 /*
- * Copyright 2023 the original author or authors.
+ * Copyright 2023-2026 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test-geb/src/main/groovy/io/jdev/miniprofiler/test/geb/MiniProfilerResultModule.groovy
+++ b/test-geb/src/main/groovy/io/jdev/miniprofiler/test/geb/MiniProfilerResultModule.groovy
@@ -1,5 +1,5 @@
 /*
- * Copyright 2023 the original author or authors.
+ * Copyright 2013-2026 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test-geb/src/main/groovy/io/jdev/miniprofiler/test/geb/MiniProfilerResultsIndexPage.groovy
+++ b/test-geb/src/main/groovy/io/jdev/miniprofiler/test/geb/MiniProfilerResultsIndexPage.groovy
@@ -1,5 +1,5 @@
 /*
- * Copyright 2026 the original author or authors.
+ * Copyright 2013-2026 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test-geb/src/main/groovy/io/jdev/miniprofiler/test/geb/MiniProfilerSingleResultPage.groovy
+++ b/test-geb/src/main/groovy/io/jdev/miniprofiler/test/geb/MiniProfilerSingleResultPage.groovy
@@ -1,5 +1,5 @@
 /*
- * Copyright 2023 the original author or authors.
+ * Copyright 2013-2026 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test-geb/src/main/groovy/io/jdev/miniprofiler/test/geb/MiniProfilerTimingRowModule.groovy
+++ b/test-geb/src/main/groovy/io/jdev/miniprofiler/test/geb/MiniProfilerTimingRowModule.groovy
@@ -1,5 +1,5 @@
 /*
- * Copyright 2023 the original author or authors.
+ * Copyright 2013-2026 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/src/main/java/io/jdev/miniprofiler/test/ExpectedProfiler.java
+++ b/test/src/main/java/io/jdev/miniprofiler/test/ExpectedProfiler.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2026 the original author or authors.
+ * Copyright 2014-2026 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/src/main/java/io/jdev/miniprofiler/test/TestProfilerProvider.java
+++ b/test/src/main/java/io/jdev/miniprofiler/test/TestProfilerProvider.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013 the original author or authors.
+ * Copyright 2013-2026 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/test.gradle.kts
+++ b/test/test.gradle.kts
@@ -1,5 +1,5 @@
 /*
- * Copyright 2026 the original author or authors.
+ * Copyright 2014-2026 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/testlib-browser/src/main/resources/GebConfig.groovy
+++ b/testlib-browser/src/main/resources/GebConfig.groovy
@@ -1,5 +1,5 @@
 /*
- * Copyright 2026 the original author or authors.
+ * Copyright 2013-2026 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/testlib-browser/testlib-browser.gradle.kts
+++ b/testlib-browser/testlib-browser.gradle.kts
@@ -1,5 +1,5 @@
 /*
- * Copyright 2026 the original author or authors.
+ * Copyright 2013-2026 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/testlib-integration/src/main/java/io/jdev/miniprofiler/integtest/TestedServer.java
+++ b/testlib-integration/src/main/java/io/jdev/miniprofiler/integtest/TestedServer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2026 the original author or authors.
+ * Copyright 2013-2026 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/testlib-integration/testlib-integration.gradle.kts
+++ b/testlib-integration/testlib-integration.gradle.kts
@@ -1,5 +1,5 @@
 /*
- * Copyright 2026 the original author or authors.
+ * Copyright 2013-2026 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/viewer/src/browserTest/groovy/io/jdev/miniprofiler/viewer/MiniProfilerViewerBrowserSpec.groovy
+++ b/viewer/src/browserTest/groovy/io/jdev/miniprofiler/viewer/MiniProfilerViewerBrowserSpec.groovy
@@ -1,5 +1,5 @@
 /*
- * Copyright 2026 the original author or authors.
+ * Copyright 2013-2026 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/viewer/src/integrationTest/resources/GebConfig.groovy
+++ b/viewer/src/integrationTest/resources/GebConfig.groovy
@@ -1,5 +1,5 @@
 /*
- * Copyright 2026 the original author or authors.
+ * Copyright 2013-2026 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/viewer/src/testFixtures/groovy/io/jdev/miniprofiler/viewer/ViewerTestFixtures.groovy
+++ b/viewer/src/testFixtures/groovy/io/jdev/miniprofiler/viewer/ViewerTestFixtures.groovy
@@ -1,5 +1,5 @@
 /*
- * Copyright 2026 the original author or authors.
+ * Copyright 2013-2026 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/viewer/viewer.gradle.kts
+++ b/viewer/viewer.gradle.kts
@@ -1,5 +1,5 @@
 /*
- * Copyright 2026 the original author or authors.
+ * Copyright 2013-2026 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.


### PR DESCRIPTION
## Summary

Add `updateCopyright` and `verifyCopyright` Gradle tasks that maintain file-header copyright years from git history, and apply them to refresh every matching header in the repository.

Each project registers its own pair of tasks scoped to its own directory tree; the root project covers everything that isn't owned by a subproject (including shared sources like `test-geb/`). Running `./gradlew verifyCopyright` or `./gradlew updateCopyright` from the root aggregates across all projects via Gradle's cross-project task invocation.

## How it works

  - Header pattern: `Copyright YYYY[-YYYY] the original author or authors` (third-party headers like Arthur Blake's log4jdbc are left alone).
  - Year computation: `git log --follow --name-status --find-renames` for each file, taking the first and last commits that are neither pure renames (`R100`/`C100`) nor cosmetic (whole-word match on `format`, `lint`, `style`, `whitespace`, `prettier`, `typo`, `reformat`, `cleanup`, `cosmetic`).
  - Per-file git calls are dispatched through the Worker API, so they run concurrently within each project task.
  - `verifyCopyright` is wired into `fullCheck`, so the existing CI step that runs `./gradlew fullCheck --continue` will now fail on copyright drift.

## Usage

```
./gradlew updateCopyright             # rewrite stale headers
./gradlew updateCopyright --preview   # report without writing
./gradlew verifyCopyright             # fail on drift (used by fullCheck)
./gradlew :core:updateCopyright       # scope to a single project
```

## Commits

  1. `Add updateCopyright/verifyCopyright tasks` — the tooling.
  2. `Refresh copyright year ranges via :updateCopyright` — 230 header rewrites produced by running the new task.