### PR TITLE
Accept and store client timings from browser performance data

### DIFF
--- a/core/src/main/java/io/jdev/miniprofiler/ScriptTagWriter.java
+++ b/core/src/main/java/io/jdev/miniprofiler/ScriptTagWriter.java
@@ -21,6 +21,7 @@ import io.jdev.miniprofiler.internal.NullProfiler;
 import java.util.Collections;
 import java.util.List;
 import java.util.UUID;
+import java.util.stream.Collectors;
 
 /**
  * Writes out a script tag in the format that the mini profiler front end
@@ -147,7 +148,7 @@ public class ScriptTagWriter {
         appendAttribute(sb, "data-version", version);
 
         appendAttribute(sb, "data-current-id", currentId);
-        appendAttribute(sb, "data-ids", ids.toString());
+        appendAttribute(sb, "data-ids", ids.stream().map(UUID::toString).collect(Collectors.joining(",")));
 
         appendAttribute(sb, "data-position", config.getPosition().name());
         if (config.getToggleShortcut() != null) {

--- a/core/src/main/java/io/jdev/miniprofiler/internal/ClientTiming.java
+++ b/core/src/main/java/io/jdev/miniprofiler/internal/ClientTiming.java
@@ -1,0 +1,86 @@
+/*
+ * Copyright 2026 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.jdev.miniprofiler.internal;
+
+import org.json.simple.JSONArray;
+import org.json.simple.JSONObject;
+
+import java.util.ArrayList;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+
+/**
+ * Represents a single client-side performance timing entry.
+ */
+public class ClientTiming implements Jsonable {
+
+    private final String name;
+    private final long start;
+    private final Long duration;
+
+    ClientTiming(String name, long start, Long duration) {
+        this.name = name;
+        this.start = start;
+        this.duration = duration;
+    }
+
+    public String getName() {
+        return name;
+    }
+
+    public long getStart() {
+        return start;
+    }
+
+    public Long getDuration() {
+        return duration;
+    }
+
+    @SuppressWarnings("unchecked")
+    public static ClientTiming fromJson(JSONObject obj) {
+        String name = (String) obj.get("Name");
+        long start = ((Number) obj.get("Start")).longValue();
+        Long duration = obj.containsKey("Duration") && obj.get("Duration") != null
+            ? ((Number) obj.get("Duration")).longValue()
+            : null;
+        return new ClientTiming(name, start, duration);
+    }
+
+    @SuppressWarnings("unchecked")
+    public static List<ClientTiming> listFromJson(JSONArray array) {
+        if (array == null || array.isEmpty()) {
+            return null;
+        }
+        List<ClientTiming> result = new ArrayList<>(array.size());
+        for (Object item : array) {
+            result.add(fromJson((JSONObject) item));
+        }
+        return result;
+    }
+
+    @Override
+    public Map<String, Object> toJson() {
+        Map<String, Object> map = new LinkedHashMap<>();
+        map.put("Name", name);
+        map.put("Start", start);
+        if (duration != null) {
+            map.put("Duration", duration);
+        }
+        return map;
+    }
+}

