### PR TITLE
Fix blocking storage call in Ratpack MiniProfilerAjaxHeaderHandler

### DIFF
--- a/core/src/main/java/io/jdev/miniprofiler/server/Ids.java
+++ b/core/src/main/java/io/jdev/miniprofiler/server/Ids.java
@@ -19,6 +19,8 @@ package io.jdev.miniprofiler.server;
 
 import io.jdev.miniprofiler.ProfilerProvider;
 
+import java.util.Collection;
+import java.util.Collections;
 import java.util.UUID;
 
 /**
@@ -71,18 +73,34 @@ public final class Ids {
      * @return a JSON array string suitable for use as the {@code X-MiniProfiler-Ids} header value
      */
     public static String buildIdsHeader(UUID currentId, String user, ProfilerProvider provider) {
+        Collection<UUID> unviewedIds = user != null
+            ? provider.getStorage().getUnviewedIds(user)
+            : Collections.emptyList();
+        int max = provider.getUiConfig().getMaxUnviewedProfiles();
+        return buildIdsHeader(currentId, unviewedIds, max);
+    }
+
+    /**
+     * Builds the value of the {@code X-MiniProfiler-Ids} response header from pre-fetched data.
+     *
+     * <p>This overload accepts already-fetched unviewed IDs, allowing callers in async
+     * frameworks (e.g.&nbsp;Ratpack) to retrieve them asynchronously before building the header.</p>
+     *
+     * @param currentId           the ID of the profiler for the current request (always first in the array)
+     * @param unviewedIds         previously-unviewed profiler IDs for the current user
+     * @param maxUnviewedProfiles the maximum number of unviewed IDs to include
+     * @return a JSON array string suitable for use as the {@code X-MiniProfiler-Ids} header value
+     */
+    public static String buildIdsHeader(UUID currentId, Collection<UUID> unviewedIds, int maxUnviewedProfiles) {
         StringBuilder sb = new StringBuilder("[\"").append(currentId).append('"');
-        if (user != null) {
-            int max = provider.getUiConfig().getMaxUnviewedProfiles();
-            int count = 0;
-            for (UUID uid : provider.getStorage().getUnviewedIds(user)) {
-                if (count >= max) {
-                    break;
-                }
-                if (!uid.equals(currentId)) {
-                    sb.append(",\"").append(uid).append('"');
-                    count++;
-                }
+        int count = 0;
+        for (UUID uid : unviewedIds) {
+            if (count >= maxUnviewedProfiles) {
+                break;
+            }
+            if (!uid.equals(currentId)) {
+                sb.append(",\"").append(uid).append('"');
+                count++;
             }
         }
         return sb.append(']').toString();

--- a/core/src/test/groovy/io/jdev/miniprofiler/server/IdsSpec.groovy
+++ b/core/src/test/groovy/io/jdev/miniprofiler/server/IdsSpec.groovy
@@ -90,4 +90,55 @@ class IdsSpec extends Specification {
         expect:
         Ids.parseId(null, null, 'not-a-uuid') == null
     }
+
+    // --- buildIdsHeader(UUID, Collection<UUID>, int) ---
+
+    void "buildIdsHeader contains only current id when unviewed list is empty"() {
+        expect:
+        Ids.buildIdsHeader(ID, [], 10) == "[\"${ID}\"]"
+    }
+
+    void "buildIdsHeader includes unviewed ids"() {
+        given:
+        def other1 = UUID.randomUUID()
+        def other2 = UUID.randomUUID()
+
+        when:
+        def header = Ids.buildIdsHeader(ID, [other1, other2], 10)
+
+        then:
+        header == "[\"${ID}\",\"${other1}\",\"${other2}\"]"
+    }
+
+    void "buildIdsHeader caps at maxUnviewedProfiles"() {
+        given:
+        def others = (1..5).collect { UUID.randomUUID() }
+
+        when:
+        def header = Ids.buildIdsHeader(ID, others, 2)
+
+        then:
+        def ids = header.replaceAll('[\\[\\]"]', '').split(',')
+        ids.length == 3
+        ids[0] == ID.toString()
+    }
+
+    void "buildIdsHeader excludes current id from unviewed list"() {
+        given:
+        def other = UUID.randomUUID()
+
+        when:
+        def header = Ids.buildIdsHeader(ID, [ID, other], 10)
+
+        then:
+        header == "[\"${ID}\",\"${other}\"]"
+    }
+
+    void "buildIdsHeader with zero max returns only current id"() {
+        given:
+        def other = UUID.randomUUID()
+
+        expect:
+        Ids.buildIdsHeader(ID, [other], 0) == "[\"${ID}\"]"
+    }
 }

--- a/ratpack/src/main/java/io/jdev/miniprofiler/ratpack/MiniProfilerAjaxHeaderHandler.java
+++ b/ratpack/src/main/java/io/jdev/miniprofiler/ratpack/MiniProfilerAjaxHeaderHandler.java
@@ -40,6 +40,9 @@ import ratpack.exec.Execution;
 import ratpack.handling.Context;
 import ratpack.handling.Handler;
 
+import java.util.Collections;
+import java.util.Optional;
+
 /**
  * Handler which adds the miniprofiler id for the current request as a response header.
  *
@@ -61,12 +64,32 @@ public class MiniProfilerAjaxHeaderHandler implements Handler {
 
     @Override
     public void handle(Context ctx) throws Exception {
-        ctx.maybeGet(Profiler.class).ifPresent(profiler -> {
-            Execution.current().add(ProfilerStoreOption.class, ProfilerStoreOption.STORE_RESULTS);
-            ctx.getResponse().getHeaders().add("X-MiniProfiler-Ids",
-                Ids.buildIdsHeader(profiler.getId(), profiler.getUser(), provider));
-        });
-        ctx.next();
+        Optional<Profiler> maybeProfiler = ctx.maybeGet(Profiler.class);
+        if (!maybeProfiler.isPresent()) {
+            ctx.next();
+            return;
+        }
+        Profiler profiler = maybeProfiler.get();
+        Execution.current().add(ProfilerStoreOption.class, ProfilerStoreOption.STORE_RESULTS);
+        String user = profiler.getUser();
+        if (user == null) {
+            ctx.getResponse().getHeaders().add(
+                "X-MiniProfiler-Ids",
+                Ids.buildIdsHeader(profiler.getId(), Collections.emptyList(), 0)
+            );
+            ctx.next();
+        } else {
+            AsyncStorage asyncStorage = AsyncStorage.adapt(provider.getStorage());
+            int max = provider.getUiConfig().getMaxUnviewedProfiles();
+            asyncStorage.getUnviewedIdsAsync(user)
+                .then(unviewedIds -> {
+                    ctx.getResponse().getHeaders().add(
+                        "X-MiniProfiler-Ids",
+                        Ids.buildIdsHeader(profiler.getId(), unviewedIds, max)
+                    );
+                    ctx.next();
+                });
+        }
     }
 
 }

--- a/ratpack/src/test/groovy/io/jdev/miniprofiler/ratpack/AsyncStorageEnforcementSpec.groovy
+++ b/ratpack/src/test/groovy/io/jdev/miniprofiler/ratpack/AsyncStorageEnforcementSpec.groovy
@@ -1,0 +1,61 @@
+/*
+ * Copyright 2026 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.jdev.miniprofiler.ratpack
+
+import groovy.io.FileType
+import spock.lang.Specification
+
+class AsyncStorageEnforcementSpec extends Specification {
+
+    // Files that legitimately wrap sync Storage calls
+    static final Set<String> ALLOWED_FILES = ['AsyncStorage.java'] as Set
+
+    // Pre-existing violations that should be fixed separately
+    // TODO: convert MiniProfilerResultsListHandler to use async storage for load() calls
+    static final Set<String> KNOWN_EXCEPTIONS = [
+        'MiniProfilerResultsListHandler.java',
+    ] as Set
+
+    // Patterns that indicate direct synchronous storage usage
+    static final List<Map> SYNC_PATTERNS = [
+        [pattern: ~/Ids\.buildIdsHeader\s*\([^)]*ProfilerProvider/, description: 'Ids.buildIdsHeader with ProfilerProvider calls sync storage internally'],
+        [pattern: ~/\.getStorage\(\)\s*\.\s*(getUnviewedIds|setUnviewed|setViewed|save|load|list)\s*\(/, description: 'direct sync Storage method call via getStorage()'],
+    ]
+
+    void "ratpack production code must not call synchronous storage methods directly"() {
+        given:
+        def srcDir = new File(System.getProperty('user.dir'), 'src/main/java')
+        def violations = []
+
+        when:
+        srcDir.eachFileRecurse(FileType.FILES) { file ->
+            if (!file.name.endsWith('.java') || file.name in ALLOWED_FILES || file.name in KNOWN_EXCEPTIONS) {
+                return
+            }
+            file.eachLine { line, lineNum ->
+                SYNC_PATTERNS.each { entry ->
+                    if (line =~ entry.pattern) {
+                        violations << "${file.name}:${lineNum}: ${entry.description} -- ${line.trim()}"
+                    }
+                }
+            }
+        }
+
+        then:
+        violations.empty
+    }
+}


### PR DESCRIPTION
## Summary

- `MiniProfilerAjaxHeaderHandler` was calling `Ids.buildIdsHeader()` which synchronously invoked `Storage.getUnviewedIds()` on Ratpack's compute thread. Refactored the handler to use `AsyncStorage.getUnviewedIdsAsync()` instead.
- Extracted a new `Ids.buildIdsHeader(UUID, Collection<UUID>, int)` overload that accepts pre-fetched unviewed IDs, so the existing servlet callers are unchanged.
- Added `AsyncStorageEnforcementSpec` — a source-scanning test that fails if new synchronous storage calls are introduced in the ratpack module. Pre-existing `MiniProfilerResultsListHandler` violations are documented as known exceptions.