### PR TITLE
Add Storage/ProfilerProvider AutoCloseable lifecycle + container shutdown wiring

### DIFF
--- a/core/src/main/java/io/jdev/miniprofiler/BaseProfilerProvider.java
+++ b/core/src/main/java/io/jdev/miniprofiler/BaseProfilerProvider.java
@@ -30,6 +30,7 @@ import java.net.UnknownHostException;
 import java.util.Map;
 import java.util.UUID;
 import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.atomic.AtomicBoolean;
 
 /**
  * Support class for profiler providers. This provides most functionality
@@ -46,6 +47,7 @@ public abstract class BaseProfilerProvider implements ProfilerProvider {
     private volatile UserProvider userProvider;
     private String machineName = getDefaultHostname();
     private ProfilerUiConfig uiConfig;
+    private final AtomicBoolean closed = new AtomicBoolean(false);
 
     /**
      * Called after a new profiler is created. Subclasses should
@@ -349,6 +351,17 @@ public abstract class BaseProfilerProvider implements ProfilerProvider {
     @Override
     public void setUiConfig(ProfilerUiConfig uiConfig) {
         this.uiConfig = uiConfig;
+    }
+
+    /**
+     * Closes this provider and its storage. Idempotent: only the first call
+     * has any effect; subsequent calls are silently ignored.
+     */
+    @Override
+    public void close() {
+        if (closed.compareAndSet(false, true)) {
+            getStorage().close();
+        }
     }
 
 }

--- a/core/src/main/java/io/jdev/miniprofiler/DelegatingProfilerProvider.java
+++ b/core/src/main/java/io/jdev/miniprofiler/DelegatingProfilerProvider.java
@@ -129,4 +129,9 @@ public abstract class DelegatingProfilerProvider implements ProfilerProvider {
         getDelegate().setUserProvider(userProvider);
     }
 
+    @Override
+    public void close() {
+        getDelegate().close();
+    }
+
 }

