### PR TITLE
Implement viewed/unviewed profiler status tracking

### DIFF
--- a/core/src/main/java/io/jdev/miniprofiler/BaseProfilerProvider.java
+++ b/core/src/main/java/io/jdev/miniprofiler/BaseProfilerProvider.java
@@ -200,7 +200,12 @@ public abstract class BaseProfilerProvider implements ProfilerProvider {
      * @param currentProfiler the profiler session to save
      */
     protected void saveProfiler(ProfilerImpl currentProfiler) {
-        getStorage().save(currentProfiler);
+        Storage storage = getStorage();
+        storage.save(currentProfiler);
+        String user = currentProfiler.getUser();
+        if (user != null) {
+            storage.setUnviewed(user, currentProfiler.getId());
+        }
     }
 
     /**

--- a/core/src/main/java/io/jdev/miniprofiler/ProfilerUiConfig.java
+++ b/core/src/main/java/io/jdev/miniprofiler/ProfilerUiConfig.java
@@ -61,6 +61,7 @@ public class ProfilerUiConfig {
     private boolean controls;
     private boolean authorized;
     private boolean startHidden;
+    private int maxUnviewedProfiles;
 
     /**
      * Returns the URL path at which the MiniProfiler UI is served.
@@ -269,6 +270,26 @@ public class ProfilerUiConfig {
         this.startHidden = startHidden;
     }
 
+    /**
+     * Returns the maximum number of previously-unviewed profiler IDs to include in the
+     * {@code X-MiniProfiler-Ids} response header.
+     *
+     * @return the maximum number of unviewed profiles
+     */
+    public int getMaxUnviewedProfiles() {
+        return maxUnviewedProfiles;
+    }
+
+    /**
+     * Sets the maximum number of previously-unviewed profiler IDs to include in the
+     * {@code X-MiniProfiler-Ids} response header.
+     *
+     * @param maxUnviewedProfiles the maximum number of unviewed profiles
+     */
+    public void setMaxUnviewedProfiles(int maxUnviewedProfiles) {
+        this.maxUnviewedProfiles = maxUnviewedProfiles;
+    }
+
     private ProfilerUiConfig() {}
 
     /**
@@ -289,6 +310,7 @@ public class ProfilerUiConfig {
         config.controls = false;
         config.authorized = true;
         config.startHidden = false;
+        config.maxUnviewedProfiles = 20;
         return config;
     }
 
@@ -323,6 +345,7 @@ public class ProfilerUiConfig {
         config.controls = getProperty(propsList, "controls", config.controls);
         config.authorized = getProperty(propsList, "authorized", config.authorized);
         config.startHidden = getProperty(propsList, "start.hidden", config.startHidden);
+        config.maxUnviewedProfiles = getProperty(propsList, "max.unviewed.profiles", config.maxUnviewedProfiles);
         return config;
     }
 
@@ -350,6 +373,9 @@ public class ProfilerUiConfig {
             return false;
         }
         if (startHidden != that.startHidden) {
+            return false;
+        }
+        if (maxUnviewedProfiles != that.maxUnviewedProfiles) {
             return false;
         }
         if (!path.equals(that.path)) {
@@ -384,6 +410,7 @@ public class ProfilerUiConfig {
         result = 31 * result + (controls ? 1 : 0);
         result = 31 * result + (authorized ? 1 : 0);
         result = 31 * result + (startHidden ? 1 : 0);
+        result = 31 * result + maxUnviewedProfiles;
         return result;
     }
 
@@ -410,6 +437,7 @@ public class ProfilerUiConfig {
         copy.controls = this.controls;
         copy.authorized = this.authorized;
         copy.startHidden = this.startHidden;
+        copy.maxUnviewedProfiles = this.maxUnviewedProfiles;
         return copy;
     }
 }

--- a/core/src/main/java/io/jdev/miniprofiler/server/Ids.java
+++ b/core/src/main/java/io/jdev/miniprofiler/server/Ids.java
@@ -17,16 +17,18 @@
 package io.jdev.miniprofiler.server;
 
 
+import io.jdev.miniprofiler.ProfilerProvider;
+
 import java.util.UUID;
 
 /**
- * Utility for parsing a profiler result UUID from an HTTP request.
+ * Utility for profiler ID parsing and header construction.
  *
  * <p>If the {@code Accept} header contains {@code application/json}, the UUID is extracted
  * from the JSON request body via {@link ResultsRequest}. Otherwise (or as a fallback) the
  * supplied {@code idParamValue} is parsed as a UUID.</p>
  */
-public final class IdParser {
+public final class Ids {
 
     /**
      * Parses a profiler UUID from an HTTP request.
@@ -56,6 +58,36 @@ public final class IdParser {
         return id;
     }
 
-    private IdParser() {
+    /**
+     * Builds the value of the {@code X-MiniProfiler-Ids} response header.
+     *
+     * <p>The header contains the current profiler's ID plus up to
+     * {@code provider.getUiConfig().getMaxUnviewedProfiles()} previously-unviewed IDs for the
+     * given user. If {@code user} is {@code null} only the current ID is included.</p>
+     *
+     * @param currentId the ID of the profiler for the current request (always first in the array)
+     * @param user      the current user (may be {@code null})
+     * @param provider  the profiler provider (used to read config and unviewed storage)
+     * @return a JSON array string suitable for use as the {@code X-MiniProfiler-Ids} header value
+     */
+    public static String buildIdsHeader(UUID currentId, String user, ProfilerProvider provider) {
+        StringBuilder sb = new StringBuilder("[\"").append(currentId).append('"');
+        if (user != null) {
+            int max = provider.getUiConfig().getMaxUnviewedProfiles();
+            int count = 0;
+            for (UUID uid : provider.getStorage().getUnviewedIds(user)) {
+                if (count >= max) {
+                    break;
+                }
+                if (!uid.equals(currentId)) {
+                    sb.append(",\"").append(uid).append('"');
+                    count++;
+                }
+            }
+        }
+        return sb.append(']').toString();
+    }
+
+    private Ids() {
     }
 }

--- a/core/src/main/java/io/jdev/miniprofiler/server/MiniProfilerServer.java
+++ b/core/src/main/java/io/jdev/miniprofiler/server/MiniProfilerServer.java
@@ -168,7 +168,7 @@ public class MiniProfilerServer implements AutoCloseable {
             }
         }
 
-        UUID id = IdParser.parseId(acceptHeader, body, extractQueryParam(exchange.getRequestURI().getRawQuery(), "id"));
+        UUID id = Ids.parseId(acceptHeader, body, extractQueryParam(exchange.getRequestURI().getRawQuery(), "id"));
         if (id == null) {
             sendError(exchange, 400);
             return;
@@ -178,6 +178,10 @@ public class MiniProfilerServer implements AutoCloseable {
         if (profiler == null) {
             sendError(exchange, 404);
             return;
+        }
+        String user = profiler.getUser();
+        if (user != null) {
+            provider.getStorage().setViewed(user, id);
         }
 
         if (jsonRequest) {

--- a/core/src/main/java/io/jdev/miniprofiler/storage/MapStorage.java
+++ b/core/src/main/java/io/jdev/miniprofiler/storage/MapStorage.java
@@ -23,10 +23,13 @@ import java.util.Collection;
 import java.util.Collections;
 import java.util.Comparator;
 import java.util.Date;
+import java.util.Iterator;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 import java.util.UUID;
+import java.util.concurrent.ConcurrentHashMap;
 import java.util.stream.Collectors;
 
 /**
@@ -36,6 +39,7 @@ public class MapStorage extends BaseStorage {
     private static final int DEFAULT_MAX_SIZE = 500;
 
     private final Map<UUID, ProfilerImpl> cache;
+    private final ConcurrentHashMap<String, Set<UUID>> unviewedByUser = new ConcurrentHashMap<>();
 
     /** Creates a new instance with the default maximum size of {@value DEFAULT_MAX_SIZE} entries. */
     public MapStorage() {
@@ -82,9 +86,51 @@ public class MapStorage extends BaseStorage {
             .collect(Collectors.toList());
     }
 
-    /** Removes all cached profiler sessions. */
+    @Override
+    public void setUnviewed(String user, UUID id) {
+        if (user == null || id == null) {
+            return;
+        }
+        unviewedByUser.computeIfAbsent(user, k -> ConcurrentHashMap.newKeySet()).add(id);
+    }
+
+    @Override
+    public void setViewed(String user, UUID id) {
+        if (user == null || id == null) {
+            return;
+        }
+        Set<UUID> set = unviewedByUser.get(user);
+        if (set != null) {
+            set.remove(id);
+        }
+    }
+
+    @Override
+    public Collection<UUID> getUnviewedIds(String user) {
+        if (user == null) {
+            return Collections.emptyList();
+        }
+        Set<UUID> set = unviewedByUser.get(user);
+        if (set == null) {
+            return Collections.emptyList();
+        }
+        List<UUID> result = new ArrayList<>();
+        Iterator<UUID> it = set.iterator();
+        while (it.hasNext()) {
+            UUID uid = it.next();
+            if (cache.containsKey(uid)) {
+                result.add(uid);
+            } else {
+                it.remove();
+            }
+        }
+        return result;
+    }
+
+    /** Removes all cached profiler sessions and resets unviewed state. */
     public void clear() {
         cache.clear();
+        unviewedByUser.clear();
     }
 
     private static class LRUMapCache extends LinkedHashMap<UUID, ProfilerImpl> {

--- a/core/src/test/groovy/io/jdev/miniprofiler/ProfilerUiConfigSpec.groovy
+++ b/core/src/test/groovy/io/jdev/miniprofiler/ProfilerUiConfigSpec.groovy
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016-2022 the original author or authors.
+ * Copyright 2016-2026 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/core/src/test/groovy/io/jdev/miniprofiler/ProfilerUiConfigSpec.groovy
+++ b/core/src/test/groovy/io/jdev/miniprofiler/ProfilerUiConfigSpec.groovy
@@ -36,6 +36,7 @@ class ProfilerUiConfigSpec extends Specification {
             controls == false
             authorized == true
             startHidden == false
+            maxUnviewedProfiles == 20
         }
 
         when:
@@ -75,6 +76,17 @@ class ProfilerUiConfigSpec extends Specification {
 
         and: 'setting to null'
         config.maxTraces == null
+
+        and: 'max.unviewed.profiles not present — stays at default'
+        config.maxUnviewedProfiles == 20
+    }
+
+    void "maxUnviewedProfiles can be set via properties"() {
+        when:
+        def config = ProfilerUiConfig.create([:] as Properties, ['max.unviewed.profiles': '5'] as Properties)
+
+        then:
+        config.maxUnviewedProfiles == 5
     }
 
     void "cannot directly set non-nullable properties to null"() {
@@ -140,6 +152,7 @@ class ProfilerUiConfigSpec extends Specification {
             controls == config.controls
             authorized == config.authorized
             startHidden == config.startHidden
+            maxUnviewedProfiles == config.maxUnviewedProfiles
         }
     }
 
@@ -156,6 +169,7 @@ class ProfilerUiConfigSpec extends Specification {
             controls = true
             authorized = true
             startHidden = true
+            maxUnviewedProfiles = 7
             it
         }
     }

--- a/core/src/test/groovy/io/jdev/miniprofiler/server/IdsSpec.groovy
+++ b/core/src/test/groovy/io/jdev/miniprofiler/server/IdsSpec.groovy
@@ -18,7 +18,7 @@ package io.jdev.miniprofiler.server
 
 import spock.lang.Specification
 
-class IdParserSpec extends Specification {
+class IdsSpec extends Specification {
 
     static final UUID ID = UUID.fromString('12345678-1234-1234-1234-123456789abc')
     static final String JSON_BODY = """{"Id": "${ID}"}"""
@@ -27,67 +27,67 @@ class IdParserSpec extends Specification {
 
     void "parses id from JSON body when Accept is application/json"() {
         expect:
-        IdParser.parseId(APPLICATION_JSON, JSON_BODY, null) == ID
+        Ids.parseId(APPLICATION_JSON, JSON_BODY, null) == ID
     }
 
     void "parses id from JSON body when Accept contains application/json among other types"() {
         expect:
-        IdParser.parseId("$TEXT_HTML, $APPLICATION_JSON", JSON_BODY, null) == ID
+        Ids.parseId("$TEXT_HTML, $APPLICATION_JSON", JSON_BODY, null) == ID
     }
 
     void "falls back to id param when JSON body is valid JSON but has no Id field"() {
         expect:
-        IdParser.parseId(APPLICATION_JSON, '{"foo": "bar"}', ID.toString()) == ID
+        Ids.parseId(APPLICATION_JSON, '{"foo": "bar"}', ID.toString()) == ID
     }
 
     void "falls back to id param when JSON body is malformed JSON"() {
         expect:
-        IdParser.parseId(APPLICATION_JSON, 'not-json', ID.toString()) == ID
+        Ids.parseId(APPLICATION_JSON, 'not-json', ID.toString()) == ID
     }
 
     void "falls back to id param when JSON body is null"() {
         expect:
-        IdParser.parseId(APPLICATION_JSON, null, ID.toString()) == ID
+        Ids.parseId(APPLICATION_JSON, null, ID.toString()) == ID
     }
 
     void "falls back to id param when JSON body is empty"() {
         expect:
-        IdParser.parseId(APPLICATION_JSON, '', ID.toString()) == ID
+        Ids.parseId(APPLICATION_JSON, '', ID.toString()) == ID
     }
 
     void "parses id from id param when Accept is not JSON"() {
         expect:
-        IdParser.parseId(TEXT_HTML, null, ID.toString()) == ID
+        Ids.parseId(TEXT_HTML, null, ID.toString()) == ID
     }
 
     void "parses id from id param when Accept is null"() {
         expect:
-        IdParser.parseId(null, null, ID.toString()) == ID
+        Ids.parseId(null, null, ID.toString()) == ID
     }
 
     void "ignores JSON body when Accept is not JSON"() {
         expect:
         // Body is valid JSON but Accept is text/html, so body is ignored
-        IdParser.parseId(TEXT_HTML, JSON_BODY, ID.toString()) == ID
+        Ids.parseId(TEXT_HTML, JSON_BODY, ID.toString()) == ID
     }
 
     void "returns null when all inputs are null"() {
         expect:
-        IdParser.parseId(null, null, null) == null
+        Ids.parseId(null, null, null) == null
     }
 
     void "returns null when id param is null and no JSON body"() {
         expect:
-        IdParser.parseId(APPLICATION_JSON, null, null) == null
+        Ids.parseId(APPLICATION_JSON, null, null) == null
     }
 
     void "returns null when id param is empty"() {
         expect:
-        IdParser.parseId(null, null, '') == null
+        Ids.parseId(null, null, '') == null
     }
 
     void "returns null when id param is not a valid UUID"() {
         expect:
-        IdParser.parseId(null, null, 'not-a-uuid') == null
+        Ids.parseId(null, null, 'not-a-uuid') == null
     }
 }

--- a/core/src/test/groovy/io/jdev/miniprofiler/server/MiniProfilerServerSpec.groovy
+++ b/core/src/test/groovy/io/jdev/miniprofiler/server/MiniProfilerServerSpec.groovy
@@ -183,6 +183,21 @@ class MiniProfilerServerSpec extends Specification {
         conn.responseCode == 405
     }
 
+    void "handleResults marks profiler as viewed"() {
+        given: 'a profiler with a known user, stored and marked unviewed'
+        Profiler userProfiler = provider.start('user-request')
+        (userProfiler as io.jdev.miniprofiler.internal.ProfilerImpl).user = 'alice'
+        userProfiler.stop()
+        provider.storage.setUnviewed('alice', userProfiler.id)
+
+        when: 'results are fetched'
+        def conn = connect("miniprofiler/results?id=${userProfiler.id}", APPLICATION_JSON)
+        conn.responseCode  // consume
+
+        then: 'profiler is no longer in unviewed set'
+        provider.storage.getUnviewedIds('alice').empty
+    }
+
     // ---- static resources ------------------------------------------------
 
     void "GET static resource returns content with correct content type"() {

--- a/core/src/test/groovy/io/jdev/miniprofiler/storage/MapStorageSpec.groovy
+++ b/core/src/test/groovy/io/jdev/miniprofiler/storage/MapStorageSpec.groovy
@@ -158,4 +158,126 @@ class MapStorageSpec extends Specification {
         then:
         result.toList() == [val2.id, val1.id]
     }
+
+    void "getUnviewedIds returns empty for unknown user"() {
+        expect:
+        storage.getUnviewedIds('alice').empty
+    }
+
+    void "getUnviewedIds returns empty for null user"() {
+        expect:
+        storage.getUnviewedIds(null).empty
+    }
+
+    void "setUnviewed and getUnviewedIds round-trip for one user"() {
+        given:
+        def p = new ProfilerImpl('test', ProfileLevel.Info, profilerProvider)
+        storage.save(p)
+
+        when:
+        storage.setUnviewed('alice', p.id)
+
+        then:
+        storage.getUnviewedIds('alice') as Set == [p.id] as Set
+    }
+
+    void "setUnviewed tracks independently per user"() {
+        given:
+        def p1 = new ProfilerImpl('test1', ProfileLevel.Info, profilerProvider)
+        def p2 = new ProfilerImpl('test2', ProfileLevel.Info, profilerProvider)
+        storage.save(p1)
+        storage.save(p2)
+
+        when:
+        storage.setUnviewed('alice', p1.id)
+        storage.setUnviewed('bob', p2.id)
+
+        then:
+        storage.getUnviewedIds('alice') as Set == [p1.id] as Set
+        storage.getUnviewedIds('bob') as Set == [p2.id] as Set
+    }
+
+    void "setViewed removes id from unviewed set"() {
+        given:
+        def p = new ProfilerImpl('test', ProfileLevel.Info, profilerProvider)
+        storage.save(p)
+        storage.setUnviewed('alice', p.id)
+
+        when:
+        storage.setViewed('alice', p.id)
+
+        then:
+        storage.getUnviewedIds('alice').empty
+    }
+
+    void "setViewed for unknown user is a no-op"() {
+        when:
+        storage.setViewed('nobody', UUID.randomUUID())
+
+        then:
+        noExceptionThrown()
+    }
+
+    void "setUnviewed ignores null user"() {
+        when:
+        storage.setUnviewed(null, UUID.randomUUID())
+
+        then:
+        noExceptionThrown()
+    }
+
+    void "setUnviewed ignores null id"() {
+        when:
+        storage.setUnviewed('alice', null)
+
+        then:
+        noExceptionThrown()
+        storage.getUnviewedIds('alice').empty
+    }
+
+    void "LRU-evicted ids are filtered out of getUnviewedIds"() {
+        given: 'maxSize=2 storage'
+        def p1 = new ProfilerImpl('test1', ProfileLevel.Info, profilerProvider)
+        def p2 = new ProfilerImpl('test2', ProfileLevel.Info, profilerProvider)
+        def p3 = new ProfilerImpl('test3', ProfileLevel.Info, profilerProvider)
+        storage.save(p1)
+        storage.save(p2)
+        storage.setUnviewed('alice', p1.id)
+
+        when: 'saving a third entry evicts p1'
+        storage.save(p3)
+
+        then:
+        !storage.getUnviewedIds('alice').contains(p1.id)
+    }
+
+    void "LRU-evicted ids are pruned from unviewedByUser on getUnviewedIds"() {
+        given: 'maxSize=2 storage'
+        def p1 = new ProfilerImpl('test1', ProfileLevel.Info, profilerProvider)
+        def p2 = new ProfilerImpl('test2', ProfileLevel.Info, profilerProvider)
+        def p3 = new ProfilerImpl('test3', ProfileLevel.Info, profilerProvider)
+        storage.save(p1)
+        storage.save(p2)
+        storage.setUnviewed('alice', p1.id)
+        storage.save(p3) // evicts p1
+
+        when:
+        storage.getUnviewedIds('alice')
+
+        then: 'stale entry is removed from the internal set'
+        !storage.unviewedByUser['alice'].contains(p1.id)
+    }
+
+    void "clear resets unviewed state"() {
+        given:
+        def p = new ProfilerImpl('test', ProfileLevel.Info, profilerProvider)
+        storage.save(p)
+        storage.setUnviewed('alice', p.id)
+
+        when:
+        storage.clear()
+
+        then:
+        storage.getUnviewedIds('alice').empty
+    }
 }

--- a/jakarta-servlet/src/integrationTest/groovy/io/jdev/miniprofiler/jakarta/servlet/UnviewedIdsIntegrationSpec.groovy
+++ b/jakarta-servlet/src/integrationTest/groovy/io/jdev/miniprofiler/jakarta/servlet/UnviewedIdsIntegrationSpec.groovy
@@ -1,0 +1,32 @@
+/*
+ * Copyright 2026 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.jdev.miniprofiler.jakarta.servlet
+
+import io.jdev.miniprofiler.integtest.AbstractProfilingHandlerIntegrationSpec
+import io.jdev.miniprofiler.integtest.InProcessTestedServer
+
+/**
+ * Runs the viewed/unviewed integration tests against an {@link InProcessJetty12} server
+ * configured with a fixed {@code UserProvider}, which is required for unviewed tracking.
+ */
+class UnviewedIdsIntegrationSpec extends AbstractProfilingHandlerIntegrationSpec {
+
+    @Override
+    protected InProcessTestedServer createServer() {
+        new InProcessJetty12('test-user')
+    }
+}

--- a/jakarta-servlet/src/integrationTest/groovy/io/jdev/miniprofiler/jakarta/servlet/UnviewedIdsIntegrationSpec.groovy
+++ b/jakarta-servlet/src/integrationTest/groovy/io/jdev/miniprofiler/jakarta/servlet/UnviewedIdsIntegrationSpec.groovy
@@ -1,5 +1,5 @@
 /*
- * Copyright 2026 the original author or authors.
+ * Copyright 2013-2026 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/jakarta-servlet/src/main/java/io/jdev/miniprofiler/jakarta/servlet/ProfilingFilter.java
+++ b/jakarta-servlet/src/main/java/io/jdev/miniprofiler/jakarta/servlet/ProfilingFilter.java
@@ -22,7 +22,7 @@ import io.jdev.miniprofiler.ProfilerProvider;
 import io.jdev.miniprofiler.StaticProfilerProvider;
 import io.jdev.miniprofiler.server.Pages;
 import io.jdev.miniprofiler.internal.ProfilerImpl;
-import io.jdev.miniprofiler.server.IdParser;
+import io.jdev.miniprofiler.server.Ids;
 import io.jdev.miniprofiler.storage.Storage;
 import io.jdev.miniprofiler.server.ResourceHelper;
 
@@ -126,7 +126,8 @@ public class ProfilingFilter implements Filter {
                     // add header, this is mostly for ajax
                     id = profiler.getId();
                     if (id != null) {
-                        response.addHeader("X-MiniProfiler-Ids", "[\"" + id.toString() + "\"]");
+                        response.addHeader("X-MiniProfiler-Ids",
+                            Ids.buildIdsHeader(id, profilerProvider.getUserProvider().getUser(), profilerProvider));
                     }
                     filterChain.doFilter(servletRequest, servletResponse);
                 } finally {
@@ -182,6 +183,10 @@ public class ProfilingFilter implements Filter {
         if (profiler == null) {
             response.sendError(HttpServletResponse.SC_NOT_FOUND);
             return;
+        }
+        String user = profiler.getUser();
+        if (user != null) {
+            profilerProvider.getStorage().setViewed(user, id);
         }
 
         if (jsonRequest) {
@@ -242,7 +247,7 @@ public class ProfilingFilter implements Filter {
                 // fall through to id param
             }
         }
-        return IdParser.parseId(request.getHeader(ACCEPT_HEADER), body, request.getParameter(ID_PARAM));
+        return Ids.parseId(request.getHeader(ACCEPT_HEADER), body, request.getParameter(ID_PARAM));
     }
 
     private void renderJson(Profiler profiler, HttpServletResponse response) throws IOException {

--- a/jakarta-servlet/src/test/groovy/io/jdev/miniprofiler/jakarta/servlet/ProfilingFilterSpec.groovy
+++ b/jakarta-servlet/src/test/groovy/io/jdev/miniprofiler/jakarta/servlet/ProfilingFilterSpec.groovy
@@ -347,6 +347,72 @@ class ProfilingFilterSpec extends Specification {
         and: 'serves includes script tag'
         body.contains("<script type='text/javascript' id='mini-profiler' src='/miniprofiler/includes.js?version=")
     }
+
+    void "X-MiniProfiler-Ids header includes previously unviewed ids for authenticated user"() {
+        given: 'a previous unviewed id'
+        def previousId = UUID.randomUUID()
+        storage.setUnviewed('alice', previousId)
+
+        and: 'an authenticated request'
+        request.requestURI = '/foo'
+        request.userPrincipal = { 'alice' } as Principal
+
+        when:
+        filter.doFilter(request, response, chain)
+
+        then: 'header contains both previous id and current profiler id'
+        def header = response.getHeader('X-MiniProfiler-Ids')
+        header.contains(previousId.toString())
+        header.contains(storage.profiler.id.toString())
+    }
+
+    void "X-MiniProfiler-Ids header contains only current id when no user"() {
+        given:
+        request.requestURI = '/foo'
+
+        when:
+        filter.doFilter(request, response, chain)
+
+        then:
+        response.getHeader('X-MiniProfiler-Ids') == """["${storage.profiler.id}"]"""
+    }
+
+    void "X-MiniProfiler-Ids header caps previously unviewed ids at maxUnviewedProfiles"() {
+        given:
+        profilerProvider.uiConfig.maxUnviewedProfiles = 2
+        5.times { storage.setUnviewed('alice', UUID.randomUUID()) }
+
+        and:
+        request.requestURI = '/foo'
+        request.userPrincipal = { 'alice' } as Principal
+
+        when:
+        filter.doFilter(request, response, chain)
+
+        then: 'header contains current id plus at most 2 previous ids'
+        def header = response.getHeader('X-MiniProfiler-Ids')
+        def parsed = new groovy.json.JsonSlurper().parseText(header) as List
+        parsed.contains(storage.profiler.id.toString())
+        parsed.size() <= 3  // current + max 2 previous
+    }
+
+    void "serveResults marks profiler as viewed"() {
+        given: 'a profiler stored and marked unviewed for alice'
+        storage.profiler = new ProfilerImpl("test", ProfileLevel.Info, profilerProvider).tap { p ->
+            p.user = 'alice'
+            stop()
+        }
+        storage.setUnviewed('alice', storage.profiler.id)
+
+        when: 'results are fetched'
+        request.requestURI = '/miniprofiler/results'
+        request.addHeader('Accept', 'application/json')
+        request.content = """{"Id":"${storage.profiler.id}"}""".bytes
+        filter.doFilter(request, response, chain)
+
+        then: 'profiler is no longer in unviewed set'
+        !storage.getUnviewedIds('alice').contains(storage.profiler.id)
+    }
 }
 
 class MockFilterChain implements FilterChain {

--- a/jakarta-servlet/src/test/groovy/io/jdev/miniprofiler/test/TestStorage.groovy
+++ b/jakarta-servlet/src/test/groovy/io/jdev/miniprofiler/test/TestStorage.groovy
@@ -41,16 +41,23 @@ public class TestStorage implements Storage {
         profiler.id == id ? profiler : null
     }
 
+    Map<String, Set<UUID>> unviewedByUser = [:]
+
     @Override
     public void setUnviewed(String user, UUID id) {
+        if (user == null) { return }
+        unviewedByUser.computeIfAbsent(user, { [] as LinkedHashSet }).add(id)
     }
 
     @Override
     public void setViewed(String user, UUID id) {
+        if (user == null) { return }
+        unviewedByUser[user]?.remove(id)
     }
 
     @Override
     public Collection<UUID> getUnviewedIds(String user) {
-        Collections.emptyList()
+        if (user == null) { return [] }
+        unviewedByUser[user] ?: []
     }
 }

--- a/jakarta-servlet/src/test/groovy/io/jdev/miniprofiler/test/TestStorage.groovy
+++ b/jakarta-servlet/src/test/groovy/io/jdev/miniprofiler/test/TestStorage.groovy
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013-2017 the original author or authors.
+ * Copyright 2013-2026 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/jakarta-servlet/src/testFixtures/groovy/io/jdev/miniprofiler/jakarta/servlet/InProcessJetty12.groovy
+++ b/jakarta-servlet/src/testFixtures/groovy/io/jdev/miniprofiler/jakarta/servlet/InProcessJetty12.groovy
@@ -44,10 +44,16 @@ import org.eclipse.jetty.util.security.Password
  */
 class InProcessJetty12 implements InProcessTestedServer {
 
-    private final DefaultProfilerProvider profilerProvider = new DefaultProfilerProvider()
+    private final DefaultProfilerProvider profilerProvider
     private final Server server
+    private final String testUser
 
-    InProcessJetty12() {
+    InProcessJetty12(String testUser = null) {
+        this.testUser = testUser
+        profilerProvider = new DefaultProfilerProvider()
+        if (testUser != null) {
+            profilerProvider.setUserProvider { testUser }
+        }
         server = new Server(0).tap {
             server.handler = new ServletContextHandler('/').tap {
                 securityHandler = buildSecurityHandler()
@@ -119,6 +125,9 @@ class InProcessJetty12 implements InProcessTestedServer {
             constraintMappings = [mapping]
         }
     }
+
+    @Override
+    String getTestUser() { testUser }
 
     @Override
     String getProfiledPagePath() { 'test-page' }

--- a/javax-servlet/src/integrationTest/groovy/io/jdev/miniprofiler/javax/servlet/UnviewedIdsIntegrationSpec.groovy
+++ b/javax-servlet/src/integrationTest/groovy/io/jdev/miniprofiler/javax/servlet/UnviewedIdsIntegrationSpec.groovy
@@ -1,0 +1,32 @@
+/*
+ * Copyright 2026 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.jdev.miniprofiler.javax.servlet
+
+import io.jdev.miniprofiler.integtest.AbstractProfilingHandlerIntegrationSpec
+import io.jdev.miniprofiler.integtest.InProcessTestedServer
+
+/**
+ * Runs the viewed/unviewed integration tests against an {@link InProcessJetty9} server
+ * configured with a fixed {@code UserProvider}, which is required for unviewed tracking.
+ */
+class UnviewedIdsIntegrationSpec extends AbstractProfilingHandlerIntegrationSpec {
+
+    @Override
+    protected InProcessTestedServer createServer() {
+        new InProcessJetty9('test-user')
+    }
+}

--- a/javax-servlet/src/integrationTest/groovy/io/jdev/miniprofiler/javax/servlet/UnviewedIdsIntegrationSpec.groovy
+++ b/javax-servlet/src/integrationTest/groovy/io/jdev/miniprofiler/javax/servlet/UnviewedIdsIntegrationSpec.groovy
@@ -1,5 +1,5 @@
 /*
- * Copyright 2026 the original author or authors.
+ * Copyright 2013-2026 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/javax-servlet/src/main/java/io/jdev/miniprofiler/javax/servlet/ProfilingFilter.java
+++ b/javax-servlet/src/main/java/io/jdev/miniprofiler/javax/servlet/ProfilingFilter.java
@@ -22,7 +22,7 @@ import io.jdev.miniprofiler.ProfilerProvider;
 import io.jdev.miniprofiler.StaticProfilerProvider;
 import io.jdev.miniprofiler.server.Pages;
 import io.jdev.miniprofiler.internal.ProfilerImpl;
-import io.jdev.miniprofiler.server.IdParser;
+import io.jdev.miniprofiler.server.Ids;
 import io.jdev.miniprofiler.storage.Storage;
 import io.jdev.miniprofiler.server.ResourceHelper;
 
@@ -126,7 +126,8 @@ public class ProfilingFilter implements Filter {
                     // add header, this is mostly for ajax
                     id = profiler.getId();
                     if (id != null) {
-                        response.addHeader("X-MiniProfiler-Ids", "[\"" + id.toString() + "\"]");
+                        response.addHeader("X-MiniProfiler-Ids",
+                            Ids.buildIdsHeader(id, profilerProvider.getUserProvider().getUser(), profilerProvider));
                     }
                     filterChain.doFilter(servletRequest, servletResponse);
                 } finally {
@@ -182,6 +183,10 @@ public class ProfilingFilter implements Filter {
         if (profiler == null) {
             response.sendError(HttpServletResponse.SC_NOT_FOUND);
             return;
+        }
+        String user = profiler.getUser();
+        if (user != null) {
+            profilerProvider.getStorage().setViewed(user, id);
         }
 
         if (jsonRequest) {
@@ -242,7 +247,7 @@ public class ProfilingFilter implements Filter {
                 // fall through to id param
             }
         }
-        return IdParser.parseId(request.getHeader(ACCEPT_HEADER), body, request.getParameter(ID_PARAM));
+        return Ids.parseId(request.getHeader(ACCEPT_HEADER), body, request.getParameter(ID_PARAM));
     }
 
     private void renderJson(Profiler profiler, HttpServletResponse response) throws IOException {

--- a/javax-servlet/src/test/groovy/io/jdev/miniprofiler/javax/servlet/ProfilingFilterSpec.groovy
+++ b/javax-servlet/src/test/groovy/io/jdev/miniprofiler/javax/servlet/ProfilingFilterSpec.groovy
@@ -348,6 +348,72 @@ class ProfilingFilterSpec extends Specification {
         and: 'serves includes script tag'
         body.contains("<script type='text/javascript' id='mini-profiler' src='/miniprofiler/includes.js?version=")
     }
+
+    void "X-MiniProfiler-Ids header includes previously unviewed ids for authenticated user"() {
+        given: 'a previous unviewed id'
+        def previousId = UUID.randomUUID()
+        storage.setUnviewed('alice', previousId)
+
+        and: 'an authenticated request'
+        request.requestURI = '/foo'
+        request.userPrincipal = { 'alice' } as Principal
+
+        when:
+        filter.doFilter(request, response, chain)
+
+        then: 'header contains both previous id and current profiler id'
+        def header = response.getHeader('X-MiniProfiler-Ids')
+        header.contains(previousId.toString())
+        header.contains(storage.profiler.id.toString())
+    }
+
+    void "X-MiniProfiler-Ids header contains only current id when no user"() {
+        given:
+        request.requestURI = '/foo'
+
+        when:
+        filter.doFilter(request, response, chain)
+
+        then:
+        response.getHeader('X-MiniProfiler-Ids') == """["${storage.profiler.id}"]"""
+    }
+
+    void "X-MiniProfiler-Ids header caps previously unviewed ids at maxUnviewedProfiles"() {
+        given:
+        profilerProvider.uiConfig.maxUnviewedProfiles = 2
+        5.times { storage.setUnviewed('alice', UUID.randomUUID()) }
+
+        and:
+        request.requestURI = '/foo'
+        request.userPrincipal = { 'alice' } as Principal
+
+        when:
+        filter.doFilter(request, response, chain)
+
+        then: 'header contains current id plus at most 2 previous ids'
+        def header = response.getHeader('X-MiniProfiler-Ids')
+        def parsed = new groovy.json.JsonSlurper().parseText(header) as List
+        parsed.contains(storage.profiler.id.toString())
+        parsed.size() <= 3  // current + max 2 previous
+    }
+
+    void "serveResults marks profiler as viewed"() {
+        given: 'a profiler stored and marked unviewed for alice'
+        storage.profiler = new ProfilerImpl("test", ProfileLevel.Info, profilerProvider).tap { p ->
+            p.user = 'alice'
+            stop()
+        }
+        storage.setUnviewed('alice', storage.profiler.id)
+
+        when: 'results are fetched'
+        request.requestURI = '/miniprofiler/results'
+        request.addHeader('Accept', 'application/json')
+        request.content = """{"Id":"${storage.profiler.id}"}""".bytes
+        filter.doFilter(request, response, chain)
+
+        then: 'profiler is no longer in unviewed set'
+        !storage.getUnviewedIds('alice').contains(storage.profiler.id)
+    }
 }
 
 class MockFilterChain implements FilterChain {

--- a/javax-servlet/src/test/groovy/io/jdev/miniprofiler/test/TestStorage.groovy
+++ b/javax-servlet/src/test/groovy/io/jdev/miniprofiler/test/TestStorage.groovy
@@ -41,16 +41,23 @@ public class TestStorage implements Storage {
         profiler.id == id ? profiler : null
     }
 
+    Map<String, Set<UUID>> unviewedByUser = [:]
+
     @Override
     public void setUnviewed(String user, UUID id) {
+        if (user == null) { return }
+        unviewedByUser.computeIfAbsent(user, { [] as LinkedHashSet }).add(id)
     }
 
     @Override
     public void setViewed(String user, UUID id) {
+        if (user == null) { return }
+        unviewedByUser[user]?.remove(id)
     }
 
     @Override
     public Collection<UUID> getUnviewedIds(String user) {
-        Collections.emptyList()
+        if (user == null) { return [] }
+        unviewedByUser[user] ?: []
     }
 }

--- a/javax-servlet/src/test/groovy/io/jdev/miniprofiler/test/TestStorage.groovy
+++ b/javax-servlet/src/test/groovy/io/jdev/miniprofiler/test/TestStorage.groovy
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013-2017 the original author or authors.
+ * Copyright 2013-2026 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/javax-servlet/src/testFixtures/groovy/io/jdev/miniprofiler/javax/servlet/InProcessJetty9.groovy
+++ b/javax-servlet/src/testFixtures/groovy/io/jdev/miniprofiler/javax/servlet/InProcessJetty9.groovy
@@ -48,10 +48,16 @@ import javax.servlet.http.HttpServletResponse
  */
 class InProcessJetty9 implements InProcessTestedServer {
 
-    private final DefaultProfilerProvider profilerProvider = new DefaultProfilerProvider()
+    private final DefaultProfilerProvider profilerProvider
     private final Server server
+    private final String testUser
 
-    InProcessJetty9() {
+    InProcessJetty9(String testUser = null) {
+        this.testUser = testUser
+        profilerProvider = new DefaultProfilerProvider()
+        if (testUser != null) {
+            profilerProvider.setUserProvider { testUser }
+        }
         server = new Server(0)
         new ServletContextHandler(server, '/', false, false).tap {
             securityHandler = buildSecurityHandler()
@@ -125,6 +131,9 @@ class InProcessJetty9 implements InProcessTestedServer {
             constraintMappings = [mapping]
         }
     }
+
+    @Override
+    String getTestUser() { testUser }
 
     @Override
     String getProfiledPagePath() { 'test-page' }

--- a/ratpack/ratpack.gradle.kts
+++ b/ratpack/ratpack.gradle.kts
@@ -16,6 +16,7 @@
 
 plugins {
     id("build.browser-test")
+    id("build.integration-test")
     id("build.java-module")
     id("build.publish")
     id("build.ratpack")
@@ -37,6 +38,12 @@ dependencies {
     testImplementation(projects.test)
     testImplementation(libs.ratpack.test)
     testImplementation(libs.ratpack.groovy.test)
+
+    integrationTestImplementation(projects.core)
+    integrationTestImplementation(projects.testlibIntegration)
+    integrationTestImplementation(testFixtures(project))
+    integrationTestImplementation(libs.ratpack.core)
+    integrationTestImplementation(libs.ratpack.guice)
 
     testFixturesImplementation(projects.testlibIntegration)
     testFixturesImplementation(libs.groovy.v4)

--- a/ratpack/src/integrationTest/groovy/io/jdev/miniprofiler/ratpack/RatpackProfilingHandlerIntegrationSpec.groovy
+++ b/ratpack/src/integrationTest/groovy/io/jdev/miniprofiler/ratpack/RatpackProfilingHandlerIntegrationSpec.groovy
@@ -1,0 +1,28 @@
+/*
+ * Copyright 2026 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.jdev.miniprofiler.ratpack
+
+import io.jdev.miniprofiler.integtest.AbstractProfilingHandlerIntegrationSpec
+import io.jdev.miniprofiler.integtest.InProcessTestedServer
+
+class RatpackProfilingHandlerIntegrationSpec extends AbstractProfilingHandlerIntegrationSpec {
+
+    @Override
+    protected InProcessTestedServer createServer() {
+        new InProcessRatpack()
+    }
+}

--- a/ratpack/src/integrationTest/groovy/io/jdev/miniprofiler/ratpack/RatpackProfilingHandlerIntegrationSpec.groovy
+++ b/ratpack/src/integrationTest/groovy/io/jdev/miniprofiler/ratpack/RatpackProfilingHandlerIntegrationSpec.groovy
@@ -1,5 +1,5 @@
 /*
- * Copyright 2026 the original author or authors.
+ * Copyright 2013-2026 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/ratpack/src/integrationTest/groovy/io/jdev/miniprofiler/ratpack/UnviewedIdsIntegrationSpec.groovy
+++ b/ratpack/src/integrationTest/groovy/io/jdev/miniprofiler/ratpack/UnviewedIdsIntegrationSpec.groovy
@@ -1,0 +1,32 @@
+/*
+ * Copyright 2026 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.jdev.miniprofiler.ratpack
+
+import io.jdev.miniprofiler.integtest.AbstractProfilingHandlerIntegrationSpec
+import io.jdev.miniprofiler.integtest.InProcessTestedServer
+
+/**
+ * Runs the viewed/unviewed integration tests against an {@link InProcessRatpack} server
+ * configured with a fixed {@code UserProvider}, which is required for unviewed tracking.
+ */
+class UnviewedIdsIntegrationSpec extends AbstractProfilingHandlerIntegrationSpec {
+
+    @Override
+    protected InProcessTestedServer createServer() {
+        new InProcessRatpack('test-user')
+    }
+}

--- a/ratpack/src/integrationTest/groovy/io/jdev/miniprofiler/ratpack/UnviewedIdsIntegrationSpec.groovy
+++ b/ratpack/src/integrationTest/groovy/io/jdev/miniprofiler/ratpack/UnviewedIdsIntegrationSpec.groovy
@@ -1,5 +1,5 @@
 /*
- * Copyright 2026 the original author or authors.
+ * Copyright 2013-2026 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/ratpack/src/main/java/io/jdev/miniprofiler/ratpack/MiniProfilerAjaxHeaderHandler.java
+++ b/ratpack/src/main/java/io/jdev/miniprofiler/ratpack/MiniProfilerAjaxHeaderHandler.java
@@ -32,7 +32,10 @@
 
 package io.jdev.miniprofiler.ratpack;
 
+import com.google.inject.Inject;
 import io.jdev.miniprofiler.Profiler;
+import io.jdev.miniprofiler.ProfilerProvider;
+import io.jdev.miniprofiler.server.Ids;
 import ratpack.exec.Execution;
 import ratpack.handling.Context;
 import ratpack.handling.Handler;
@@ -44,15 +47,24 @@ import ratpack.handling.Handler;
  */
 public class MiniProfilerAjaxHeaderHandler implements Handler {
 
-    /** Creates a new AJAX header handler. */
-    public MiniProfilerAjaxHeaderHandler() {
+    private final ProfilerProvider provider;
+
+    /**
+     * Creates a new AJAX header handler.
+     *
+     * @param provider the profiler provider used to look up unviewed IDs and configuration
+     */
+    @Inject
+    public MiniProfilerAjaxHeaderHandler(ProfilerProvider provider) {
+        this.provider = provider;
     }
 
     @Override
     public void handle(Context ctx) throws Exception {
         ctx.maybeGet(Profiler.class).ifPresent(profiler -> {
             Execution.current().add(ProfilerStoreOption.class, ProfilerStoreOption.STORE_RESULTS);
-            ctx.getResponse().getHeaders().add("X-MiniProfiler-Ids", "[\"" + profiler.getId() + "\"]");
+            ctx.getResponse().getHeaders().add("X-MiniProfiler-Ids",
+                Ids.buildIdsHeader(profiler.getId(), profiler.getUser(), provider));
         });
         ctx.next();
     }

--- a/ratpack/src/main/java/io/jdev/miniprofiler/ratpack/MiniProfilerResultsHandler.java
+++ b/ratpack/src/main/java/io/jdev/miniprofiler/ratpack/MiniProfilerResultsHandler.java
@@ -19,7 +19,7 @@ package io.jdev.miniprofiler.ratpack;
 import com.google.inject.Inject;
 import io.jdev.miniprofiler.ProfilerProvider;
 import io.jdev.miniprofiler.internal.ProfilerImpl;
-import io.jdev.miniprofiler.server.IdParser;
+import io.jdev.miniprofiler.server.Ids;
 import ratpack.handling.Context;
 import ratpack.handling.Handler;
 import ratpack.http.Response;
@@ -75,7 +75,7 @@ public class MiniProfilerResultsHandler implements Handler {
         ctx.getRequest().getBody()
             .map(TypedData::getText)
             .then(body -> {
-                UUID requestedId = IdParser.parseId(
+                UUID requestedId = Ids.parseId(
                     ctx.getRequest().getHeaders().get(ACCEPT),
                     body,
                     ctx.getRequest().getQueryParams().get("id")
@@ -85,17 +85,24 @@ public class MiniProfilerResultsHandler implements Handler {
                     return;
                 }
 
-                AsyncStorage.adapt(provider.getStorage())
-                    .loadAsync(requestedId)
+                AsyncStorage asyncStorage = AsyncStorage.adapt(provider.getStorage());
+                asyncStorage.loadAsync(requestedId)
                     .then(profiler -> {
                         if (profiler != null) {
-                            if (isJsonRequest(ctx)) {
-                                renderJson(ctx, profiler);
+                            String user = profiler.getUser();
+                            Runnable render = () -> {
+                                if (isJsonRequest(ctx)) {
+                                    renderJson(ctx, profiler);
+                                } else {
+                                    renderSinglePageHtml(ctx, profiler);
+                                }
+                            };
+                            if (user != null) {
+                                asyncStorage.setViewedAsync(user, requestedId).then(render::run);
                             } else {
-                                renderSinglePageHtml(ctx, profiler);
+                                render.run();
                             }
                         } else {
-                            // not there
                             response.status(Status.NOT_FOUND).send();
                         }
                     });

--- a/ratpack/src/main/java/io/jdev/miniprofiler/ratpack/RatpackContextProfilerProvider.java
+++ b/ratpack/src/main/java/io/jdev/miniprofiler/ratpack/RatpackContextProfilerProvider.java
@@ -57,9 +57,15 @@ public class RatpackContextProfilerProvider extends BaseProfilerProvider {
 
     @Override
     protected void saveProfiler(ProfilerImpl currentProfiler) {
-        AsyncStorage.adapt(getStorage())
-            .saveAsync(currentProfiler)
-            .then();
+        String user = currentProfiler.getUser();
+        AsyncStorage asyncStorage = AsyncStorage.adapt(getStorage());
+        if (user != null) {
+            asyncStorage.saveAsync(currentProfiler)
+                .next(asyncStorage.setUnviewedAsync(user, currentProfiler.getId()))
+                .then();
+        } else {
+            asyncStorage.saveAsync(currentProfiler).then();
+        }
     }
 
     /**

--- a/ratpack/src/test/groovy/io/jdev/miniprofiler/ratpack/MiniProfilerAjaxHeaderHandlerSpec.groovy
+++ b/ratpack/src/test/groovy/io/jdev/miniprofiler/ratpack/MiniProfilerAjaxHeaderHandlerSpec.groovy
@@ -1,0 +1,98 @@
+/*
+ * Copyright 2026 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.jdev.miniprofiler.ratpack
+
+import io.jdev.miniprofiler.ProfileLevel
+import io.jdev.miniprofiler.Profiler
+import io.jdev.miniprofiler.internal.ProfilerImpl
+import io.jdev.miniprofiler.storage.MapStorage
+import io.jdev.miniprofiler.test.TestProfilerProvider
+import ratpack.func.Action
+import ratpack.test.handling.RequestFixture
+import spock.lang.Specification
+
+class MiniProfilerAjaxHeaderHandlerSpec extends Specification {
+
+    TestProfilerProvider provider
+    MapStorage storage
+    MiniProfilerAjaxHeaderHandler handler
+
+    void setup() {
+        provider = new TestProfilerProvider()
+        storage = (MapStorage) provider.storage
+        handler = new MiniProfilerAjaxHeaderHandler(provider)
+    }
+
+    void "header contains only current id when no user"() {
+        given:
+        def profiler = new ProfilerImpl('/test', ProfileLevel.Info, provider)
+
+        when:
+        def result = RequestFixture.handle(handler, { RequestFixture req ->
+            req.registry { r -> r.add(Profiler, profiler) }
+        } as Action)
+
+        then:
+        result.headers.get('X-MiniProfiler-Ids') == "[\"${profiler.id}\"]"
+    }
+
+    void "header includes previously unviewed ids for authenticated user"() {
+        given:
+        def profiler = new ProfilerImpl('/test', ProfileLevel.Info, provider)
+        profiler.setUser('alice')
+        def previousProfiler = new ProfilerImpl('/previous', ProfileLevel.Info, provider)
+        previousProfiler.stop()
+        storage.save(previousProfiler)
+        storage.setUnviewed('alice', previousProfiler.id)
+
+        when:
+        def result = RequestFixture.handle(handler, { RequestFixture req ->
+            req.registry { r -> r.add(Profiler, profiler) }
+        } as Action)
+
+        then:
+        def header = result.headers.get('X-MiniProfiler-Ids')
+        header.contains("\"${profiler.id}\"")
+        header.contains("\"${previousProfiler.id}\"")
+    }
+
+    void "header caps previously unviewed ids at maxUnviewedProfiles"() {
+        given:
+        provider.uiConfig.maxUnviewedProfiles = 2
+        def profiler = new ProfilerImpl('/test', ProfileLevel.Info, provider)
+        profiler.setUser('alice')
+
+        and: 'add 5 unviewed profiles'
+        5.times {
+            def p = new ProfilerImpl("/old-$it", ProfileLevel.Info, provider)
+            p.stop()
+            storage.save(p)
+            storage.setUnviewed('alice', p.id)
+        }
+
+        when:
+        def result = RequestFixture.handle(handler, { RequestFixture req ->
+            req.registry { r -> r.add(Profiler, profiler) }
+        } as Action)
+
+        then: 'header contains current id + at most 2 previous ids'
+        def header = result.headers.get('X-MiniProfiler-Ids')
+        def ids = header.replaceAll('[\\[\\]"]', '').split(',')
+        ids.length <= 3
+        ids[0] == profiler.id.toString()
+    }
+}

--- a/ratpack/src/test/groovy/io/jdev/miniprofiler/ratpack/MiniProfilerResultsHandlerSpec.groovy
+++ b/ratpack/src/test/groovy/io/jdev/miniprofiler/ratpack/MiniProfilerResultsHandlerSpec.groovy
@@ -18,6 +18,7 @@ package io.jdev.miniprofiler.ratpack
 
 import io.jdev.miniprofiler.ProfileLevel
 import io.jdev.miniprofiler.internal.ProfilerImpl
+import io.jdev.miniprofiler.storage.MapStorage
 import io.jdev.miniprofiler.test.TestProfilerProvider
 import ratpack.func.Action
 import ratpack.test.handling.RequestFixture
@@ -114,6 +115,30 @@ class MiniProfilerResultsHandlerSpec extends Specification {
         then: '400 sent'
         result.sentResponse
         result.status.code == 400
+    }
+
+    void "handler marks profiler as viewed when serving results"() {
+        given:
+        def viewedProvider = new TestProfilerProvider()
+        def viewedProfiler = new ProfilerImpl("viewed-test", ProfileLevel.Info, viewedProvider)
+        viewedProfiler.setUser('alice')
+        viewedProfiler.stop()
+        def storage = (MapStorage) viewedProvider.storage
+        storage.save(viewedProfiler)
+        storage.setUnviewed('alice', viewedProfiler.id)
+        def viewedHandler = new MiniProfilerResultsHandler(viewedProvider)
+
+        when:
+        def result = handle(viewedHandler, { RequestFixture req ->
+            req.body("{\"Id\":\"$viewedProfiler.id\"}", APPLICATION_JSON)
+            req.header(ACCEPT, APPLICATION_JSON)
+        } as Action)
+
+        then:
+        result.status.code == 200
+
+        and: 'profiler is no longer unviewed'
+        storage.getUnviewedIds('alice').isEmpty()
     }
 
     void "handler serves standalone results page"() {

--- a/ratpack/src/test/groovy/io/jdev/miniprofiler/ratpack/MiniProfilerResultsHandlerSpec.groovy
+++ b/ratpack/src/test/groovy/io/jdev/miniprofiler/ratpack/MiniProfilerResultsHandlerSpec.groovy
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015-2023 the original author or authors.
+ * Copyright 2015-2026 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/ratpack/src/testFixtures/groovy/io/jdev/miniprofiler/ratpack/InProcessRatpack.groovy
+++ b/ratpack/src/testFixtures/groovy/io/jdev/miniprofiler/ratpack/InProcessRatpack.groovy
@@ -16,11 +16,10 @@
 
 package io.jdev.miniprofiler.ratpack
 
-import io.jdev.miniprofiler.ProfileLevel
 import io.jdev.miniprofiler.ProfilerProvider
 import io.jdev.miniprofiler.ScriptTagWriter
 import io.jdev.miniprofiler.integtest.InProcessTestedServer
-import io.jdev.miniprofiler.internal.ProfilerImpl
+import io.jdev.miniprofiler.user.UserProvider
 import ratpack.func.Action
 import ratpack.guice.Guice
 import ratpack.server.RatpackServer
@@ -32,9 +31,18 @@ import ratpack.server.RatpackServerSpec
 class InProcessRatpack implements InProcessTestedServer {
 
     private final RatpackServer server
+    private final String testUser
 
     InProcessRatpack() {
+        this(null)
+    }
+
+    InProcessRatpack(String testUser) {
+        this.testUser = testUser
         server = RatpackServer.start(configure())
+        if (testUser != null) {
+            profilerProvider.userProvider = { testUser } as UserProvider
+        }
     }
 
     protected Action<? super RatpackServerSpec> configure() {
@@ -43,21 +51,22 @@ class InProcessRatpack implements InProcessTestedServer {
                 bindings.module(MiniProfilerModule)
             })
             spec.handlers { chain ->
-                chain.get('test-page') { ctx ->
-                    def provider = ctx.get(ProfilerProvider)
-                    def profiler = new ProfilerImpl('/test-page', ProfileLevel.Info, provider)
-                    def child = profiler.step('child step')
-                    child.addCustomTiming('sql', 'reader', 'select * from people', 50L)
-                    child.stop()
-                    profiler.stop()
-                    provider.storage.save(profiler)
-                    def scriptTag = new ScriptTagWriter(provider).printScriptTag(profiler)
-                    def html = """\
-                        <html><head>${scriptTag}</head><body>
-                        <h1>Test Page</h1>
-                        <button id="ajax-call" onclick="fetch('/ajax-endpoint').then(r => r.text())">Make AJAX Call</button>
-                        </body></html>""".stripIndent()
-                    ctx.response.send('text/html; charset=utf-8', html)
+                chain.prefix('test-page') { testPageChain ->
+                    testPageChain.insert(MiniProfilerStartProfilingHandlers)
+                    testPageChain.get { ctx ->
+                        def provider = ctx.get(ProfilerProvider)
+                        def profiler = provider.current()
+                        def child = profiler.step('child step')
+                        child.addCustomTiming('sql', 'reader', 'select * from people', 50L)
+                        child.stop()
+                        def scriptTag = new ScriptTagWriter(provider).printScriptTag(profiler)
+                        def html = """\
+                            <html><head>${scriptTag}</head><body>
+                            <h1>Test Page</h1>
+                            <button id="ajax-call" onclick="fetch('/ajax-endpoint').then(r => r.text())">Make AJAX Call</button>
+                            </body></html>""".stripIndent()
+                        ctx.response.send('text/html; charset=utf-8', html)
+                    }
                 }
                 chain.prefix('ajax-endpoint') { ajaxChain ->
                     ajaxChain.insert(MiniProfilerStartProfilingHandlers)
@@ -83,6 +92,38 @@ class InProcessRatpack implements InProcessTestedServer {
     @Override
     ProfilerProvider getProfilerProvider() {
         server.registry.get().get(ProfilerProvider)
+    }
+
+    @Override
+    String getTestUser() { testUser }
+
+    @Override
+    void waitForProfilerSave(UUID id) {
+        def storage = profilerProvider.storage as io.jdev.miniprofiler.storage.MapStorage
+        def deadline = System.currentTimeMillis() + 2000
+        // Wait for both the save and the setUnviewed to complete — they are chained
+        // asynchronously in RatpackContextProfilerProvider.saveProfiler()
+        while (System.currentTimeMillis() < deadline) {
+            if (storage.load(id) == null) {
+                Thread.sleep(50)
+                continue
+            }
+            if (testUser == null || !storage.getUnviewedIds(testUser).isEmpty()) {
+                break
+            }
+            Thread.sleep(50)
+        }
+    }
+
+    @Override
+    void clearProfiles() {
+        def storage = profilerProvider.storage as io.jdev.miniprofiler.storage.MapStorage
+        // Clear twice with a pause to drain any in-flight async saves from the previous test.
+        // RatpackContextProfilerProvider.saveProfiler() chains saveAsync → setUnviewedAsync
+        // asynchronously, so a setUnviewed call may land after the first clear.
+        storage.clear()
+        Thread.sleep(100)
+        storage.clear()
     }
 
     @Override

--- a/testlib-integration/src/main/groovy/io/jdev/miniprofiler/integtest/AbstractProfilingHandlerIntegrationSpec.groovy
+++ b/testlib-integration/src/main/groovy/io/jdev/miniprofiler/integtest/AbstractProfilingHandlerIntegrationSpec.groovy
@@ -164,6 +164,47 @@ abstract class AbstractProfilingHandlerIntegrationSpec extends Specification {
         response.statusCode() == 404
     }
 
+    @Requires({ instance.server.testUser && instance.server.profiledPagePath })
+    void 'unviewed id from previous request appears in X-MiniProfiler-Ids header of next request'() {
+        when: 'first request is made but results are not fetched'
+        def firstResponse = client.get(server.profiledPagePath)
+        def firstId = firstResponse.miniProfilerId()
+
+        and: 'second request is made'
+        def secondResponse = client.get(server.profiledPagePath)
+
+        then: 'the second response header includes the first request id as unviewed'
+        secondResponse.miniProfilerIds().contains(firstId)
+    }
+
+    @Requires({ instance.server.testUser && instance.server.profiledPagePath })
+    void 'after a profiled request the profiler id appears in getUnviewedIds for the test user'() {
+        when:
+        def response = client.get(server.profiledPagePath)
+
+        then:
+        response.statusCode() == 200
+        def id = UUID.fromString(response.miniProfilerId())
+        (server.profilerProvider.storage as io.jdev.miniprofiler.storage.MapStorage)
+            .getUnviewedIds(server.testUser).contains(id)
+    }
+
+    @Requires({ instance.server.testUser && instance.server.profiledPagePath })
+    void 'fetching results removes the profiler id from getUnviewedIds'() {
+        given:
+        def pageResponse = client.get(server.profiledPagePath)
+        def id = pageResponse.miniProfilerId()
+        assert (server.profilerProvider.storage as io.jdev.miniprofiler.storage.MapStorage)
+            .getUnviewedIds(server.testUser).contains(UUID.fromString(id))
+
+        when:
+        client.getResultsJson(id)
+
+        then:
+        !(server.profilerProvider.storage as io.jdev.miniprofiler.storage.MapStorage)
+            .getUnviewedIds(server.testUser).contains(UUID.fromString(id))
+    }
+
     @Requires({ instance.server.ajaxEndpointPath })
     void 'ajax endpoint is profiled with X-MiniProfiler-Ids header'() {
         when:

--- a/testlib-integration/src/main/groovy/io/jdev/miniprofiler/integtest/AbstractProfilingHandlerIntegrationSpec.groovy
+++ b/testlib-integration/src/main/groovy/io/jdev/miniprofiler/integtest/AbstractProfilingHandlerIntegrationSpec.groovy
@@ -81,13 +81,10 @@ abstract class AbstractProfilingHandlerIntegrationSpec extends Specification {
 
     void 'results endpoint returns HTML for known id'() {
         given:
-        def profiler = server.profilerProvider.start('test-request')
-        profiler.stop()
-        def list = client.getResultsList().bodyAsJson() as List
-        def knownId = list[0].Id
+        def profiler = server.createProfile('test-request')
 
         when:
-        def response = client.getResultsHtml(knownId as String)
+        def response = client.getResultsHtml(profiler.id.toString())
 
         then:
         response.statusCode() == 200
@@ -105,8 +102,7 @@ abstract class AbstractProfilingHandlerIntegrationSpec extends Specification {
 
     void 'results-list returns JSON array of stored profiles'() {
         given:
-        def profiler = server.profilerProvider.start('test-request')
-        profiler.stop()
+        def profiler = server.createProfile('test-request')
 
         when:
         def response = client.getResultsList()
@@ -121,11 +117,9 @@ abstract class AbstractProfilingHandlerIntegrationSpec extends Specification {
 
     void 'results-list pagination with last-id filters results'() {
         given:
-        def first = server.profilerProvider.start('first-request')
-        first.stop()
+        def first = server.createProfile('first-request')
         Thread.sleep(10)
-        def second = server.profilerProvider.start('second-request')
-        second.stop()
+        def second = server.createProfile('second-request')
 
         when:
         def response = client.getResultsList(first.id.toString())
@@ -170,6 +164,9 @@ abstract class AbstractProfilingHandlerIntegrationSpec extends Specification {
         def firstResponse = client.get(server.profiledPagePath)
         def firstId = firstResponse.miniProfilerId()
 
+        and: 'wait for async save if needed'
+        server.waitForProfilerSave(UUID.fromString(firstId))
+
         and: 'second request is made'
         def secondResponse = client.get(server.profiledPagePath)
 
@@ -181,10 +178,11 @@ abstract class AbstractProfilingHandlerIntegrationSpec extends Specification {
     void 'after a profiled request the profiler id appears in getUnviewedIds for the test user'() {
         when:
         def response = client.get(server.profiledPagePath)
+        def id = UUID.fromString(response.miniProfilerId())
+        server.waitForProfilerSave(id)
 
         then:
         response.statusCode() == 200
-        def id = UUID.fromString(response.miniProfilerId())
         (server.profilerProvider.storage as io.jdev.miniprofiler.storage.MapStorage)
             .getUnviewedIds(server.testUser).contains(id)
     }
@@ -194,6 +192,7 @@ abstract class AbstractProfilingHandlerIntegrationSpec extends Specification {
         given:
         def pageResponse = client.get(server.profiledPagePath)
         def id = pageResponse.miniProfilerId()
+        server.waitForProfilerSave(UUID.fromString(id))
         assert (server.profilerProvider.storage as io.jdev.miniprofiler.storage.MapStorage)
             .getUnviewedIds(server.testUser).contains(UUID.fromString(id))
 

--- a/testlib-integration/src/main/java/io/jdev/miniprofiler/integtest/InProcessTestedServer.java
+++ b/testlib-integration/src/main/java/io/jdev/miniprofiler/integtest/InProcessTestedServer.java
@@ -16,6 +16,7 @@
 
 package io.jdev.miniprofiler.integtest;
 
+import io.jdev.miniprofiler.ProfileLevel;
 import io.jdev.miniprofiler.ProfilerProvider;
 import io.jdev.miniprofiler.internal.ProfilerImpl;
 import io.jdev.miniprofiler.storage.MapStorage;
@@ -75,8 +76,37 @@ public interface InProcessTestedServer extends TestedServer {
         return null;
     }
 
+    /**
+     * Creates a stopped profiler with the given name and saves it directly to storage.
+     *
+     * <p>This bypasses the provider's {@code start()} lifecycle, making it safe to call
+     * from any thread (e.g. Ratpack providers require a managed thread for {@code start()}).</p>
+     *
+     * @param name the profiler name
+     * @return the saved profiler
+     */
+    default ProfilerImpl createProfile(String name) {
+        ProfilerImpl profiler = new ProfilerImpl(null, name, name, ProfileLevel.Info, null);
+        profiler.stop();
+        getProfilerProvider().getStorage().save(profiler);
+        return profiler;
+    }
+
     default void addProfile(ProfilerImpl profiler) {
         getProfilerProvider().getStorage().save(profiler);
+    }
+
+    /**
+     * Waits for a profiler with the given ID to be saved to storage.
+     *
+     * <p>The default implementation returns immediately, assuming synchronous saves.
+     * Implementations with asynchronous save paths (e.g. Ratpack) should override
+     * this to poll until the profiler appears in storage.</p>
+     *
+     * @param id the profiler ID to wait for
+     */
+    default void waitForProfilerSave(java.util.UUID id) {
+        // synchronous by default — no waiting needed
     }
 
     default void clearProfiles() {

--- a/testlib-integration/src/main/java/io/jdev/miniprofiler/integtest/InProcessTestedServer.java
+++ b/testlib-integration/src/main/java/io/jdev/miniprofiler/integtest/InProcessTestedServer.java
@@ -62,6 +62,19 @@ public interface InProcessTestedServer extends TestedServer {
         return null;
     }
 
+    /**
+     * Returns a fixed username configured on the server's {@code UserProvider}, or {@code null}
+     * if this server does not configure a user provider.
+     *
+     * <p>Integration tests gated on a non-null value can use this user to verify
+     * viewed/unviewed state.</p>
+     *
+     * @return the test user name, or {@code null}
+     */
+    default String getTestUser() {
+        return null;
+    }
+
     default void addProfile(ProfilerImpl profiler) {
         getProfilerProvider().getStorage().save(profiler);
     }


### PR DESCRIPTION
## Summary

- Implement the viewed/unviewed profiler lifecycle from .NET MiniProfiler: profiles are marked unviewed when saved and viewed when results are fetched by the browser
- The `X-MiniProfiler-Ids` response header now includes previously-unviewed profile IDs alongside the current request's ID, capped by a configurable `maxUnviewedProfiles` (default 20)
- Wire the lifecycle across all handler implementations: servlet (javax + jakarta), core `MiniProfilerServer`, and Ratpack (async)

## Changes

**Core (`miniprofiler-core`):**
- Add `maxUnviewedProfiles` to `ProfilerUiConfig` (property: `miniprofiler.max.unviewed.profiles`)
- Implement `setUnviewed`, `setViewed`, `getUnviewedIds` on `MapStorage` with `ConcurrentHashMap`-backed per-user sets; LRU-evicted profiles are filtered out automatically
- `BaseProfilerProvider.saveProfiler()` calls `setUnviewed` after save
- `MiniProfilerServer.handleResults()` calls `setViewed` after load
- Rename `IdParser` → `Ids` and add `Ids.buildIdsHeader()` shared helper

**Servlet (`javax-servlet`, `jakarta-servlet`):**
- `ProfilingFilter.doFilter()` uses `Ids.buildIdsHeader()` for the full header
- `ProfilingFilter.serveResults()` calls `setViewed` after load

**Ratpack:**
- `RatpackContextProfilerProvider.saveProfiler()` chains `setUnviewedAsync` after async save
- `MiniProfilerResultsHandler` chains `setViewedAsync` before rendering
- `MiniProfilerAjaxHeaderHandler` now injects `ProfilerProvider` and uses `Ids.buildIdsHeader()`

**Test infrastructure (`testlib-integration`):**
- Add `InProcessTestedServer.createProfile()` (thread-safe, bypasses provider lifecycle) and `waitForProfilerSave()` hook for async implementations
- `AbstractProfilingHandlerIntegrationSpec` uses these for Ratpack compatibility and adds viewed/unviewed integration tests gated on `testUser`