--- a/core/src/main/java/io/jdev/miniprofiler/internal/ClientTiming.java
+++ b/core/src/main/java/io/jdev/miniprofiler/internal/ClientTiming.java
@@ -33,7 +33,7 @@ public class ClientTiming implements Jsonable {
     private final long start;
     private final Long duration;
 
-    ClientTiming(String name, long start, Long duration) {
+    public ClientTiming(String name, long start, Long duration) {
         this.name = name;
         this.start = start;
         this.duration = duration;

--- a/core/src/main/java/io/jdev/miniprofiler/internal/ProfilerImpl.java
+++ b/core/src/main/java/io/jdev/miniprofiler/internal/ProfilerImpl.java
@@ -17,6 +17,7 @@
 package io.jdev.miniprofiler.internal;
 
 import io.jdev.miniprofiler.*;
+import org.json.simple.JSONArray;
 import org.json.simple.JSONObject;
 import org.json.simple.JSONValue;
 import org.json.simple.parser.ParseException;
@@ -56,6 +57,7 @@ public class ProfilerImpl implements Profiler, Serializable, Jsonable {
     private boolean hasQueryTimings;
     private TimingInternal head;
     private boolean stopped;
+    private List<ClientTiming> clientTimings;
     private final ProfilerProvider profilerProvider;
 
     ProfilerProvider getProfilerProvider() {
@@ -173,6 +175,11 @@ public class ProfilerImpl implements Profiler, Serializable, Jsonable {
         ProfilerImpl profiler = new ProfilerImpl(id, name, started, machineName, level);
         TimingImpl root = TimingImpl.fromJson(profiler, null, (JSONObject) obj.get("Root"));
         profiler.root = root;
+
+        JSONObject clientTimingsObj = (JSONObject) obj.get("ClientTimings");
+        if (clientTimingsObj != null) {
+            profiler.clientTimings = ClientTiming.listFromJson((JSONArray) clientTimingsObj.get("Timings"));
+        }
 
         return profiler;
     }
@@ -304,8 +311,13 @@ public class ProfilerImpl implements Profiler, Serializable, Jsonable {
         map.put("DurationMilliseconds", getDurationMilliseconds());
         map.put("MachineName", machineName);
         map.put("Root", root);
-        // TODO support ClientTimings and CustomLinks
-        map.put("ClientTimings", null);
+        if (clientTimings != null) {
+            Map<String, Object> ct = new LinkedHashMap<>();
+            ct.put("Timings", clientTimings);
+            map.put("ClientTimings", ct);
+        } else {
+            map.put("ClientTimings", null);
+        }
         return map;
     }
 
@@ -323,7 +335,13 @@ public class ProfilerImpl implements Profiler, Serializable, Jsonable {
         Map<String, Object> map = new LinkedHashMap<>();
         map.put("Id", id.toString());
         map.put("Name", name);
-        map.put("ClientTimings", null);
+        if (clientTimings != null) {
+            Map<String, Object> ct = new LinkedHashMap<>();
+            ct.put("Timings", clientTimings);
+            map.put("ClientTimings", ct);
+        } else {
+            map.put("ClientTimings", null);
+        }
         map.put("Started", Instant.ofEpochMilli(started).atOffset(ZoneOffset.UTC).toString());
         map.put("HasUserViewed", false);
         map.put("MachineName", machineName);
@@ -476,6 +494,15 @@ public class ProfilerImpl implements Profiler, Serializable, Jsonable {
      */
     public void setHasQueryTimings(boolean hasQueryTimings) {
         this.hasQueryTimings = hasQueryTimings;
+    }
+
+    /**
+     * Sets the client-side performance timings for this session.
+     *
+     * @param clientTimings the list of client timings, or null to clear
+     */
+    public void setClientTimings(List<ClientTiming> clientTimings) {
+        this.clientTimings = clientTimings;
     }
 
     @Override

--- a/core/src/main/java/io/jdev/miniprofiler/server/MiniProfilerServer.java
+++ b/core/src/main/java/io/jdev/miniprofiler/server/MiniProfilerServer.java
@@ -27,8 +27,11 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.io.OutputStream;
 import java.net.InetSocketAddress;
+import io.jdev.miniprofiler.internal.ClientTiming;
+
 import java.nio.charset.StandardCharsets;
 import java.util.Collection;
+import java.util.List;
 import java.util.Optional;
 import java.util.UUID;
 import java.util.function.Consumer;
@@ -195,14 +198,28 @@ public class MiniProfilerServer implements AutoCloseable {
             return;
         }
 
-        ProfilerImpl profiler = provider.getStorage().load(id);
+        Storage storage = provider.getStorage();
+        ProfilerImpl profiler = storage.load(id);
         if (profiler == null) {
             sendError(exchange, 404);
             return;
         }
+
+        if (body != null && !body.isEmpty()) {
+            try {
+                List<ClientTiming> clientTimings = ResultsRequest.from(body).clientTimings;
+                if (clientTimings != null) {
+                    profiler.setClientTimings(clientTimings);
+                    storage.save(profiler);
+                }
+            } catch (IllegalArgumentException ignored) {
+                // ignore malformed body
+            }
+        }
+
         String user = profiler.getUser();
         if (user != null) {
-            provider.getStorage().setViewed(user, id);
+            storage.setViewed(user, id);
         }
 
         if (jsonRequest) {

--- a/core/src/main/java/io/jdev/miniprofiler/server/ResultsRequest.java
+++ b/core/src/main/java/io/jdev/miniprofiler/server/ResultsRequest.java
@@ -16,10 +16,13 @@
 
 package io.jdev.miniprofiler.server;
 
+import io.jdev.miniprofiler.internal.ClientTiming;
+import org.json.simple.JSONArray;
 import org.json.simple.JSONObject;
 import org.json.simple.JSONValue;
 import org.json.simple.parser.ParseException;
 
+import java.util.List;
 import java.util.UUID;
 
 /**
@@ -30,8 +33,12 @@ public final class ResultsRequest {
     /** The unique identifier of the requested profiling session. */
     public final UUID id;
 
-    private ResultsRequest(UUID id) {
+    /** Client-side performance timings, or null if not provided. */
+    public final List<ClientTiming> clientTimings;
+
+    private ResultsRequest(UUID id, List<ClientTiming> clientTimings) {
         this.id = id;
+        this.clientTimings = clientTimings;
     }
 
     /**
@@ -78,10 +85,14 @@ public final class ResultsRequest {
             id = id.substring(1, id.length() - 1);
         }
 
+        UUID uuid;
         try {
-            return new ResultsRequest(UUID.fromString(id));
+            uuid = UUID.fromString(id);
         } catch (IllegalArgumentException e) {
             throw new IllegalArgumentException("Results request Id property was not a UUID", e);
         }
+
+        List<ClientTiming> clientTimings = ClientTiming.listFromJson((JSONArray) reqJson.get("Performance"));
+        return new ResultsRequest(uuid, clientTimings);
     }
 }

--- a/core/src/test/groovy/io/jdev/miniprofiler/ScriptTagWriterSpec.groovy
+++ b/core/src/test/groovy/io/jdev/miniprofiler/ScriptTagWriterSpec.groovy
@@ -43,7 +43,7 @@ class ScriptTagWriterSpec extends Specification {
 
         and:
         attrs['data-current-id'] == profiler.id.toString()
-        attrs['data-ids'] == "[$profiler.id]"
+        attrs['data-ids'] == profiler.id.toString()
 
         and:
         validateUiAttrs(attrs, config)
@@ -112,7 +112,7 @@ class ScriptTagWriterSpec extends Specification {
         attrs.src == "/foo/includes.js?version=${version}"
         attrs['data-path'] == "/foo/"
         attrs['data-current-id'] == profiler.id.toString()
-        attrs['data-ids'] == "[$profiler.id]"
+        attrs['data-ids'] == profiler.id.toString()
     }
 
     void "printListScriptTag writes correct attributes"() {

--- a/core/src/test/groovy/io/jdev/miniprofiler/internal/ClientTimingSpec.groovy
+++ b/core/src/test/groovy/io/jdev/miniprofiler/internal/ClientTimingSpec.groovy
@@ -1,0 +1,118 @@
+/*
+ * Copyright 2026 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.jdev.miniprofiler.internal
+
+import groovy.json.JsonSlurper
+import io.jdev.miniprofiler.ProfileLevel
+import io.jdev.miniprofiler.test.TestProfilerProvider
+import spock.lang.Specification
+
+class ClientTimingSpec extends Specification {
+
+    def provider = new TestProfilerProvider()
+
+    void "toJson includes Duration for span timings"() {
+        given:
+        def ct = new ClientTiming("fetchStart", 0L, 12L)
+
+        when:
+        def json = ct.toJson()
+
+        then:
+        json["Name"] == "fetchStart"
+        json["Start"] == 0L
+        json["Duration"] == 12L
+        json.containsKey("Duration")
+    }
+
+    void "toJson omits Duration key for point timings"() {
+        given:
+        def ct = new ClientTiming("firstPaintTime", 380L, null)
+
+        when:
+        def json = ct.toJson()
+
+        then:
+        json["Name"] == "firstPaintTime"
+        json["Start"] == 380L
+        !json.containsKey("Duration")
+    }
+
+    void "toJSONString serializes span timing correctly"() {
+        given:
+        def ct = new ClientTiming("fetchStart", 0L, 12L)
+
+        when:
+        def parsed = new JsonSlurper().parseText(ct.toJSONString())
+
+        then:
+        parsed.Name == "fetchStart"
+        parsed.Start == 0
+        parsed.Duration == 12
+    }
+
+    void "toJSONString omits Duration for point timing"() {
+        given:
+        def ct = new ClientTiming("firstPaintTime", 380L, null)
+
+        when:
+        def parsed = new JsonSlurper().parseText(ct.toJSONString())
+
+        then:
+        parsed.Name == "firstPaintTime"
+        parsed.Start == 380
+        !parsed.containsKey("Duration")
+    }
+
+    void "listFromJson with mix of span and point timings parses correctly via profiler round-trip"() {
+        given: "a JSON string embedding client timings in a profiler"
+        def profiler = new ProfilerImpl("test", ProfileLevel.Info, provider)
+        profiler.stop()
+        def json = profiler.asUiJson().replace('"ClientTimings":null',
+            '"ClientTimings":{"Timings":[' +
+                '{"Name":"fetchStart","Start":0,"Duration":12},' +
+                '{"Name":"firstPaintTime","Start":380}' +
+            ']}')
+
+        when:
+        def restored = ProfilerImpl.fromJson(json)
+
+        then:
+        def ct = restored.toJson()["ClientTimings"]
+        ct != null
+        def timings = ct["Timings"]
+        timings.size() == 2
+        timings[0].name == "fetchStart"
+        timings[0].start == 0L
+        timings[0].duration == 12L
+        timings[1].name == "firstPaintTime"
+        timings[1].start == 380L
+        timings[1].duration == null
+    }
+
+    void "listFromJson returns null when Timings array is absent"() {
+        given:
+        def profiler = new ProfilerImpl("test", ProfileLevel.Info, provider)
+        profiler.stop()
+
+        when:
+        def restored = ProfilerImpl.fromJson(profiler.asUiJson())
+
+        then:
+        restored.toJson()["ClientTimings"] == null
+    }
+}

--- a/core/src/test/groovy/io/jdev/miniprofiler/internal/ProfilerImplFromJsonSpec.groovy
+++ b/core/src/test/groovy/io/jdev/miniprofiler/internal/ProfilerImplFromJsonSpec.groovy
@@ -179,4 +179,64 @@ class ProfilerImplFromJsonSpec extends Specification {
         then:
         thrown(IllegalArgumentException)
     }
+
+    void "toJson without client timings has null ClientTimings"() {
+        given:
+        def profiler = new ProfilerImpl("test-request", ProfileLevel.Info, provider)
+        profiler.stop()
+
+        when:
+        def json = profiler.toJson()
+
+        then:
+        json.containsKey("ClientTimings")
+        json["ClientTimings"] == null
+    }
+
+    void "toJson with client timings has nested Timings list"() {
+        given:
+        def profiler = new ProfilerImpl("test-request", ProfileLevel.Info, provider)
+        profiler.stop()
+        profiler.setClientTimings([
+            new ClientTiming("fetchStart", 0L, 12L),
+            new ClientTiming("firstPaintTime", 380L, null)
+        ])
+
+        when:
+        def json = profiler.toJson()
+
+        then:
+        json["ClientTimings"] != null
+        json["ClientTimings"]["Timings"].size() == 2
+        json["ClientTimings"]["Timings"][0].toJson()["Name"] == "fetchStart"
+        json["ClientTimings"]["Timings"][0].toJson()["Duration"] == 12L
+        json["ClientTimings"]["Timings"][1].toJson()["Name"] == "firstPaintTime"
+        !json["ClientTimings"]["Timings"][1].toJson().containsKey("Duration")
+    }
+
+    void "round-trip toJson/fromJson preserves client timings with null duration"() {
+        given:
+        def profiler = new ProfilerImpl("test-request", ProfileLevel.Info, provider)
+        profiler.machineName = 'testhost'
+        profiler.stop()
+        profiler.setClientTimings([
+            new ClientTiming("fetchStart", 0L, 12L),
+            new ClientTiming("firstPaintTime", 380L, null)
+        ])
+
+        when:
+        def restored = ProfilerImpl.fromJson(profiler.asUiJson())
+
+        then:
+        def ct = restored.toJson()["ClientTimings"]
+        ct != null
+        def timings = ct["Timings"]
+        timings.size() == 2
+        timings[0].name == "fetchStart"
+        timings[0].start == 0L
+        timings[0].duration == 12L
+        timings[1].name == "firstPaintTime"
+        timings[1].start == 380L
+        timings[1].duration == null
+    }
 }

--- a/core/src/test/groovy/io/jdev/miniprofiler/server/MiniProfilerServerSpec.groovy
+++ b/core/src/test/groovy/io/jdev/miniprofiler/server/MiniProfilerServerSpec.groovy
@@ -186,6 +186,41 @@ class MiniProfilerServerSpec extends Specification {
         conn.responseCode == 405
     }
 
+    void "POST results with Performance array returns response with ClientTimings"() {
+        given:
+        def body = """{"Id":"${profiler.id}","Performance":[{"Name":"fetchStart","Start":0,"Duration":12},{"Name":"firstPaintTime","Start":380}]}"""
+
+        when:
+        def conn = connect('miniprofiler/results', APPLICATION_JSON, 'POST', body)
+        def json = new JsonSlurper().parse(conn.inputStream)
+
+        then:
+        conn.responseCode == 200
+        json.ClientTimings != null
+        json.ClientTimings.Timings.size() == 2
+        json.ClientTimings.Timings[0].Name == 'fetchStart'
+        json.ClientTimings.Timings[0].Duration == 12
+        json.ClientTimings.Timings[1].Name == 'firstPaintTime'
+        json.ClientTimings.Timings[1].Duration == null
+    }
+
+    void "POST results with Performance array persists ClientTimings on subsequent GET"() {
+        given:
+        def body = """{"Id":"${profiler.id}","Performance":[{"Name":"fetchStart","Start":0,"Duration":12}]}"""
+        def postConn = connect('miniprofiler/results', APPLICATION_JSON, 'POST', body)
+        postConn.responseCode  // consume
+
+        when:
+        def conn = connect("miniprofiler/results?id=${profiler.id}", APPLICATION_JSON)
+        def json = new JsonSlurper().parse(conn.inputStream)
+
+        then:
+        conn.responseCode == 200
+        json.ClientTimings != null
+        json.ClientTimings.Timings.size() == 1
+        json.ClientTimings.Timings[0].Name == 'fetchStart'
+    }
+
     void "handleResults marks profiler as viewed"() {
         given: 'a profiler with a known user, stored and marked unviewed'
         Profiler userProfiler = provider.start('user-request')

--- a/core/src/test/groovy/io/jdev/miniprofiler/server/ResultsRequestSpec.groovy
+++ b/core/src/test/groovy/io/jdev/miniprofiler/server/ResultsRequestSpec.groovy
@@ -1,0 +1,78 @@
+/*
+ * Copyright 2026 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.jdev.miniprofiler.server
+
+import spock.lang.Specification
+
+class ResultsRequestSpec extends Specification {
+
+    void "body without Performance field produces null clientTimings"() {
+        given:
+        def id = UUID.randomUUID().toString()
+
+        when:
+        def req = ResultsRequest.from("""{"Id":"${id}"}""")
+
+        then:
+        req.id == UUID.fromString(id)
+        req.clientTimings == null
+    }
+
+    void "body with Performance array produces non-null clientTimings"() {
+        given:
+        def id = UUID.randomUUID().toString()
+        def body = """{"Id":"${id}","Performance":[{"Name":"fetchStart","Start":0,"Duration":12},{"Name":"firstPaintTime","Start":380}]}"""
+
+        when:
+        def req = ResultsRequest.from(body)
+
+        then:
+        req.clientTimings != null
+        req.clientTimings.size() == 2
+    }
+
+    void "body with Performance array preserves span and point timing values"() {
+        given:
+        def id = UUID.randomUUID().toString()
+        def body = """{"Id":"${id}","Performance":[{"Name":"fetchStart","Start":0,"Duration":12},{"Name":"firstPaintTime","Start":380}]}"""
+
+        when:
+        def req = ResultsRequest.from(body)
+
+        then:
+        def span = req.clientTimings[0]
+        span.name == "fetchStart"
+        span.start == 0L
+        span.duration == 12L
+
+        def point = req.clientTimings[1]
+        point.name == "firstPaintTime"
+        point.start == 380L
+        point.duration == null
+    }
+
+    void "body with empty Performance array produces null clientTimings"() {
+        given:
+        def id = UUID.randomUUID().toString()
+
+        when:
+        def req = ResultsRequest.from("""{"Id":"${id}","Performance":[]}""")
+
+        then:
+        req.clientTimings == null
+    }
+}

--- a/jakarta-servlet/src/main/java/io/jdev/miniprofiler/jakarta/servlet/ProfilingFilter.java
+++ b/jakarta-servlet/src/main/java/io/jdev/miniprofiler/jakarta/servlet/ProfilingFilter.java
@@ -20,9 +20,11 @@ import io.jdev.miniprofiler.MiniProfiler;
 import io.jdev.miniprofiler.Profiler;
 import io.jdev.miniprofiler.ProfilerProvider;
 import io.jdev.miniprofiler.StaticProfilerProvider;
+import io.jdev.miniprofiler.internal.ClientTiming;
 import io.jdev.miniprofiler.server.Pages;
 import io.jdev.miniprofiler.internal.ProfilerImpl;
 import io.jdev.miniprofiler.server.Ids;
+import io.jdev.miniprofiler.server.ResultsRequest;
 import io.jdev.miniprofiler.storage.Storage;
 import io.jdev.miniprofiler.server.ResourceHelper;
 
@@ -35,6 +37,7 @@ import java.io.Writer;
 import java.net.MalformedURLException;
 import java.nio.charset.StandardCharsets;
 import java.util.Collection;
+import java.util.List;
 import java.util.Optional;
 import java.util.UUID;
 
@@ -173,20 +176,43 @@ public class ProfilingFilter implements Filter {
         boolean jsonRequest = Optional.ofNullable(request.getHeader(ACCEPT_HEADER))
             .map(header -> header.contains(CONTENT_TYPE_JSON)).orElse(false);
 
-        UUID id = parseId(request, jsonRequest);
+        String body = null;
+        if (jsonRequest) {
+            try {
+                body = getBody(request);
+            } catch (IOException ignored) {
+                // fall through to id param
+            }
+        }
+
+        UUID id = Ids.parseId(request.getHeader(ACCEPT_HEADER), body, request.getParameter(ID_PARAM));
         if (id == null) {
             response.sendError(HttpServletResponse.SC_BAD_REQUEST);
             return;
         }
 
-        Profiler profiler = profilerProvider.getStorage().load(id);
+        Storage storage = profilerProvider.getStorage();
+        ProfilerImpl profiler = storage.load(id);
         if (profiler == null) {
             response.sendError(HttpServletResponse.SC_NOT_FOUND);
             return;
         }
+
+        if (body != null && !body.isEmpty()) {
+            try {
+                List<ClientTiming> clientTimings = ResultsRequest.from(body).clientTimings;
+                if (clientTimings != null) {
+                    profiler.setClientTimings(clientTimings);
+                    storage.save(profiler);
+                }
+            } catch (IllegalArgumentException ignored) {
+                // ignore malformed body
+            }
+        }
+
         String user = profiler.getUser();
         if (user != null) {
-            profilerProvider.getStorage().setViewed(user, id);
+            storage.setViewed(user, id);
         }
 
         if (jsonRequest) {
@@ -236,18 +262,6 @@ public class ProfilingFilter implements Filter {
         try (Writer writer = response.getWriter()) {
             writer.write(Pages.renderResultListJson(ids, storage));
         }
-    }
-
-    private static UUID parseId(HttpServletRequest request, boolean jsonRequest) {
-        String body = null;
-        if (jsonRequest) {
-            try {
-                body = getBody(request);
-            } catch (IOException ignored) {
-                // fall through to id param
-            }
-        }
-        return Ids.parseId(request.getHeader(ACCEPT_HEADER), body, request.getParameter(ID_PARAM));
     }
 
     private void renderJson(Profiler profiler, HttpServletResponse response) throws IOException {

--- a/javax-servlet/src/main/java/io/jdev/miniprofiler/javax/servlet/ProfilingFilter.java
+++ b/javax-servlet/src/main/java/io/jdev/miniprofiler/javax/servlet/ProfilingFilter.java
@@ -20,9 +20,11 @@ import io.jdev.miniprofiler.MiniProfiler;
 import io.jdev.miniprofiler.Profiler;
 import io.jdev.miniprofiler.ProfilerProvider;
 import io.jdev.miniprofiler.StaticProfilerProvider;
+import io.jdev.miniprofiler.internal.ClientTiming;
 import io.jdev.miniprofiler.server.Pages;
 import io.jdev.miniprofiler.internal.ProfilerImpl;
 import io.jdev.miniprofiler.server.Ids;
+import io.jdev.miniprofiler.server.ResultsRequest;
 import io.jdev.miniprofiler.storage.Storage;
 import io.jdev.miniprofiler.server.ResourceHelper;
 
@@ -35,6 +37,7 @@ import java.io.Writer;
 import java.net.MalformedURLException;
 import java.nio.charset.StandardCharsets;
 import java.util.Collection;
+import java.util.List;
 import java.util.Optional;
 import java.util.UUID;
 
@@ -173,20 +176,43 @@ public class ProfilingFilter implements Filter {
         boolean jsonRequest = Optional.ofNullable(request.getHeader(ACCEPT_HEADER))
             .map(header -> header.contains(CONTENT_TYPE_JSON)).orElse(false);
 
-        UUID id = parseId(request, jsonRequest);
+        String body = null;
+        if (jsonRequest) {
+            try {
+                body = getBody(request);
+            } catch (IOException ignored) {
+                // fall through to id param
+            }
+        }
+
+        UUID id = Ids.parseId(request.getHeader(ACCEPT_HEADER), body, request.getParameter(ID_PARAM));
         if (id == null) {
             response.sendError(HttpServletResponse.SC_BAD_REQUEST);
             return;
         }
 
-        Profiler profiler = profilerProvider.getStorage().load(id);
+        Storage storage = profilerProvider.getStorage();
+        ProfilerImpl profiler = storage.load(id);
         if (profiler == null) {
             response.sendError(HttpServletResponse.SC_NOT_FOUND);
             return;
         }
+
+        if (body != null && !body.isEmpty()) {
+            try {
+                List<ClientTiming> clientTimings = ResultsRequest.from(body).clientTimings;
+                if (clientTimings != null) {
+                    profiler.setClientTimings(clientTimings);
+                    storage.save(profiler);
+                }
+            } catch (IllegalArgumentException ignored) {
+                // ignore malformed body
+            }
+        }
+
         String user = profiler.getUser();
         if (user != null) {
-            profilerProvider.getStorage().setViewed(user, id);
+            storage.setViewed(user, id);
         }
 
         if (jsonRequest) {
@@ -236,18 +262,6 @@ public class ProfilingFilter implements Filter {
         try (Writer writer = response.getWriter()) {
             writer.write(Pages.renderResultListJson(ids, storage));
         }
-    }
-
-    private static UUID parseId(HttpServletRequest request, boolean jsonRequest) {
-        String body = null;
-        if (jsonRequest) {
-            try {
-                body = getBody(request);
-            } catch (IOException ignored) {
-                // fall through to id param
-            }
-        }
-        return Ids.parseId(request.getHeader(ACCEPT_HEADER), body, request.getParameter(ID_PARAM));
     }
 
     private void renderJson(Profiler profiler, HttpServletResponse response) throws IOException {

--- a/ratpack/src/main/java/io/jdev/miniprofiler/ratpack/MiniProfilerResultsHandler.java
+++ b/ratpack/src/main/java/io/jdev/miniprofiler/ratpack/MiniProfilerResultsHandler.java
@@ -18,14 +18,17 @@ package io.jdev.miniprofiler.ratpack;
 
 import com.google.inject.Inject;
 import io.jdev.miniprofiler.ProfilerProvider;
+import io.jdev.miniprofiler.internal.ClientTiming;
 import io.jdev.miniprofiler.internal.ProfilerImpl;
 import io.jdev.miniprofiler.server.Ids;
+import io.jdev.miniprofiler.server.ResultsRequest;
 import ratpack.handling.Context;
 import ratpack.handling.Handler;
 import ratpack.http.Response;
 import ratpack.http.Status;
 import ratpack.http.TypedData;
 
+import java.util.List;
 import java.util.Optional;
 import java.util.UUID;
 
@@ -89,6 +92,17 @@ public class MiniProfilerResultsHandler implements Handler {
                 asyncStorage.loadAsync(requestedId)
                     .then(profiler -> {
                         if (profiler != null) {
+                            if (body != null && !body.isEmpty()) {
+                                try {
+                                    List<ClientTiming> clientTimings = ResultsRequest.from(body).clientTimings;
+                                    if (clientTimings != null) {
+                                        profiler.setClientTimings(clientTimings);
+                                        asyncStorage.saveAsync(profiler);
+                                    }
+                                } catch (IllegalArgumentException ignored) {
+                                    // ignore malformed body
+                                }
+                            }
                             String user = profiler.getUser();
                             Runnable render = () -> {
                                 if (isJsonRequest(ctx)) {

--- a/test-geb/src/main/groovy/io/jdev/miniprofiler/test/geb/MiniProfilerPopupModule.groovy
+++ b/test-geb/src/main/groovy/io/jdev/miniprofiler/test/geb/MiniProfilerPopupModule.groovy
@@ -24,9 +24,11 @@ class MiniProfilerPopupModule extends Module {
 
     static content = {
         name { $('.mp-name') }
-        timings { $('.mp-output .mp-timings tbody tr').moduleList(MiniProfilerTimingRowModule) }
+        timings { $('.mp-output .mp-timings:not(.mp-client-timings) tbody tr').moduleList(MiniProfilerTimingRowModule) }
         toggleChildTimingLink { $('.mp-toggle-columns').first() }
         shareLink { $('.mp-share-mp-results') }
+        clientTimings(required: false) { $('.mp-output .mp-client-timings') }
+        clientTimingRows { clientTimings.find('tbody tr') }
     }
 
     void close() {

--- a/testlib-browser/src/main/groovy/io/jdev/miniprofiler/browsertest/AbstractMiniProfilerHandlerBrowserSpec.groovy
+++ b/testlib-browser/src/main/groovy/io/jdev/miniprofiler/browsertest/AbstractMiniProfilerHandlerBrowserSpec.groovy
@@ -19,6 +19,7 @@ package io.jdev.miniprofiler.browsertest
 import geb.spock.GebReportingSpec
 import io.jdev.miniprofiler.ProfileLevel
 import io.jdev.miniprofiler.integtest.InProcessTestedServer
+import io.jdev.miniprofiler.internal.ClientTiming
 import io.jdev.miniprofiler.internal.ProfilerImpl
 import io.jdev.miniprofiler.test.geb.MiniProfilerModule
 import io.jdev.miniprofiler.test.geb.MiniProfilerPopupModule
@@ -73,6 +74,26 @@ abstract class AbstractMiniProfilerHandlerBrowserSpec extends GebReportingSpec {
         child.addCustomTiming('sql', 'reader', 'select * from people', 50L)
         child.stop()
         p.stop(true)
+        server.addProfile(p)
+        return p.id
+    }
+
+    /**
+     * Injects a profile with pre-set client timings directly into storage. This is used by
+     * tests that verify client timings are rendered in the popup, since WebDriver-controlled
+     * Firefox does not provide real window.performance values. The server preserves pre-set
+     * client timings when the browser posts an empty Performance array.
+     */
+    protected UUID injectProfileWithClientTimings(String name = '/test-request') {
+        def p = new ProfilerImpl(name, ProfileLevel.Info, server.profilerProvider)
+        def child = p.step('child step')
+        child.addCustomTiming('sql', 'reader', 'select * from people', 50L)
+        child.stop()
+        p.stop(true)
+        p.setClientTimings([
+            new ClientTiming('requestStart', 50L, 100L),
+            new ClientTiming('responseStart', 150L, 50L),
+        ])
         server.addProfile(p)
         return p.id
     }
@@ -318,6 +339,48 @@ abstract class AbstractMiniProfilerHandlerBrowserSpec extends GebReportingSpec {
         query.type == 'sql - reader'
         query.query ==~ /select\s+\*\s+from\s+people/
         query.duration ==~ /\d+\.\d+ ms \(T\+-?\d+\.\d+ ms\)/
+    }
+
+    void 'results page popup shows client timings sent by browser'() {
+        given:
+        UUID id = injectProfileWithClientTimings()
+
+        when:
+        go "miniprofiler/results?id=${id}"
+
+        then:
+        at MiniProfilerSingleResultPage
+        waitFor { page.items.size() >= 1 }
+        def popup = page.items[0] as MiniProfilerPopupModule
+        waitFor { popup.clientTimings.present }
+        popup.clientTimingRows.size() >= 1
+        popup.clientTimingRows[0].find('.mp-label').text() == 'Request'
+    }
+
+    @Requires({ instance.server.profiledPagePath })
+    void 'widget popup shows client timings sent by browser'() {
+        when:
+        go server.profiledPagePath
+
+        then:
+        waitFor { !module(MiniProfilerModule).results.empty }
+        def result = module(MiniProfilerModule).results[0]
+
+        when:
+        result.button.click()
+
+        then:
+        waitFor { result.popup.displayed }
+        waitFor {
+            result.popup.clientTimings.present
+        }
+        result.popup.clientTimingRows.size() >= 1
+
+        when:
+        result.popup.$('.mp-toggle-trivial').first().click()
+
+        then:
+        waitFor { result.popup.clientTimingRows.any { it.find('.mp-label').text() == 'Fetch' } }
     }
 
     @Requires({ instance.server.ajaxEndpointPath })

--- a/testlib-integration/src/main/groovy/io/jdev/miniprofiler/integtest/AbstractProfilingHandlerIntegrationSpec.groovy
+++ b/testlib-integration/src/main/groovy/io/jdev/miniprofiler/integtest/AbstractProfilingHandlerIntegrationSpec.groovy
@@ -204,6 +204,44 @@ abstract class AbstractProfilingHandlerIntegrationSpec extends Specification {
             .getUnviewedIds(server.testUser).contains(UUID.fromString(id))
     }
 
+    void 'POST results with Performance array returns ClientTimings in response'() {
+        given:
+        def profiler = server.createProfile('test-request')
+        def id = profiler.id.toString()
+        def performanceJson = '[{"Name":"fetchStart","Start":0,"Duration":12},{"Name":"firstPaintTime","Start":380}]'
+
+        when:
+        def response = client.postResultsJson(id, performanceJson)
+        def body = response.bodyAsJson()
+
+        then:
+        response.statusCode() == 200
+        body.ClientTimings != null
+        body.ClientTimings.Timings.size() == 2
+        body.ClientTimings.Timings[0].Name == 'fetchStart'
+        body.ClientTimings.Timings[0].Duration == 12
+        body.ClientTimings.Timings[1].Name == 'firstPaintTime'
+        body.ClientTimings.Timings[1].Duration == null
+    }
+
+    void 'POST results with Performance array persists ClientTimings on subsequent GET'() {
+        given:
+        def profiler = server.createProfile('test-request')
+        def id = profiler.id.toString()
+        def performanceJson = '[{"Name":"fetchStart","Start":0,"Duration":12}]'
+        client.postResultsJson(id, performanceJson)
+
+        when:
+        def response = client.getResultsJson(id)
+        def body = response.bodyAsJson()
+
+        then:
+        response.statusCode() == 200
+        body.ClientTimings != null
+        body.ClientTimings.Timings.size() == 1
+        body.ClientTimings.Timings[0].Name == 'fetchStart'
+    }
+
     @Requires({ instance.server.ajaxEndpointPath })
     void 'ajax endpoint is profiled with X-MiniProfiler-Ids header'() {
         when:

--- a/testlib-integration/src/main/java/io/jdev/miniprofiler/integtest/TestMiniProfilerHttpClient.java
+++ b/testlib-integration/src/main/java/io/jdev/miniprofiler/integtest/TestMiniProfilerHttpClient.java
@@ -156,6 +156,42 @@ public class TestMiniProfilerHttpClient {
         return get(profilerPath + "/" + name);
     }
 
+    /**
+     * POSTs client-side performance data to {@code <profilerPath>/results} with
+     * {@code Accept: application/json} and {@code Content-Type: application/json}.
+     *
+     * @param id             the profiler result ID
+     * @param performanceJson JSON array string for the {@code Performance} field, or {@code null} to omit it
+     * @return the response
+     * @throws IOException on network error
+     */
+    public TestHttpResponse postResultsJson(String id, String performanceJson) throws IOException {
+        String body = performanceJson != null
+            ? "{\"Id\":\"" + id + "\",\"Performance\":" + performanceJson + "}"
+            : "{\"Id\":\"" + id + "\"}";
+        return post(profilerPath + "/results", body,
+            Collections.singletonMap("Accept", "application/json"));
+    }
+
+    private TestHttpResponse post(String path, String body, Map<String, String> headers) throws IOException {
+        byte[] bodyBytes = body.getBytes(StandardCharsets.UTF_8);
+        HttpURLConnection conn = (HttpURLConnection) new URL(baseUrl + path).openConnection();
+        conn.setConnectTimeout(5_000);
+        conn.setReadTimeout(10_000);
+        conn.setInstanceFollowRedirects(false);
+        conn.setRequestMethod("POST");
+        conn.setDoOutput(true);
+        conn.setRequestProperty("Content-Type", "application/json");
+        for (Map.Entry<String, String> entry : headers.entrySet()) {
+            conn.setRequestProperty(entry.getKey(), entry.getValue());
+        }
+        conn.getOutputStream().write(bodyBytes);
+        int statusCode = conn.getResponseCode();
+        InputStream stream = statusCode >= 400 ? conn.getErrorStream() : conn.getInputStream();
+        String responseBody = stream == null ? "" : readStream(stream);
+        return new TestHttpResponse(statusCode, responseBody, conn.getHeaderFields());
+    }
+
     private static String readStream(InputStream stream) throws IOException {
         ByteArrayOutputStream result = new ByteArrayOutputStream();
         byte[] buffer = new byte[4096];


### PR DESCRIPTION
## Summary

The MiniProfiler UI JavaScript already collects `window.performance` timing data and
POSTs it to the results endpoint, but the server ignored it and always returned
`"ClientTimings": null`. This PR wires it through so client timings are parsed, stored
on the profiler, and returned in the JSON response — enabling the existing client
timings UI rendering.

- Add `ClientTiming` model class and serialisation support on `ProfilerImpl`
- Parse the `Performance` array from the POST body via `ResultsRequest`
- Wire client timing persistence through all four handler implementations
  (MiniProfilerServer, jakarta ProfilingFilter, javax ProfilingFilter, Ratpack handler)
- Fix `ScriptTagWriter` `data-ids` format to emit comma-separated UUIDs
  matching what the JavaScript expects (was using `List.toString()` brackets)