### PR TITLE
Extract storage expiry scheduling into StorageExpiryService

### DIFF
--- a/core/src/main/java/io/jdev/miniprofiler/BaseProfilerProvider.java
+++ b/core/src/main/java/io/jdev/miniprofiler/BaseProfilerProvider.java
@@ -21,12 +21,14 @@ import io.jdev.miniprofiler.format.CommandFormatterLocator;
 import io.jdev.miniprofiler.internal.NullProfiler;
 import io.jdev.miniprofiler.internal.ProfilerImpl;
 import io.jdev.miniprofiler.storage.Storage;
+import io.jdev.miniprofiler.storage.StorageExpiryService;
 import io.jdev.miniprofiler.storage.StorageLocator;
 import io.jdev.miniprofiler.user.UserProvider;
 import io.jdev.miniprofiler.user.UserProviderLocator;
 
 import java.net.InetAddress;
 import java.net.UnknownHostException;
+import java.time.Duration;
 import java.util.Map;
 import java.util.UUID;
 import java.util.concurrent.ConcurrentHashMap;
@@ -48,6 +50,9 @@ public abstract class BaseProfilerProvider implements ProfilerProvider {
     private String machineName = getDefaultHostname();
     private ProfilerUiConfig uiConfig;
     private final AtomicBoolean closed = new AtomicBoolean(false);
+    private volatile int expiryMaxAgeDays;
+    private volatile Duration expiryCleanupInterval;
+    private volatile StorageExpiryService expiryService;
 
     /**
      * Called after a new profiler is created. Subclasses should
@@ -223,6 +228,35 @@ public abstract class BaseProfilerProvider implements ProfilerProvider {
     @Override
     public void setStorage(Storage storage) {
         this.storage = storage;
+        maybeStartExpiryService();
+    }
+
+    /**
+     * Sets the expiry age for profiling sessions. When set (and positive), a background
+     * scheduler will periodically call {@link Storage#expireOlderThan} to remove old sessions.
+     *
+     * <p>If not set programmatically, the {@code storage.expiry.maxAgeDays} property is read from
+     * {@link MiniProfilerConfig} when storage is first configured. A value of zero or negative
+     * disables automatic expiry. The cleanup interval defaults to one hour but can be overridden
+     * via {@code storage.expiry.cleanupInterval} or {@link #setExpiryCleanupInterval(Duration)}.</p>
+     *
+     * @param expiryMaxAgeDays the maximum age of profiling sessions in days; zero or negative disables expiry
+     */
+    public void setExpiryMaxAgeDays(int expiryMaxAgeDays) {
+        this.expiryMaxAgeDays = expiryMaxAgeDays;
+        maybeStartExpiryService();
+    }
+
+    /**
+     * Sets the interval between automatic expiry runs. When not set, falls back to
+     * {@code storage.expiry.intervalHours} from {@link MiniProfilerConfig}, then the
+     * {@link StorageExpiryService} default of one hour.
+     *
+     * @param expiryCleanupInterval the interval between expiry runs; {@code null} uses the config/default
+     */
+    public void setExpiryCleanupInterval(Duration expiryCleanupInterval) {
+        this.expiryCleanupInterval = expiryCleanupInterval;
+        maybeStartExpiryService();
     }
 
     /**
@@ -241,6 +275,7 @@ public abstract class BaseProfilerProvider implements ProfilerProvider {
             synchronized (this) {
                 if (storage == null) {
                     storage = StorageLocator.findStorage();
+                    maybeStartExpiryService();
                 }
             }
         }
@@ -360,7 +395,38 @@ public abstract class BaseProfilerProvider implements ProfilerProvider {
     @Override
     public void close() {
         if (closed.compareAndSet(false, true)) {
+            StorageExpiryService svc = this.expiryService;
+            if (svc != null) {
+                svc.close();
+            }
             getStorage().close();
+        }
+    }
+
+    private synchronized void maybeStartExpiryService() {
+        if (storage == null) {
+            return;
+        }
+        MiniProfilerConfig config = new MiniProfilerConfig();
+        int maxAgeDays = this.expiryMaxAgeDays;
+        if (maxAgeDays <= 0) {
+            maxAgeDays = config.getProperty("storage.expiry.maxAgeDays", 0);
+        }
+        Duration maxAge = maxAgeDays > 0 ? Duration.ofDays(maxAgeDays) : null;
+        if (maxAge != null && !maxAge.isNegative() && !maxAge.isZero()) {
+            Duration cleanupInterval = this.expiryCleanupInterval;
+            if (cleanupInterval == null) {
+                int intervalHours = config.getProperty("storage.expiry.cleanupInterval", 0);
+                if (intervalHours > 0) {
+                    cleanupInterval = Duration.ofHours(intervalHours);
+                }
+            }
+            StorageExpiryService old = this.expiryService;
+            this.expiryService = new StorageExpiryService(storage, maxAge,
+                cleanupInterval != null ? cleanupInterval : StorageExpiryService.DEFAULT_SCHEDULE_INTERVAL);
+            if (old != null) {
+                old.close();
+            }
         }
     }
 

--- a/core/src/main/java/io/jdev/miniprofiler/storage/StorageExpiryService.java
+++ b/core/src/main/java/io/jdev/miniprofiler/storage/StorageExpiryService.java
@@ -1,0 +1,69 @@
+/*
+ * Copyright 2026 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.jdev.miniprofiler.storage;
+
+import java.time.Duration;
+import java.time.Instant;
+import java.util.concurrent.Executors;
+import java.util.concurrent.ScheduledExecutorService;
+import java.util.concurrent.TimeUnit;
+
+/**
+ * Schedules periodic calls to {@link Storage#expireOlderThan} on a background daemon thread.
+ *
+ * <p>Storage implementations only need to implement {@link Storage#expireOlderThan}; this class
+ * handles the scheduling and lifecycle of the background cleanup task. Instances are created
+ * and closed by the owning {@link io.jdev.miniprofiler.ProfilerProvider}.</p>
+ */
+public class StorageExpiryService implements AutoCloseable {
+
+    /** Default interval between expiry runs: one hour. */
+    public static final Duration DEFAULT_SCHEDULE_INTERVAL = Duration.ofHours(1);
+
+    private final ScheduledExecutorService scheduler;
+    private volatile boolean closed;
+
+    /**
+     * Creates a new service with an explicit schedule interval.
+     *
+     * @param storage          the storage to expire entries from
+     * @param expiryAge        sessions older than this duration are removed on each run
+     * @param scheduleInterval how often to run the expiry task
+     */
+    public StorageExpiryService(Storage storage, Duration expiryAge, Duration scheduleInterval) {
+        this.scheduler = Executors.newSingleThreadScheduledExecutor(r -> {
+            Thread t = new Thread(r, "miniprofiler-storage-expiry");
+            t.setDaemon(true);
+            return t;
+        });
+        long intervalMs = scheduleInterval.toMillis();
+        this.scheduler.scheduleAtFixedRate(
+            () -> storage.expireOlderThan(Instant.now().minus(expiryAge)),
+            intervalMs, intervalMs, TimeUnit.MILLISECONDS);
+    }
+
+    /**
+     * Shuts down the background scheduler. Idempotent: subsequent calls have no effect.
+     */
+    @Override
+    public void close() {
+        if (!closed) {
+            closed = true;
+            scheduler.shutdownNow();
+        }
+    }
+}

--- a/core/src/test/groovy/io/jdev/miniprofiler/storage/StorageExpiryServiceSpec.groovy
+++ b/core/src/test/groovy/io/jdev/miniprofiler/storage/StorageExpiryServiceSpec.groovy
@@ -1,0 +1,83 @@
+/*
+ * Copyright 2026 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.jdev.miniprofiler.storage
+
+import spock.lang.Specification
+
+import java.time.Duration
+import java.time.Instant
+import java.util.concurrent.CopyOnWriteArrayList
+import java.util.concurrent.atomic.AtomicInteger
+
+import static org.awaitility.Awaitility.await
+import static java.util.concurrent.TimeUnit.SECONDS
+
+class StorageExpiryServiceSpec extends Specification {
+
+    def "calls expireOlderThan on the schedule"() {
+        given:
+        def cutoffs = new CopyOnWriteArrayList<Instant>()
+        def storage = Stub(Storage) {
+            expireOlderThan(_ as Instant) >> { Instant cutoff -> cutoffs.add(cutoff) }
+        }
+        def expiryAge = Duration.ofMillis(500)
+        def service = new StorageExpiryService(storage, expiryAge, Duration.ofMillis(100))
+
+        when:
+        await().atMost(5, SECONDS).until { cutoffs.size() >= 2 }
+        service.close()
+
+        then:
+        cutoffs.size() >= 2
+        // each cutoff should be approximately now - expiryAge
+        cutoffs.every { cutoff ->
+            def expected = Instant.now().minus(expiryAge)
+            Math.abs(cutoff.toEpochMilli() - expected.toEpochMilli()) < 2000
+        }
+    }
+
+    def "close stops further calls to expireOlderThan"() {
+        given:
+        def callCount = new AtomicInteger()
+        def storage = Stub(Storage) {
+            expireOlderThan(_ as Instant) >> { callCount.incrementAndGet() }
+        }
+        def service = new StorageExpiryService(storage, Duration.ofMillis(500), Duration.ofMillis(50))
+
+        when:
+        await().atMost(5, SECONDS).until { callCount.get() >= 1 }
+        service.close()
+        int countAfterClose = callCount.get()
+        Thread.sleep(200)
+
+        then:
+        callCount.get() == countAfterClose
+    }
+
+    def "close is idempotent"() {
+        given:
+        def storage = Stub(Storage)
+        def service = new StorageExpiryService(storage, Duration.ofHours(1), Duration.ofHours(1))
+
+        when:
+        service.close()
+        service.close()
+
+        then:
+        noExceptionThrown()
+    }
+}

--- a/storage-objectstorage/src/main/java/io/jdev/miniprofiler/storage/objectstorage/BaseObjectStorage.java
+++ b/storage-objectstorage/src/main/java/io/jdev/miniprofiler/storage/objectstorage/BaseObjectStorage.java
@@ -21,7 +21,6 @@ import io.jdev.miniprofiler.storage.BaseStorage;
 import io.jdev.miniprofiler.storage.Storage;
 
 import java.nio.charset.StandardCharsets;
-import java.time.Duration;
 import java.time.Instant;
 import java.util.ArrayList;
 import java.util.Collection;
@@ -29,9 +28,6 @@ import java.util.Collections;
 import java.util.Date;
 import java.util.List;
 import java.util.UUID;
-import java.util.concurrent.Executors;
-import java.util.concurrent.ScheduledExecutorService;
-import java.util.concurrent.TimeUnit;
 
 /**
  * Abstract base class for object-storage-backed {@link Storage} implementations.
@@ -50,61 +46,25 @@ import java.util.concurrent.TimeUnit;
 public abstract class BaseObjectStorage extends BaseStorage {
 
     private static final byte[] EMPTY_BYTES = new byte[0];
-    private static final Duration DEFAULT_SCHEDULE_INTERVAL = Duration.ofHours(1);
 
     /** Key calculator for this storage instance. */
     protected final ObjectStorageKeys keys;
     /** The bucket or container name. */
     protected final String bucket;
     private final boolean ownsClient;
-    private final ScheduledExecutorService scheduler;
-    private final Duration expiryAge;
     private volatile boolean closed;
 
     /**
-     * Creates a new instance. If the config specifies a positive {@code expiryHours},
-     * a background scheduler is started that runs an hourly cleanup job.
+     * Creates a new instance.
      *
      * @param config     the storage configuration
      * @param ownsClient {@code true} if this instance owns the cloud client and should
      *                   close it when {@link #close()} is called
      */
     protected BaseObjectStorage(BaseObjectStorageConfig config, boolean ownsClient) {
-        this(config, ownsClient,
-            config.getExpiryHours() > 0 ? Duration.ofHours(config.getExpiryHours()) : null,
-            DEFAULT_SCHEDULE_INTERVAL);
-    }
-
-    /**
-     * Creates a new instance with explicit expiry age and schedule interval. Intended
-     * for testing with short durations.
-     *
-     * @param config           the storage configuration
-     * @param ownsClient       {@code true} if this instance owns the cloud client
-     * @param expiryAge        maximum age of profiling sessions; {@code null} or non-positive
-     *                         disables automatic expiry
-     * @param scheduleInterval interval between expiry runs; must not be {@code null} when
-     *                         {@code expiryAge} is positive
-     */
-    protected BaseObjectStorage(BaseObjectStorageConfig config, boolean ownsClient,
-                                Duration expiryAge, Duration scheduleInterval) {
         this.keys = new ObjectStorageKeys(config.getPrefix());
         this.bucket = config.getBucketName();
         this.ownsClient = ownsClient;
-        if (expiryAge != null && !expiryAge.isNegative() && !expiryAge.isZero()) {
-            this.expiryAge = expiryAge;
-            this.scheduler = Executors.newSingleThreadScheduledExecutor(r -> {
-                Thread t = new Thread(r, "miniprofiler-storage-expiry");
-                t.setDaemon(true);
-                return t;
-            });
-            long intervalMs = scheduleInterval.toMillis();
-            this.scheduler.scheduleAtFixedRate(this::runExpiry, intervalMs, intervalMs,
-                TimeUnit.MILLISECONDS);
-        } else {
-            this.expiryAge = null;
-            this.scheduler = null;
-        }
     }
 
     /**
@@ -235,23 +195,16 @@ public abstract class BaseObjectStorage extends BaseStorage {
         return result;
     }
 
-    /** {@inheritDoc} Idempotent. Shuts down the expiry scheduler and closes the underlying client if this instance owns it. */
+    /** {@inheritDoc} Idempotent. Closes the underlying client if this instance owns it. */
     @Override
     public void close() {
         if (closed) {
             return;
         }
         closed = true;
-        if (scheduler != null) {
-            scheduler.shutdownNow();
-        }
         if (ownsClient) {
             closeClient();
         }
-    }
-
-    private void runExpiry() {
-        expireOlderThan(Instant.now().minus(expiryAge));
     }
 
     @Override

--- a/storage-objectstorage/src/main/java/io/jdev/miniprofiler/storage/objectstorage/BaseObjectStorageConfig.java
+++ b/storage-objectstorage/src/main/java/io/jdev/miniprofiler/storage/objectstorage/BaseObjectStorageConfig.java
@@ -24,32 +24,25 @@ package io.jdev.miniprofiler.storage.objectstorage;
  */
 public abstract class BaseObjectStorageConfig {
 
-    /** Default expiry age in hours. */
-    public static final int DEFAULT_EXPIRY_HOURS = 24;
-
     private final String bucketName;
     private final String prefix;
     private final String region;
     private final String endpoint;
-    private final int expiryHours;
 
     /**
      * Creates a new instance.
      *
-     * @param bucketName  the name of the bucket or container; may be {@code null}
-     * @param prefix      optional key prefix prepended to all object keys; may be {@code null}
-     * @param region      optional cloud region; may be {@code null}
-     * @param endpoint    optional endpoint URL override; may be {@code null}
-     * @param expiryHours hours after which profiling sessions are automatically expired;
-     *                    zero or negative disables automatic expiry
+     * @param bucketName the name of the bucket or container; may be {@code null}
+     * @param prefix     optional key prefix prepended to all object keys; may be {@code null}
+     * @param region     optional cloud region; may be {@code null}
+     * @param endpoint   optional endpoint URL override; may be {@code null}
      */
     protected BaseObjectStorageConfig(String bucketName, String prefix, String region,
-                                      String endpoint, int expiryHours) {
+                                      String endpoint) {
         this.bucketName = bucketName;
         this.prefix = prefix;
         this.region = region;
         this.endpoint = endpoint;
-        this.expiryHours = expiryHours;
     }
 
     /**
@@ -86,16 +79,6 @@ public abstract class BaseObjectStorageConfig {
      */
     public String getEndpoint() {
         return endpoint;
-    }
-
-    /**
-     * Returns the expiry age in hours. Profiling sessions older than this are automatically
-     * removed. Zero or negative means automatic expiry is disabled.
-     *
-     * @return the expiry age in hours
-     */
-    public int getExpiryHours() {
-        return expiryHours;
     }
 
     /**

--- a/storage-objectstorage/src/main/java/io/jdev/miniprofiler/storage/objectstorage/azureblob/AzureBlobStorageConfig.java
+++ b/storage-objectstorage/src/main/java/io/jdev/miniprofiler/storage/objectstorage/azureblob/AzureBlobStorageConfig.java
@@ -28,7 +28,7 @@ import java.util.Properties;
  * (prefix {@code miniprofiler.}) take precedence over {@code miniprofiler.properties} on the classpath.</p>
  *
  * <p>Supported keys: {@code storage.azure-blob.container}, {@code storage.azure-blob.prefix},
- * {@code storage.azure-blob.endpoint}, {@code storage.azure-blob.expiryHours}.
+ * {@code storage.azure-blob.endpoint}.
  * The {@code container} property maps to the base class {@code bucketName} field.</p>
  */
 public class AzureBlobStorageConfig extends BaseObjectStorageConfig {
@@ -41,19 +41,7 @@ public class AzureBlobStorageConfig extends BaseObjectStorageConfig {
      * @param endpoint  the Azure Blob endpoint URL; may be {@code null}
      */
     public AzureBlobStorageConfig(String container, String prefix, String endpoint) {
-        this(container, prefix, endpoint, DEFAULT_EXPIRY_HOURS);
-    }
-
-    /**
-     * Creates a new instance with explicit values.
-     *
-     * @param container   the Azure Blob container name; may be {@code null}
-     * @param prefix      the optional key prefix; may be {@code null}
-     * @param endpoint    the Azure Blob endpoint URL; may be {@code null}
-     * @param expiryHours hours after which sessions are expired; zero or negative disables
-     */
-    public AzureBlobStorageConfig(String container, String prefix, String endpoint, int expiryHours) {
-        super(container, prefix, null, endpoint, expiryHours);
+        super(container, prefix, null, endpoint);
     }
 
     /**
@@ -80,10 +68,9 @@ public class AzureBlobStorageConfig extends BaseObjectStorageConfig {
     }
 
     static AzureBlobStorageConfig create(MiniProfilerConfig props) {
-        String container = props.getProperty("storage.azure-blob.container",   (String) null);
-        String prefix    = props.getProperty("storage.azure-blob.prefix",      (String) null);
-        String endpoint  = props.getProperty("storage.azure-blob.endpoint",    (String) null);
-        int expiryHours  = props.getProperty("storage.azure-blob.expiryHours", DEFAULT_EXPIRY_HOURS);
-        return new AzureBlobStorageConfig(container, prefix, endpoint, expiryHours);
+        String container = props.getProperty("storage.azure-blob.container", (String) null);
+        String prefix    = props.getProperty("storage.azure-blob.prefix",    (String) null);
+        String endpoint  = props.getProperty("storage.azure-blob.endpoint",  (String) null);
+        return new AzureBlobStorageConfig(container, prefix, endpoint);
     }
 }

--- a/storage-objectstorage/src/main/java/io/jdev/miniprofiler/storage/objectstorage/gcs/GcsStorageConfig.java
+++ b/storage-objectstorage/src/main/java/io/jdev/miniprofiler/storage/objectstorage/gcs/GcsStorageConfig.java
@@ -28,7 +28,7 @@ import java.util.Properties;
  * (prefix {@code miniprofiler.}) take precedence over {@code miniprofiler.properties} on the classpath.</p>
  *
  * <p>Supported keys: {@code storage.gcs.bucket}, {@code storage.gcs.prefix},
- * {@code storage.gcs.endpoint}, {@code storage.gcs.expiryHours}.
+ * {@code storage.gcs.endpoint}.
  * GCS is a global service so no {@code region} property is used.</p>
  */
 public class GcsStorageConfig extends BaseObjectStorageConfig {
@@ -41,19 +41,7 @@ public class GcsStorageConfig extends BaseObjectStorageConfig {
      * @param endpoint the optional host override for the GCS client; may be {@code null}
      */
     public GcsStorageConfig(String bucket, String prefix, String endpoint) {
-        this(bucket, prefix, endpoint, DEFAULT_EXPIRY_HOURS);
-    }
-
-    /**
-     * Creates a new instance with explicit values.
-     *
-     * @param bucket      the GCS bucket name; may be {@code null}
-     * @param prefix      the optional key prefix; may be {@code null}
-     * @param endpoint    the optional host override for the GCS client; may be {@code null}
-     * @param expiryHours hours after which sessions are expired; zero or negative disables
-     */
-    public GcsStorageConfig(String bucket, String prefix, String endpoint, int expiryHours) {
-        super(bucket, prefix, null, endpoint, expiryHours);
+        super(bucket, prefix, null, endpoint);
     }
 
     /**
@@ -71,10 +59,9 @@ public class GcsStorageConfig extends BaseObjectStorageConfig {
     }
 
     static GcsStorageConfig create(MiniProfilerConfig props) {
-        String bucket   = props.getProperty("storage.gcs.bucket",      (String) null);
-        String prefix   = props.getProperty("storage.gcs.prefix",      (String) null);
-        String endpoint = props.getProperty("storage.gcs.endpoint",    (String) null);
-        int expiryHours = props.getProperty("storage.gcs.expiryHours", DEFAULT_EXPIRY_HOURS);
-        return new GcsStorageConfig(bucket, prefix, endpoint, expiryHours);
+        String bucket   = props.getProperty("storage.gcs.bucket",   (String) null);
+        String prefix   = props.getProperty("storage.gcs.prefix",   (String) null);
+        String endpoint = props.getProperty("storage.gcs.endpoint", (String) null);
+        return new GcsStorageConfig(bucket, prefix, endpoint);
     }
 }

--- a/storage-objectstorage/src/main/java/io/jdev/miniprofiler/storage/objectstorage/s3/S3StorageConfig.java
+++ b/storage-objectstorage/src/main/java/io/jdev/miniprofiler/storage/objectstorage/s3/S3StorageConfig.java
@@ -28,12 +28,12 @@ import java.util.Properties;
  * (prefix {@code miniprofiler.}) take precedence over {@code miniprofiler.properties} on the classpath.</p>
  *
  * <p>Supported keys: {@code storage.s3.bucket}, {@code storage.s3.prefix},
- * {@code storage.s3.region}, {@code storage.s3.endpoint}, {@code storage.s3.expiryHours}.</p>
+ * {@code storage.s3.region}, {@code storage.s3.endpoint}.</p>
  */
 public class S3StorageConfig extends BaseObjectStorageConfig {
 
     /**
-     * Creates a new instance with explicit values and default expiry.
+     * Creates a new instance with explicit values.
      *
      * @param bucket   the S3 bucket name; may be {@code null}
      * @param prefix   the optional key prefix; may be {@code null}
@@ -41,20 +41,7 @@ public class S3StorageConfig extends BaseObjectStorageConfig {
      * @param endpoint the endpoint URL override; may be {@code null}
      */
     public S3StorageConfig(String bucket, String prefix, String region, String endpoint) {
-        this(bucket, prefix, region, endpoint, DEFAULT_EXPIRY_HOURS);
-    }
-
-    /**
-     * Creates a new instance with explicit values.
-     *
-     * @param bucket      the S3 bucket name; may be {@code null}
-     * @param prefix      the optional key prefix; may be {@code null}
-     * @param region      the AWS region; may be {@code null}
-     * @param endpoint    the endpoint URL override; may be {@code null}
-     * @param expiryHours hours after which sessions are expired; zero or negative disables
-     */
-    public S3StorageConfig(String bucket, String prefix, String region, String endpoint, int expiryHours) {
-        super(bucket, prefix, region, endpoint, expiryHours);
+        super(bucket, prefix, region, endpoint);
     }
 
     /**
@@ -72,11 +59,10 @@ public class S3StorageConfig extends BaseObjectStorageConfig {
     }
 
     static S3StorageConfig create(MiniProfilerConfig props) {
-        String bucket   = props.getProperty("storage.s3.bucket",      (String) null);
-        String prefix   = props.getProperty("storage.s3.prefix",      (String) null);
-        String region   = props.getProperty("storage.s3.region",      (String) null);
-        String endpoint = props.getProperty("storage.s3.endpoint",    (String) null);
-        int expiryHours = props.getProperty("storage.s3.expiryHours", DEFAULT_EXPIRY_HOURS);
-        return new S3StorageConfig(bucket, prefix, region, endpoint, expiryHours);
+        String bucket   = props.getProperty("storage.s3.bucket",   (String) null);
+        String prefix   = props.getProperty("storage.s3.prefix",   (String) null);
+        String region   = props.getProperty("storage.s3.region",   (String) null);
+        String endpoint = props.getProperty("storage.s3.endpoint", (String) null);
+        return new S3StorageConfig(bucket, prefix, region, endpoint);
     }
 }

--- a/storage-objectstorage/src/test/groovy/io/jdev/miniprofiler/storage/objectstorage/BaseObjectStorageConfigSpec.groovy
+++ b/storage-objectstorage/src/test/groovy/io/jdev/miniprofiler/storage/objectstorage/BaseObjectStorageConfigSpec.groovy
@@ -89,41 +89,4 @@ abstract class BaseObjectStorageConfigSpec extends Specification {
         !config.configured
     }
 
-    def "expiryHours defaults to 24"() {
-        given:
-        def sysprops = new Properties()
-        sysprops["${systemPropPrefix}${bucketPropertyKey}"] = "b"
-
-        when:
-        def config = createConfig(sysprops, null)
-
-        then:
-        config.expiryHours == 24
-    }
-
-    def "expiryHours can be overridden"() {
-        given:
-        def sysprops = new Properties()
-        sysprops["${systemPropPrefix}${bucketPropertyKey}"] = "b"
-        sysprops["${systemPropPrefix}expiryHours"] = "48"
-
-        when:
-        def config = createConfig(sysprops, null)
-
-        then:
-        config.expiryHours == 48
-    }
-
-    def "expiryHours zero disables expiry"() {
-        given:
-        def sysprops = new Properties()
-        sysprops["${systemPropPrefix}${bucketPropertyKey}"] = "b"
-        sysprops["${systemPropPrefix}expiryHours"] = "0"
-
-        when:
-        def config = createConfig(sysprops, null)
-
-        then:
-        config.expiryHours == 0
-    }
 }

--- a/storage-objectstorage/src/test/groovy/io/jdev/miniprofiler/storage/objectstorage/BaseObjectStorageSpec.groovy
+++ b/storage-objectstorage/src/test/groovy/io/jdev/miniprofiler/storage/objectstorage/BaseObjectStorageSpec.groovy
@@ -22,12 +22,8 @@ import io.jdev.miniprofiler.internal.ProfilerImpl
 import io.jdev.miniprofiler.storage.Storage
 import spock.lang.Specification
 
-import java.time.Duration
 import java.time.Instant
 import java.util.concurrent.ConcurrentHashMap
-
-import static org.awaitility.Awaitility.await
-import static java.util.concurrent.TimeUnit.SECONDS
 
 class BaseObjectStorageSpec extends Specification {
 
@@ -254,54 +250,6 @@ class BaseObjectStorageSpec extends Specification {
         storage.store.keySet().any { it.contains(String.format("%019d", 3000L)) }
     }
 
-    def "scheduler expires old entries automatically"() {
-        given:
-        def expiryAge = Duration.ofMillis(200)
-        def scheduleInterval = Duration.ofMillis(100)
-        def s = new InMemoryObjectStorage(new TestConfig("bucket", null), true, expiryAge, scheduleInterval)
-        // old profiler started 10 seconds ago — well past 200ms expiry
-        def old = profilerStartedAt(Instant.now().minusSeconds(10).toEpochMilli())
-        // recent profiler started just now
-        def recent = profilerStartedAt(Instant.now().toEpochMilli())
-        s.save(old)
-        s.save(recent)
-
-        expect:
-        await().atMost(5, SECONDS).until { s.load(old.id) == null }
-        s.load(recent.id) != null
-
-        cleanup:
-        s.close()
-    }
-
-    def "close shuts down scheduler without error"() {
-        given:
-        def s = new InMemoryObjectStorage(new TestConfig("bucket", null), true,
-            Duration.ofHours(1), Duration.ofHours(1))
-
-        when:
-        s.close()
-
-        then:
-        notThrown(Exception)
-        s.closeClientCallCount == 1
-    }
-
-    def "no scheduler when expiryHours is zero"() {
-        given:
-        def s = new InMemoryObjectStorage(new TestConfig("bucket", null, 0), true)
-        def old = profilerStartedAt(1000L)
-        s.save(old)
-
-        when:
-        s.close()
-
-        then:
-        notThrown(Exception)
-        // old profiler still there — no automatic expiry
-        s.load(old.id) != null
-    }
-
     private ProfilerImpl profilerStartedAt(long startedMs) {
         ProfilerImpl p = new ProfilerImpl("test", ProfileLevel.Info, profilerProvider)
         // reflect to set started to a known value
@@ -316,11 +264,7 @@ class BaseObjectStorageSpec extends Specification {
 
     static class TestConfig extends BaseObjectStorageConfig {
         TestConfig(String bucket, String prefix) {
-            super(bucket, prefix, null, null, DEFAULT_EXPIRY_HOURS)
-        }
-
-        TestConfig(String bucket, String prefix, int expiryHours) {
-            super(bucket, prefix, null, null, expiryHours)
+            super(bucket, prefix, null, null)
         }
     }
 
@@ -330,11 +274,6 @@ class BaseObjectStorageSpec extends Specification {
 
         InMemoryObjectStorage(BaseObjectStorageConfig config, boolean ownsClient) {
             super(config, ownsClient)
-        }
-
-        InMemoryObjectStorage(BaseObjectStorageConfig config, boolean ownsClient,
-                              Duration expiryAge, Duration scheduleInterval) {
-            super(config, ownsClient, expiryAge, scheduleInterval)
         }
 
         @Override


### PR DESCRIPTION
Move the background expiry scheduler out of BaseObjectStorage and into a new storage-agnostic StorageExpiryService in miniprofiler-core. BaseProfilerProvider now owns the service lifecycle, starting it when storage is configured and closing it on shutdown.

Expiry is configured via storage.expiry.maxAgeDays and storage.expiry.cleanupInterval in MiniProfilerConfig, or programmatically via setExpiryMaxAgeDays() and setExpiryCleanupInterval() on the provider.

Remove expiryHours from BaseObjectStorageConfig and the concrete S3, Azure and GCS configs, since expiry scheduling is no longer a storage concern.