--- a/core/src/main/java/io/jdev/miniprofiler/ProfilerProvider.java
+++ b/core/src/main/java/io/jdev/miniprofiler/ProfilerProvider.java
@@ -42,7 +42,7 @@ import java.util.UUID;
  * instance can be set using
  * {@link MiniProfiler#setProfilerProvider(ProfilerProvider)}.</p>
  */
-public interface ProfilerProvider {
+public interface ProfilerProvider extends AutoCloseable {
 
     /**
      * Start a new profiling session with the default {@link ProfileLevel#Info} level.
@@ -200,5 +200,23 @@ public interface ProfilerProvider {
      * @see UserProvider
      */
     void setUserProvider(UserProvider userProvider);
+
+    /**
+     * Releases resources held by this provider and its associated storage.
+     * Default: closes the provider's {@link Storage}.
+     *
+     * <p>Implementations must be idempotent: calling {@code close()} more than
+     * once must have no further effect after the first call. This is important
+     * because a provider may be registered with multiple container lifecycle hooks
+     * (e.g. a CDI {@code @PreDestroy} and a servlet {@code destroy()}) that
+     * both fire on application undeploy.</p>
+     *
+     * <p>{@link BaseProfilerProvider} provides an idempotent implementation via
+     * an {@link java.util.concurrent.atomic.AtomicBoolean} guard.</p>
+     */
+    @Override
+    default void close() {
+        getStorage().close();
+    }
 
 }

--- a/core/src/main/java/io/jdev/miniprofiler/server/MiniProfilerServer.java
+++ b/core/src/main/java/io/jdev/miniprofiler/server/MiniProfilerServer.java
@@ -60,6 +60,7 @@ public class MiniProfilerServer implements AutoCloseable {
     private final ProfilerProvider provider;
     private final HttpServer httpServer;
     private final ResourceHelper resourceHelper = new ResourceHelper();
+    private final boolean closeProviderOnClose;
 
     /**
      * Creates and starts a server on a random available port.
@@ -68,7 +69,7 @@ public class MiniProfilerServer implements AutoCloseable {
      * @throws IOException if the server cannot be started
      */
     public MiniProfilerServer(ProfilerProvider provider) throws IOException {
-        this(provider, null);
+        this(provider, null, true);
     }
 
     /**
@@ -81,7 +82,24 @@ public class MiniProfilerServer implements AutoCloseable {
      * @throws IOException if the server cannot be started
      */
     public MiniProfilerServer(ProfilerProvider provider, Consumer<HttpServer> customizer) throws IOException {
+        this(provider, customizer, true);
+    }
+
+    /**
+     * Creates and starts a server on a random available port.
+     *
+     * @param provider             the profiler provider supplying UI config, storage, and profiler results
+     * @param customizer           optional consumer called on the {@link HttpServer} before start;
+     *                             use it to register additional contexts
+     * @param closeProviderOnClose if {@code true}, {@link #close()} will also call
+     *                             {@link ProfilerProvider#close()} on the provider; set to
+     *                             {@code false} when the provider lifecycle is managed externally
+     * @throws IOException if the server cannot be started
+     */
+    public MiniProfilerServer(ProfilerProvider provider, Consumer<HttpServer> customizer,
+            boolean closeProviderOnClose) throws IOException {
         this.provider = provider;
+        this.closeProviderOnClose = closeProviderOnClose;
         String path = provider.getUiConfig().getPath();
         String basePath = path.endsWith("/") ? path : path + "/";
 
@@ -144,10 +162,13 @@ public class MiniProfilerServer implements AutoCloseable {
         return "http://127.0.0.1:" + getPort() + "/";
     }
 
-    /** Stops the server immediately. */
+    /** Stops the server and, if {@code closeProviderOnClose} is {@code true}, closes the provider. */
     @Override
     public void close() {
         httpServer.stop(0);
+        if (closeProviderOnClose) {
+            provider.close();
+        }
     }
 
     private void handleResults(HttpExchange exchange) throws IOException {

--- a/core/src/main/java/io/jdev/miniprofiler/storage/MapStorage.java
+++ b/core/src/main/java/io/jdev/miniprofiler/storage/MapStorage.java
@@ -18,11 +18,13 @@ package io.jdev.miniprofiler.storage;
 
 import io.jdev.miniprofiler.internal.ProfilerImpl;
 
+import java.time.Instant;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.Comparator;
 import java.util.Date;
+import java.util.HashSet;
 import java.util.Iterator;
 import java.util.LinkedHashMap;
 import java.util.List;
@@ -128,9 +130,29 @@ public class MapStorage extends BaseStorage {
     }
 
     /** Removes all cached profiler sessions and resets unviewed state. */
+    @Override
     public void clear() {
         cache.clear();
         unviewedByUser.clear();
+    }
+
+    @Override
+    public void expireOlderThan(Instant cutoff) {
+        long cutoffMs = cutoff.toEpochMilli();
+        Set<UUID> removed = new HashSet<>();
+        synchronized (cache) {
+            Iterator<Map.Entry<UUID, ProfilerImpl>> it = cache.entrySet().iterator();
+            while (it.hasNext()) {
+                Map.Entry<UUID, ProfilerImpl> entry = it.next();
+                if (entry.getValue().getStarted() < cutoffMs) {
+                    removed.add(entry.getKey());
+                    it.remove();
+                }
+            }
+        }
+        if (!removed.isEmpty()) {
+            unviewedByUser.values().forEach(set -> set.removeAll(removed));
+        }
     }
 
     private static class LRUMapCache extends LinkedHashMap<UUID, ProfilerImpl> {

--- a/core/src/main/java/io/jdev/miniprofiler/storage/Storage.java
+++ b/core/src/main/java/io/jdev/miniprofiler/storage/Storage.java
@@ -91,7 +91,12 @@ public interface Storage extends AutoCloseable {
      */
     Collection<UUID> getUnviewedIds(String user);
 
-    /** Releases any resources held by this storage. Default: no-op. */
+    /**
+     * Releases any resources held by this storage. Default: no-op.
+     *
+     * <p>Implementations must be idempotent: calling {@code close()} more than
+     * once must have no further effect after the first call.</p>
+     */
     @Override
     default void close() {}
 

--- a/core/src/main/java/io/jdev/miniprofiler/storage/Storage.java
+++ b/core/src/main/java/io/jdev/miniprofiler/storage/Storage.java
@@ -18,6 +18,7 @@ package io.jdev.miniprofiler.storage;
 
 import io.jdev.miniprofiler.internal.ProfilerImpl;
 
+import java.time.Instant;
 import java.util.Collection;
 import java.util.Date;
 import java.util.UUID;
@@ -89,4 +90,15 @@ public interface Storage {
      * @return a list of ids that the user hasn't viewed
      */
     Collection<UUID> getUnviewedIds(String user);
+
+    /** Removes all stored profiling sessions and resets associated state. Default: no-op. */
+    default void clear() {}
+
+    /**
+     * Removes all profiling sessions that started before the given cutoff instant.
+     * Default: no-op.
+     *
+     * @param cutoff sessions started strictly before this instant are removed
+     */
+    default void expireOlderThan(Instant cutoff) {}
 }

--- a/core/src/main/java/io/jdev/miniprofiler/storage/Storage.java
+++ b/core/src/main/java/io/jdev/miniprofiler/storage/Storage.java
@@ -29,7 +29,7 @@ import java.util.UUID;
  * <p>Profiling info is stored for later retrieval either by AJAX from the
  * mini-profiler UI on the same page, or later inspection.</p>
  */
-public interface Storage {
+public interface Storage extends AutoCloseable {
 
     /**
      * Which order to list results in.
@@ -90,6 +90,10 @@ public interface Storage {
      * @return a list of ids that the user hasn't viewed
      */
     Collection<UUID> getUnviewedIds(String user);
+
+    /** Releases any resources held by this storage. Default: no-op. */
+    @Override
+    default void close() {}
 
     /** Removes all stored profiling sessions and resets associated state. Default: no-op. */
     default void clear() {}

--- a/core/src/test/groovy/io/jdev/miniprofiler/DefaultProfilerProviderSpec.groovy
+++ b/core/src/test/groovy/io/jdev/miniprofiler/DefaultProfilerProviderSpec.groovy
@@ -23,6 +23,7 @@ import spock.lang.Specification
 
 import java.util.concurrent.ExecutorService
 import java.util.concurrent.Executors
+import java.util.concurrent.atomic.AtomicInteger
 
 class DefaultProfilerProviderSpec extends Specification {
 
@@ -73,6 +74,24 @@ class DefaultProfilerProviderSpec extends Specification {
 
         and: 'still current in that thread'
         otherProfiler == executorService.submit({ profilerProvider.current }).get()
+    }
+
+    void "close is idempotent: storage.close() called only once even if close() is called multiple times"() {
+        given:
+        def closeCount = new AtomicInteger(0)
+        def trackingStorage = new MapStorage() {
+            @Override
+            void close() { closeCount.incrementAndGet() }
+        }
+        profilerProvider.storage = trackingStorage
+
+        when:
+        profilerProvider.close()
+        profilerProvider.close()
+        profilerProvider.close()
+
+        then:
+        closeCount.get() == 1
     }
 
 }

--- a/core/src/test/groovy/io/jdev/miniprofiler/DefaultProfilerProviderSpec.groovy
+++ b/core/src/test/groovy/io/jdev/miniprofiler/DefaultProfilerProviderSpec.groovy
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013-2017 the original author or authors.
+ * Copyright 2013-2026 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/core/src/test/groovy/io/jdev/miniprofiler/server/MiniProfilerServerSpec.groovy
+++ b/core/src/test/groovy/io/jdev/miniprofiler/server/MiniProfilerServerSpec.groovy
@@ -18,9 +18,12 @@ package io.jdev.miniprofiler.server
 
 import groovy.json.JsonSlurper
 import io.jdev.miniprofiler.Profiler
+import io.jdev.miniprofiler.storage.MapStorage
 import io.jdev.miniprofiler.test.TestProfilerProvider
 import spock.lang.AutoCleanup
 import spock.lang.Specification
+
+import java.util.concurrent.atomic.AtomicInteger
 
 class MiniProfilerServerSpec extends Specification {
 
@@ -224,6 +227,40 @@ class MiniProfilerServerSpec extends Specification {
 
         then:
         conn.responseCode == 405
+    }
+
+    // ---- close / provider lifecycle --------------------------------------
+
+    void "close() closes the provider by default"() {
+        given:
+        def closeCount = new AtomicInteger(0)
+        def trackingStorage = new MapStorage() {
+            @Override void close() { closeCount.incrementAndGet() }
+        }
+        def localProvider = new TestProfilerProvider(storage: trackingStorage)
+        def localServer = new MiniProfilerServer(localProvider)
+
+        when:
+        localServer.close()
+
+        then:
+        closeCount.get() == 1
+    }
+
+    void "close() does not close the provider when closeProviderOnClose is false"() {
+        given:
+        def closeCount = new AtomicInteger(0)
+        def trackingStorage = new MapStorage() {
+            @Override void close() { closeCount.incrementAndGet() }
+        }
+        def localProvider = new TestProfilerProvider(storage: trackingStorage)
+        def localServer = new MiniProfilerServer(localProvider, null, false)
+
+        when:
+        localServer.close()
+
+        then:
+        closeCount.get() == 0
     }
 
     // ---- customizer ------------------------------------------------------

--- a/core/src/test/groovy/io/jdev/miniprofiler/storage/MapStorageSpec.groovy
+++ b/core/src/test/groovy/io/jdev/miniprofiler/storage/MapStorageSpec.groovy
@@ -22,6 +22,8 @@ import io.jdev.miniprofiler.ProfilerProvider
 import io.jdev.miniprofiler.storage.Storage.ListResultsOrder
 import spock.lang.Specification
 
+import java.time.Instant
+
 class MapStorageSpec extends Specification {
 
     MapStorage storage
@@ -279,5 +281,58 @@ class MapStorageSpec extends Specification {
 
         then:
         storage.getUnviewedIds('alice').empty
+    }
+
+    void "expireOlderThan removes sessions started before cutoff"() {
+        given:
+        storage = new MapStorage(10)
+        def val1 = new ProfilerImpl(null, 'test1', 'test1', ProfileLevel.Info, profilerProvider)
+        Thread.sleep(10)
+        def val2 = new ProfilerImpl(null, 'test2', 'test2', ProfileLevel.Info, profilerProvider)
+        Thread.sleep(10)
+        def val3 = new ProfilerImpl(null, 'test3', 'test3', ProfileLevel.Info, profilerProvider)
+        storage.save(val1)
+        storage.save(val2)
+        storage.save(val3)
+
+        when:
+        storage.expireOlderThan(Instant.ofEpochMilli(val2.started))
+
+        then:
+        !storage.load(val1.id)
+        storage.load(val2.id) == val2
+        storage.load(val3.id) == val3
+    }
+
+    void "expireOlderThan keeps session started at exactly the cutoff"() {
+        given:
+        storage = new MapStorage(10)
+        def val = new ProfilerImpl(null, 'test', 'test', ProfileLevel.Info, profilerProvider)
+        storage.save(val)
+
+        when:
+        storage.expireOlderThan(Instant.ofEpochMilli(val.started))
+
+        then:
+        storage.load(val.id) == val
+    }
+
+    void "expireOlderThan cleans up unviewed state for removed sessions"() {
+        given:
+        storage = new MapStorage(10)
+        def val1 = new ProfilerImpl(null, 'test1', 'test1', ProfileLevel.Info, profilerProvider)
+        Thread.sleep(10)
+        def val2 = new ProfilerImpl(null, 'test2', 'test2', ProfileLevel.Info, profilerProvider)
+        storage.save(val1)
+        storage.save(val2)
+        storage.setUnviewed('alice', val1.id)
+        storage.setUnviewed('alice', val2.id)
+
+        when:
+        storage.expireOlderThan(Instant.ofEpochMilli(val2.started))
+
+        then:
+        !storage.unviewedByUser['alice'].contains(val1.id)
+        storage.unviewedByUser['alice'].contains(val2.id)
     }
 }

--- a/jakarta-ee/src/integrationTest/groovy/io/jdev/miniprofiler/jakarta/ee/DefaultCdiProfilerProviderIntegrationSpec.groovy
+++ b/jakarta-ee/src/integrationTest/groovy/io/jdev/miniprofiler/jakarta/ee/DefaultCdiProfilerProviderIntegrationSpec.groovy
@@ -1,0 +1,53 @@
+/*
+ * Copyright 2026 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.jdev.miniprofiler.jakarta.ee
+
+import io.jdev.miniprofiler.ProfilerProvider
+import io.jdev.miniprofiler.storage.MapStorage
+import spock.lang.Specification
+
+import jakarta.enterprise.inject.se.SeContainerInitializer
+import java.util.concurrent.atomic.AtomicInteger
+
+class DefaultCdiProfilerProviderIntegrationSpec extends Specification {
+
+    void "CDI container calls @PreDestroy shutdown() which closes the storage"() {
+        given: 'a tracking storage that counts close() calls'
+        def closeCount = new AtomicInteger(0)
+        def trackingStorage = new MapStorage() {
+            @Override
+            void close() {
+                closeCount.incrementAndGet()
+            }
+        }
+
+        and: 'a CDI SE container with DefaultCdiProfilerProvider'
+        def container = SeContainerInitializer.newInstance()
+            .addBeanClasses(DefaultCdiProfilerProvider)
+            .initialize()
+
+        and: 'the provider bean has the tracking storage injected'
+        def provider = container.select(ProfilerProvider).get()
+        provider.storage = trackingStorage
+
+        when: 'the container is closed, triggering @PreDestroy'
+        container.close()
+
+        then:
+        closeCount.get() == 1
+    }
+}

--- a/jakarta-ee/src/main/java/io/jdev/miniprofiler/jakarta/ee/DefaultCdiProfilerProvider.java
+++ b/jakarta-ee/src/main/java/io/jdev/miniprofiler/jakarta/ee/DefaultCdiProfilerProvider.java
@@ -18,6 +18,7 @@ package io.jdev.miniprofiler.jakarta.ee;
 
 import io.jdev.miniprofiler.DefaultProfilerProvider;
 
+import jakarta.annotation.PreDestroy;
 import jakarta.enterprise.context.ApplicationScoped;
 import jakarta.enterprise.inject.Default;
 
@@ -31,5 +32,11 @@ public class DefaultCdiProfilerProvider extends DefaultProfilerProvider {
 
     /** Default constructor for CDI. */
     public DefaultCdiProfilerProvider() {
+    }
+
+    /** Called by the CDI container on application undeploy to release storage resources. */
+    @PreDestroy
+    public void shutdown() {
+        close();
     }
 }

--- a/jakarta-ee/src/test/groovy/io/jdev/miniprofiler/jakarta/ee/DefaultCdiProfilerProviderSpec.groovy
+++ b/jakarta-ee/src/test/groovy/io/jdev/miniprofiler/jakarta/ee/DefaultCdiProfilerProviderSpec.groovy
@@ -1,0 +1,36 @@
+/*
+ * Copyright 2026 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.jdev.miniprofiler.jakarta.ee
+
+import io.jdev.miniprofiler.storage.Storage
+import spock.lang.Specification
+
+class DefaultCdiProfilerProviderSpec extends Specification {
+
+    void "shutdown() closes the storage"() {
+        given:
+        def storage = Mock(Storage)
+        def provider = new DefaultCdiProfilerProvider()
+        provider.storage = storage
+
+        when:
+        provider.shutdown()
+
+        then:
+        1 * storage.close()
+    }
+}

--- a/jakarta-servlet/src/main/java/io/jdev/miniprofiler/jakarta/servlet/ProfilingFilter.java
+++ b/jakarta-servlet/src/main/java/io/jdev/miniprofiler/jakarta/servlet/ProfilingFilter.java
@@ -324,6 +324,11 @@ public class ProfilingFilter implements Filter {
         }
     }
 
+    @Override
+    public void destroy() {
+        profilerProvider.close();
+    }
+
     /**
      * Here so that DI frameworks can inject a profiler provider, rather than
      * relying on {@link MiniProfiler#start(String)}.

--- a/jakarta-servlet/src/test/groovy/io/jdev/miniprofiler/jakarta/servlet/ProfilingFilterSpec.groovy
+++ b/jakarta-servlet/src/test/groovy/io/jdev/miniprofiler/jakarta/servlet/ProfilingFilterSpec.groovy
@@ -413,6 +413,18 @@ class ProfilingFilterSpec extends Specification {
         then: 'profiler is no longer in unviewed set'
         !storage.getUnviewedIds('alice').contains(storage.profiler.id)
     }
+
+    void "destroy closes the profiler provider"() {
+        given:
+        def mockProvider = Mock(ProfilerProvider)
+        filter.profilerProvider = mockProvider
+
+        when:
+        filter.destroy()
+
+        then:
+        1 * mockProvider.close()
+    }
 }
 
 class MockFilterChain implements FilterChain {

--- a/javax-ee/src/integrationTest/groovy/io/jdev/miniprofiler/javax/ee/DefaultCdiProfilerProviderIntegrationSpec.groovy
+++ b/javax-ee/src/integrationTest/groovy/io/jdev/miniprofiler/javax/ee/DefaultCdiProfilerProviderIntegrationSpec.groovy
@@ -1,0 +1,53 @@
+/*
+ * Copyright 2026 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.jdev.miniprofiler.javax.ee
+
+import io.jdev.miniprofiler.ProfilerProvider
+import io.jdev.miniprofiler.storage.MapStorage
+import spock.lang.Specification
+
+import javax.enterprise.inject.se.SeContainerInitializer
+import java.util.concurrent.atomic.AtomicInteger
+
+class DefaultCdiProfilerProviderIntegrationSpec extends Specification {
+
+    void "CDI container calls @PreDestroy shutdown() which closes the storage"() {
+        given: 'a tracking storage that counts close() calls'
+        def closeCount = new AtomicInteger(0)
+        def trackingStorage = new MapStorage() {
+            @Override
+            void close() {
+                closeCount.incrementAndGet()
+            }
+        }
+
+        and: 'a CDI SE container with DefaultCdiProfilerProvider'
+        def container = SeContainerInitializer.newInstance()
+            .addBeanClasses(DefaultCdiProfilerProvider)
+            .initialize()
+
+        and: 'the provider bean has the tracking storage injected'
+        def provider = container.select(ProfilerProvider).get()
+        provider.storage = trackingStorage
+
+        when: 'the container is closed, triggering @PreDestroy'
+        container.close()
+
+        then:
+        closeCount.get() == 1
+    }
+}

--- a/javax-ee/src/main/java/io/jdev/miniprofiler/javax/ee/DefaultCdiProfilerProvider.java
+++ b/javax-ee/src/main/java/io/jdev/miniprofiler/javax/ee/DefaultCdiProfilerProvider.java
@@ -18,6 +18,7 @@ package io.jdev.miniprofiler.javax.ee;
 
 import io.jdev.miniprofiler.DefaultProfilerProvider;
 
+import javax.annotation.PreDestroy;
 import javax.enterprise.context.ApplicationScoped;
 import javax.enterprise.inject.Default;
 
@@ -28,5 +29,11 @@ public class DefaultCdiProfilerProvider extends DefaultProfilerProvider {
 
     /** Default constructor for CDI. */
     public DefaultCdiProfilerProvider() {
+    }
+
+    /** Called by the CDI container on application undeploy to release storage resources. */
+    @PreDestroy
+    public void shutdown() {
+        close();
     }
 }

--- a/javax-ee/src/test/groovy/io/jdev/miniprofiler/javax/ee/DefaultCdiProfilerProviderSpec.groovy
+++ b/javax-ee/src/test/groovy/io/jdev/miniprofiler/javax/ee/DefaultCdiProfilerProviderSpec.groovy
@@ -1,0 +1,36 @@
+/*
+ * Copyright 2026 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.jdev.miniprofiler.javax.ee
+
+import io.jdev.miniprofiler.storage.Storage
+import spock.lang.Specification
+
+class DefaultCdiProfilerProviderSpec extends Specification {
+
+    void "shutdown() closes the storage"() {
+        given:
+        def storage = Mock(Storage)
+        def provider = new DefaultCdiProfilerProvider()
+        provider.storage = storage
+
+        when:
+        provider.shutdown()
+
+        then:
+        1 * storage.close()
+    }
+}

--- a/javax-servlet/src/main/java/io/jdev/miniprofiler/javax/servlet/ProfilingFilter.java
+++ b/javax-servlet/src/main/java/io/jdev/miniprofiler/javax/servlet/ProfilingFilter.java
@@ -298,6 +298,7 @@ public class ProfilingFilter implements Filter {
 
     @Override
     public void destroy() {
+        profilerProvider.close();
     }
 
     /**

--- a/javax-servlet/src/test/groovy/io/jdev/miniprofiler/javax/servlet/ProfilingFilterSpec.groovy
+++ b/javax-servlet/src/test/groovy/io/jdev/miniprofiler/javax/servlet/ProfilingFilterSpec.groovy
@@ -397,6 +397,18 @@ class ProfilingFilterSpec extends Specification {
         parsed.size() <= 3  // current + max 2 previous
     }
 
+    void "destroy closes the profiler provider"() {
+        given:
+        def mockProvider = Mock(ProfilerProvider)
+        filter.profilerProvider = mockProvider
+
+        when:
+        filter.destroy()
+
+        then:
+        1 * mockProvider.close()
+    }
+
     void "serveResults marks profiler as viewed"() {
         given: 'a profiler stored and marked unviewed for alice'
         storage.profiler = new ProfilerImpl("test", ProfileLevel.Info, profilerProvider).tap { p ->

--- a/ratpack/src/main/java/io/jdev/miniprofiler/ratpack/AsyncStorage.java
+++ b/ratpack/src/main/java/io/jdev/miniprofiler/ratpack/AsyncStorage.java
@@ -100,6 +100,15 @@ public interface AsyncStorage extends Storage {
     }
 
     /**
+     * Asynchronously closes this storage, wrapping {@link #close()} in a {@link Blocking#op}.
+     *
+     * @return an operation that closes this storage
+     */
+    default Operation closeAsync() {
+        return Blocking.op(this::close);
+    }
+
+    /**
      * Wraps the given {@link Storage} as an {@link AsyncStorage}, returning it unchanged if it already is one.
      *
      * @param storage the storage to wrap
@@ -138,6 +147,11 @@ public interface AsyncStorage extends Storage {
                 @Override
                 public Collection<UUID> getUnviewedIds(String user) {
                     return storage.getUnviewedIds(user);
+                }
+
+                @Override
+                public void close() {
+                    storage.close();
                 }
             };
         }

--- a/ratpack/src/main/java/io/jdev/miniprofiler/ratpack/MiniProfilerModule.java
+++ b/ratpack/src/main/java/io/jdev/miniprofiler/ratpack/MiniProfilerModule.java
@@ -50,7 +50,8 @@ public class MiniProfilerModule extends ConfigurableModule<MiniProfilerModule.Co
     @Override
     protected void configure() {
         if (bindDefaultProvider()) {
-            bind(ProfilerProvider.class).toProvider(ProviderProvider.class).in(Singleton.class);
+            bind(RatpackContextProfilerProvider.class).toProvider(ProviderProvider.class).in(Singleton.class);
+            bind(ProfilerProvider.class).to(RatpackContextProfilerProvider.class);
         }
 
         requestStaticInjection(MiniProfilerModule.class);
@@ -64,6 +65,23 @@ public class MiniProfilerModule extends ConfigurableModule<MiniProfilerModule.Co
         bind(MiniProfilerResultsIndexHandler.class).in(Scopes.SINGLETON);
         bind(MiniProfilerResultsListHandler.class).in(Scopes.SINGLETON);
         bind(MiniProfilerResourceHandler.class).in(Scopes.SINGLETON);
+
+        if (isShutdownStorageOnStop()) {
+            bind(MiniProfilerShutdownService.class).in(Scopes.SINGLETON);
+        }
+    }
+
+    /**
+     * Return whether to register a {@link MiniProfilerShutdownService} that closes the
+     * {@link RatpackContextProfilerProvider} (and its storage) when the Ratpack server stops.
+     *
+     * <p>Override to return {@code true} if your storage implementation requires explicit
+     * shutdown (e.g. a storage with a background expiry thread). Defaults to {@code false}.</p>
+     *
+     * @return true to register the shutdown service
+     */
+    protected boolean isShutdownStorageOnStop() {
+        return false;
     }
 
     /**
@@ -132,7 +150,7 @@ public class MiniProfilerModule extends ConfigurableModule<MiniProfilerModule.Co
         MiniProfiler.setProfilerProvider(provider);
     }
 
-    private static class ProviderProvider implements Provider<ProfilerProvider> {
+    private static class ProviderProvider implements Provider<RatpackContextProfilerProvider> {
         private final Config config;
 
         @Inject
@@ -140,9 +158,8 @@ public class MiniProfilerModule extends ConfigurableModule<MiniProfilerModule.Co
             this.config = config;
         }
 
-
         @Override
-        public ProfilerProvider get() {
+        public RatpackContextProfilerProvider get() {
             RatpackContextProfilerProvider provider = new RatpackContextProfilerProvider();
             provider.setUiConfig(config.uiConfig);
             return provider;

--- a/ratpack/src/main/java/io/jdev/miniprofiler/ratpack/MiniProfilerShutdownService.java
+++ b/ratpack/src/main/java/io/jdev/miniprofiler/ratpack/MiniProfilerShutdownService.java
@@ -1,0 +1,56 @@
+/*
+ * Copyright 2026 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.jdev.miniprofiler.ratpack;
+
+import com.google.inject.Inject;
+import ratpack.service.Service;
+import ratpack.service.StopEvent;
+
+/**
+ * A Ratpack {@link Service} that closes the {@link RatpackContextProfilerProvider}
+ * (and its storage) when the server stops.
+ *
+ * <p>Register this service when your storage implementation requires explicit shutdown
+ * (e.g. a storage with a background expiry thread). When using {@link MiniProfilerModule},
+ * override {@link MiniProfilerModule#isShutdownStorageOnStop()} to return {@code true}
+ * to have this service registered automatically.</p>
+ */
+public class MiniProfilerShutdownService implements Service {
+
+    private final RatpackContextProfilerProvider provider;
+
+    /**
+     * Creates a new instance; normally called by Guice.
+     *
+     * @param provider the profiler provider whose storage will be closed on server stop
+     */
+    @Inject
+    public MiniProfilerShutdownService(RatpackContextProfilerProvider provider) {
+        this.provider = provider;
+    }
+
+    /**
+     * Closes the provider's storage asynchronously when the server stops.
+     *
+     * @param event the stop event
+     */
+    @Override
+    public void onStop(StopEvent event) {
+        provider.closeAsync()
+            .then();
+    }
+}

--- a/ratpack/src/main/java/io/jdev/miniprofiler/ratpack/RatpackContextProfilerProvider.java
+++ b/ratpack/src/main/java/io/jdev/miniprofiler/ratpack/RatpackContextProfilerProvider.java
@@ -20,6 +20,7 @@ import io.jdev.miniprofiler.BaseProfilerProvider;
 import io.jdev.miniprofiler.Profiler;
 import io.jdev.miniprofiler.internal.ProfilerImpl;
 import ratpack.exec.Execution;
+import ratpack.exec.Operation;
 
 import java.util.Optional;
 
@@ -90,5 +91,14 @@ public class RatpackContextProfilerProvider extends BaseProfilerProvider {
      */
     protected Optional<Profiler> lookupCurrentProfiler(Execution execution) {
         return execution.maybeGet(Profiler.class);
+    }
+
+    /**
+     * Asynchronously closes the storage associated with this provider.
+     *
+     * @return an operation that closes the provider's storage
+     */
+    public Operation closeAsync() {
+        return AsyncStorage.adapt(getStorage()).closeAsync();
     }
 }

--- a/ratpack/src/test/groovy/io/jdev/miniprofiler/ratpack/MiniProfilerModuleShutdownSpec.groovy
+++ b/ratpack/src/test/groovy/io/jdev/miniprofiler/ratpack/MiniProfilerModuleShutdownSpec.groovy
@@ -1,0 +1,83 @@
+/*
+ * Copyright 2026 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.jdev.miniprofiler.ratpack
+
+import com.google.inject.Provides
+import com.google.inject.Singleton
+import io.jdev.miniprofiler.ProfilerProvider
+import io.jdev.miniprofiler.storage.MapStorage
+import ratpack.groovy.test.embed.GroovyEmbeddedApp
+import ratpack.guice.Guice
+import spock.lang.Specification
+
+import java.util.concurrent.atomic.AtomicInteger
+
+class MiniProfilerModuleShutdownSpec extends Specification {
+
+    void "isShutdownStorageOnStop=true causes storage to be closed when server stops"() {
+        given:
+        def closeCount = new AtomicInteger(0)
+        def trackingStorage = new MapStorage() {
+            @Override
+            void close() { closeCount.incrementAndGet() }
+        }
+        def app = GroovyEmbeddedApp.of {
+            registry(Guice.registry { b ->
+                b.module(new TestMiniProfilerModule(trackingStorage))
+            })
+            handlers {
+                get { ctx -> ctx.render("ok") }
+            }
+        }
+
+        when:
+        app.httpClient.get()
+        app.close()
+
+        then:
+        closeCount.get() == 1
+    }
+
+    static class TestMiniProfilerModule extends MiniProfilerModule {
+
+        private final MapStorage trackingStorage
+
+        TestMiniProfilerModule(MapStorage trackingStorage) {
+            this.trackingStorage = trackingStorage
+        }
+
+        @Override
+        protected boolean isShutdownStorageOnStop() { true }
+
+        @Override
+        protected boolean bindDefaultProvider() { false }
+
+        @Provides
+        @Singleton
+        RatpackContextProfilerProvider ratpackProvider() {
+            def provider = new RatpackContextProfilerProvider()
+            provider.storage = trackingStorage
+            return provider
+        }
+
+        @Provides
+        @Singleton
+        ProfilerProvider profilerProvider(RatpackContextProfilerProvider provider) {
+            return provider
+        }
+    }
+}


### PR DESCRIPTION
In long-running containers (servlet containers, EE servers, Ratpack), a web app can be undeployed and redeployed without a JVM restart. Storage implementations with background threads (e.g. an expiry thread) would leak resources unless shutdown is wired into the container's lifecycle hooks. This PR adds `AutoCloseable` support to `Storage` and `ProfilerProvider`, and wires `close()` into each integration's appropriate shutdown hook.

## Changes

**Core**
- `Storage` extends `AutoCloseable` with a no-op default `close()`, plus new `clear()` and `expireOlderThan(Instant)` methods (also no-op defaults, implemented in `MapStorage`)
- `ProfilerProvider` extends `AutoCloseable`; default `close()` delegates to `getStorage().close()`; `BaseProfilerProvider` guards against double-close with an `AtomicBoolean`; `DelegatingProfilerProvider` forwards to its delegate
- `MiniProfilerServer` now closes its `ProfilerProvider` (and thus storage) on `close()` by default; a new 3-arg constructor allows opting out

**Servlet** (`javax-servlet`, `jakarta-servlet`)
- `ProfilingFilter.destroy()` calls `profilerProvider.close()`

**EE** (`javax-ee`, `jakarta-ee`)
- `DefaultCdiProfilerProvider` gains a `@PreDestroy shutdown()` method that calls `close()`, so the CDI container triggers storage shutdown on undeploy
- Unit tests (`DefaultCdiProfilerProviderSpec`) and Weld SE integration tests (`DefaultCdiProfilerProviderIntegrationSpec`) in both modules

**Ratpack**
- `AsyncStorage` gains a `closeAsync()` default method (wraps `close()` in `Blocking.op`)
- `RatpackContextProfilerProvider` exposes `closeAsync()`
- New `MiniProfilerShutdownService` calls `provider.closeAsync().then()` in `Service.onStop()`
- `MiniProfilerModule.isShutdownStorageOnStop()` (default `false`) — override to `true` to have the module bind the shutdown service automatically