### PR TITLE
Add custom links support to profiler

### DIFF
--- a/core/src/main/java/io/jdev/miniprofiler/Profiler.java
+++ b/core/src/main/java/io/jdev/miniprofiler/Profiler.java
@@ -17,6 +17,7 @@
 package io.jdev.miniprofiler;
 
 import java.io.Closeable;
+import java.util.Map;
 import java.util.UUID;
 import java.util.concurrent.Callable;
 
@@ -279,5 +280,28 @@ public interface Profiler extends Closeable {
      */
     default boolean isActive() {
         return true;
+    }
+
+    /**
+     * Adds a named URL link to this profiling session.
+     *
+     * <p>Custom links appear in the profiler popup UI and open in a new tab.
+     * They are useful for linking a profiler result to deeper diagnostics pages
+     * for the same request (e.g. distributed tracing UIs, AppStats).</p>
+     *
+     * @param text the display text for the link
+     * @param url  the URL the link points to
+     */
+    default void addCustomLink(String text, String url) {
+    }
+
+    /**
+     * Returns the custom links attached to this profiling session, or {@code null}
+     * if none have been added.
+     *
+     * @return a map of link text to URL, or {@code null}
+     */
+    default Map<String, String> getCustomLinks() {
+        return null;
     }
 }

--- a/core/src/main/java/io/jdev/miniprofiler/internal/ProfilerImpl.java
+++ b/core/src/main/java/io/jdev/miniprofiler/internal/ProfilerImpl.java
@@ -58,6 +58,7 @@ public class ProfilerImpl implements Profiler, Serializable, Jsonable {
     private TimingInternal head;
     private boolean stopped;
     private List<ClientTiming> clientTimings;
+    private volatile Map<String, String> customLinks;
     private final ProfilerProvider profilerProvider;
 
     ProfilerProvider getProfilerProvider() {
@@ -179,6 +180,15 @@ public class ProfilerImpl implements Profiler, Serializable, Jsonable {
         JSONObject clientTimingsObj = (JSONObject) obj.get("ClientTimings");
         if (clientTimingsObj != null) {
             profiler.clientTimings = ClientTiming.listFromJson((JSONArray) clientTimingsObj.get("Timings"));
+        }
+
+        JSONObject customLinksObj = (JSONObject) obj.get("CustomLinks");
+        if (customLinksObj != null) {
+            Map<String, String> links = new LinkedHashMap<>();
+            for (Object key : customLinksObj.keySet()) {
+                links.put((String) key, (String) customLinksObj.get(key));
+            }
+            profiler.customLinks = links;
         }
 
         return profiler;
@@ -318,6 +328,7 @@ public class ProfilerImpl implements Profiler, Serializable, Jsonable {
         } else {
             map.put("ClientTimings", null);
         }
+        map.put("CustomLinks", customLinks);
         return map;
     }
 
@@ -503,6 +514,25 @@ public class ProfilerImpl implements Profiler, Serializable, Jsonable {
      */
     public void setClientTimings(List<ClientTiming> clientTimings) {
         this.clientTimings = clientTimings;
+    }
+
+    @Override
+    public void addCustomLink(String text, String url) {
+        Map<String, String> links = customLinks;
+        if (links == null) {
+            synchronized (this) {
+                links = customLinks;
+                if (links == null) {
+                    customLinks = links = new LinkedHashMap<>();
+                }
+            }
+        }
+        links.put(text, url);
+    }
+
+    @Override
+    public Map<String, String> getCustomLinks() {
+        return customLinks;
     }
 
     @Override

--- a/core/src/test/groovy/io/jdev/miniprofiler/internal/ProfilerImplFromJsonSpec.groovy
+++ b/core/src/test/groovy/io/jdev/miniprofiler/internal/ProfilerImplFromJsonSpec.groovy
@@ -180,6 +180,37 @@ class ProfilerImplFromJsonSpec extends Specification {
         thrown(IllegalArgumentException)
     }
 
+    void "round-trip profiler with custom links"() {
+        given:
+        def profiler = new ProfilerImpl("test-request", ProfileLevel.Info, provider)
+        profiler.machineName = 'testhost'
+        profiler.addCustomLink('AppStats', 'http://example.com/appstats')
+        profiler.addCustomLink('Tracing', 'http://example.com/tracing')
+        profiler.stop()
+
+        when:
+        def json = profiler.asUiJson()
+        def restored = ProfilerImpl.fromJson(json)
+
+        then:
+        restored.customLinks == [
+            'AppStats': 'http://example.com/appstats',
+            'Tracing': 'http://example.com/tracing'
+        ]
+    }
+
+    void "customLinks is null when no links present in JSON"() {
+        given:
+        def profiler = new ProfilerImpl("test-request", ProfileLevel.Info, provider)
+        profiler.stop()
+
+        when:
+        def restored = ProfilerImpl.fromJson(profiler.asUiJson())
+
+        then:
+        restored.customLinks == null
+    }
+
     void "toJson without client timings has null ClientTimings"() {
         given:
         def profiler = new ProfilerImpl("test-request", ProfileLevel.Info, provider)

--- a/core/src/test/groovy/io/jdev/miniprofiler/internal/ProfilerImplSpec.groovy
+++ b/core/src/test/groovy/io/jdev/miniprofiler/internal/ProfilerImplSpec.groovy
@@ -138,6 +138,32 @@ class ProfilerImplSpec extends Specification {
         result == 'bar'
     }
 
+    void "addCustomLink stores an entry"() {
+        when:
+        profiler.addCustomLink('AppStats', 'http://example.com/appstats')
+
+        then:
+        profiler.customLinks == ['AppStats': 'http://example.com/appstats']
+    }
+
+    void "multiple addCustomLink calls accumulate entries in insertion order"() {
+        when:
+        profiler.addCustomLink('AppStats', 'http://example.com/appstats')
+        profiler.addCustomLink('Tracing', 'http://example.com/tracing')
+
+        then:
+        profiler.customLinks.keySet() as List == ['AppStats', 'Tracing']
+        profiler.customLinks == [
+            'AppStats': 'http://example.com/appstats',
+            'Tracing': 'http://example.com/tracing'
+        ]
+    }
+
+    void "getCustomLinks returns null when no links added"() {
+        expect:
+        profiler.customLinks == null
+    }
+
     void "json is in expected order"() {
         when:
         def parsed = new ObjectMapper().readTree(profiler.asUiJson())
@@ -150,7 +176,8 @@ class ProfilerImplSpec extends Specification {
             'DurationMilliseconds',
             'MachineName',
             'Root',
-            'ClientTimings'
+            'ClientTimings',
+            'CustomLinks'
         ]
     }
 

--- a/test-geb/src/browserTest/groovy/io/jdev/miniprofiler/test/geb/ProfilerUiComparatorSpec.groovy
+++ b/test-geb/src/browserTest/groovy/io/jdev/miniprofiler/test/geb/ProfilerUiComparatorSpec.groovy
@@ -218,6 +218,39 @@ class ProfilerUiComparatorSpec extends GebReportingSpec {
         thrown(AssertionError)
     }
 
+    // ---- Custom links verification -----------------------------------------
+
+    void "comparator passes when custom links match"() {
+        given:
+        ExpectedProfiler expected = ProfilerDsl.profiler('/test-request/', 0) { root ->
+            root.step('child step', 0) { step ->
+                step.customTiming('sql', 'reader', 'select * from people')
+            }
+        }
+
+        when:
+        ProfilerUiComparator.verify(expected, miniProfiler)
+
+        then:
+        noExceptionThrown()
+    }
+
+    void "comparator fails when expected custom link is not in UI"() {
+        given:
+        ExpectedProfiler expected = ProfilerDsl.profiler('/test-request/', 0) { root ->
+            root.customLink('AppStats', 'http://example.com/appstats')
+            root.step('child step', 0) { step ->
+                step.customTiming('sql', 'reader', 'select * from people')
+            }
+        }
+
+        when:
+        ProfilerUiComparator.verify(expected, miniProfiler)
+
+        then:
+        thrown(AssertionError)
+    }
+
     // ---- Profiler-based exact verification --------------------------------
 
     void "exact verify passes for matching profiler"() {

--- a/test-geb/src/main/groovy/io/jdev/miniprofiler/test/geb/MiniProfilerPopupModule.groovy
+++ b/test-geb/src/main/groovy/io/jdev/miniprofiler/test/geb/MiniProfilerPopupModule.groovy
@@ -29,6 +29,7 @@ class MiniProfilerPopupModule extends Module {
         shareLink { $('.mp-share-mp-results') }
         clientTimings(required: false) { $('.mp-output .mp-client-timings') }
         clientTimingRows { clientTimings.find('tbody tr') }
+        customLinks(required: false) { $('.mp-links .mp-custom-link') }
     }
 
     void close() {

--- a/test-geb/src/main/groovy/io/jdev/miniprofiler/test/geb/ProfilerUiComparator.groovy
+++ b/test-geb/src/main/groovy/io/jdev/miniprofiler/test/geb/ProfilerUiComparator.groovy
@@ -144,6 +144,8 @@ class ProfilerUiComparator {
             throw new AssertionError(
                 "Expected ${nextIndex} timing row(s) in the UI but found ${rows.size()}")
         }
+
+        verifyCustomLinksInPopup(profiler.customLinks, popup)
     }
 
     private static int verifyTimingRowExact(List<MiniProfilerTimingRowModule> rows, int rowIndex,
@@ -217,6 +219,8 @@ class ProfilerUiComparator {
 
         List<MiniProfilerTimingRowModule> rows = popup.timings
         verifyTimingRow(rows, 0, expected.root, result)
+
+        verifyCustomLinksInPopup(expected.customLinks, popup)
     }
 
     /**
@@ -291,6 +295,20 @@ class ProfilerUiComparator {
 
                 queryIndex++
             }
+        }
+    }
+
+    @SuppressWarnings('MethodParameterTypeRequired')
+    private static void verifyCustomLinksInPopup(Map<String, String> expectedLinks, popup) {
+        Map<String, String> effectiveExpected = expectedLinks ?: [:]
+        def linkElements = popup.customLinks
+        int actualCount = linkElements.size()
+        assertEqual("custom link count", effectiveExpected.size(), actualCount)
+        effectiveExpected.eachWithIndex { String text, String url, int i ->
+            String actualText = linkElements[i].text()?.trim()
+            assertEqual("custom link text at index ${i}", text, actualText)
+            String actualHref = linkElements[i].@href
+            assertEqual("custom link URL for '${text}'", url, actualHref)
         }
     }
 

--- a/test/src/main/java/io/jdev/miniprofiler/test/ExpectedProfiler.java
+++ b/test/src/main/java/io/jdev/miniprofiler/test/ExpectedProfiler.java
@@ -16,6 +16,8 @@
 
 package io.jdev.miniprofiler.test;
 
+import java.util.Map;
+
 /**
  * Describes expected properties of a profiling session for use in test assertions.
  * Instances are built via {@link ProfilerDsl}.
@@ -24,10 +26,12 @@ public final class ExpectedProfiler {
 
     private final String name;
     private final ExpectedTiming root;
+    private final Map<String, String> customLinks;
 
-    ExpectedProfiler(String name, ExpectedTiming root) {
+    ExpectedProfiler(String name, ExpectedTiming root, Map<String, String> customLinks) {
         this.name = name;
         this.root = root;
+        this.customLinks = customLinks;
     }
 
     /**
@@ -46,5 +50,14 @@ public final class ExpectedProfiler {
      */
     public ExpectedTiming getRoot() {
         return root;
+    }
+
+    /**
+     * Returns the expected custom links, or {@code null} if none are expected.
+     *
+     * @return a map of link text to URL, or {@code null}
+     */
+    public Map<String, String> getCustomLinks() {
+        return customLinks;
     }
 }

--- a/test/src/main/java/io/jdev/miniprofiler/test/ProfilerComparator.java
+++ b/test/src/main/java/io/jdev/miniprofiler/test/ProfilerComparator.java
@@ -56,6 +56,22 @@ public final class ProfilerComparator {
     public static void verify(ProfilerImpl actual, ExpectedProfiler expected) {
         assertEqual("profiler name", expected.getName(), actual.getName());
         verifyTiming(actual.getRoot(), expected.getRoot(), "root");
+        verifyCustomLinks(actual.getCustomLinks(), expected.getCustomLinks());
+    }
+
+    private static void verifyCustomLinks(Map<String, String> actual, Map<String, String> expected) {
+        Map<String, String> effectiveExpected = expected != null ? expected : Collections.emptyMap();
+        Map<String, String> effectiveActual = actual != null ? actual : Collections.emptyMap();
+        assertEqual("custom link count", effectiveExpected.size(), effectiveActual.size());
+        for (Map.Entry<String, String> entry : effectiveExpected.entrySet()) {
+            String text = entry.getKey();
+            String expectedUrl = entry.getValue();
+            String actualUrl = effectiveActual.get(text);
+            if (actualUrl == null) {
+                throw new AssertionError("Expected custom link '" + text + "' but none found");
+            }
+            assertEqual("custom link URL for '" + text + "'", expectedUrl, actualUrl);
+        }
     }
 
     private static void verifyTiming(Timing actual, ExpectedTiming expected, String path) {

--- a/test/src/main/java/io/jdev/miniprofiler/test/ProfilerDsl.java
+++ b/test/src/main/java/io/jdev/miniprofiler/test/ProfilerDsl.java
@@ -56,20 +56,20 @@ public final class ProfilerDsl {
 
     /**
      * Creates an {@link ExpectedProfiler} with the given name and minimum duration,
-     * configured by the given spec.
+     * configured by the given spec which can set profiler-level properties such as custom links.
      *
      * <p>The root timing of the profiler will have the same name as the profiler,
      * matching the behaviour of {@link io.jdev.miniprofiler.internal.ProfilerImpl}.</p>
      *
      * @param name         the expected profiler name
      * @param minDurationMs minimum expected duration in milliseconds
-     * @param spec         spec that configures the root timing's children and custom timings
+     * @param spec         spec that configures the profiler's custom links and root timing
      * @return the built {@link ExpectedProfiler}
      */
-    public static ExpectedProfiler profiler(String name, long minDurationMs, Consumer<TimingBuilder> spec) {
-        TimingBuilder rootBuilder = new TimingBuilder(name, minDurationMs);
-        spec.accept(rootBuilder);
-        return new ExpectedProfiler(name, rootBuilder.build());
+    public static ExpectedProfiler profiler(String name, long minDurationMs, Consumer<ProfilerBuilder> spec) {
+        ProfilerBuilder builder = new ProfilerBuilder(name, minDurationMs);
+        spec.accept(builder);
+        return builder.build();
     }
 
     /**
@@ -77,10 +77,10 @@ public final class ProfilerDsl {
      * constraint, configured by the given spec.
      *
      * @param name the expected profiler name
-     * @param spec spec that configures the root timing's children and custom timings
+     * @param spec spec that configures the profiler's custom links and root timing
      * @return the built {@link ExpectedProfiler}
      */
-    public static ExpectedProfiler profiler(String name, Consumer<TimingBuilder> spec) {
+    public static ExpectedProfiler profiler(String name, Consumer<ProfilerBuilder> spec) {
         return profiler(name, 0, spec);
     }
 
@@ -190,6 +190,102 @@ public final class ProfilerDsl {
 
         ExpectedTiming build() {
             return new ExpectedTiming(name, minDurationMs, children, customTimings);
+        }
+    }
+
+    /**
+     * Builder for an {@link ExpectedProfiler} within the DSL.
+     *
+     * <p>Wraps a {@link TimingBuilder} for the root timing and adds profiler-level
+     * properties such as custom links. All timing methods delegate to the root builder.</p>
+     */
+    public static final class ProfilerBuilder {
+
+        private final TimingBuilder rootBuilder;
+        private final Map<String, String> customLinks = new LinkedHashMap<>();
+
+        private ProfilerBuilder(String name, long minDurationMs) {
+            this.rootBuilder = new TimingBuilder(name, minDurationMs);
+        }
+
+        /**
+         * Adds a child timing step with a minimum duration, configured by the given spec.
+         *
+         * @param stepName the name of the timing step
+         * @param stepMinDurationMs minimum expected duration in milliseconds
+         * @param spec spec that configures the step's children and custom timings
+         * @return this builder
+         */
+        public ProfilerBuilder step(String stepName, long stepMinDurationMs, Consumer<TimingBuilder> spec) {
+            rootBuilder.step(stepName, stepMinDurationMs, spec);
+            return this;
+        }
+
+        /**
+         * Adds a child timing step with no minimum duration constraint, configured by the given spec.
+         *
+         * @param stepName the name of the timing step
+         * @param spec spec that configures the step's children and custom timings
+         * @return this builder
+         */
+        public ProfilerBuilder step(String stepName, Consumer<TimingBuilder> spec) {
+            rootBuilder.step(stepName, spec);
+            return this;
+        }
+
+        /**
+         * Adds a child timing step with no minimum duration and no children or custom timings.
+         *
+         * @param stepName the name of the timing step
+         * @return this builder
+         */
+        public ProfilerBuilder step(String stepName) {
+            rootBuilder.step(stepName);
+            return this;
+        }
+
+        /**
+         * Adds an expected custom timing entry (e.g. a SQL query) with a minimum duration.
+         *
+         * @param type          the custom timing type key (e.g. {@code "sql"})
+         * @param executeType   the execute type (e.g. {@code "reader"})
+         * @param commandString the command string
+         * @param minDurationMs minimum expected duration in milliseconds
+         * @return this builder
+         */
+        public ProfilerBuilder customTiming(String type, String executeType, String commandString, long minDurationMs) {
+            rootBuilder.customTiming(type, executeType, commandString, minDurationMs);
+            return this;
+        }
+
+        /**
+         * Adds an expected custom timing entry with no minimum duration constraint.
+         *
+         * @param type the custom timing type key (e.g. {@code "sql"})
+         * @param executeType the execute type (e.g. {@code "reader"})
+         * @param commandString the command string
+         * @return this builder
+         */
+        public ProfilerBuilder customTiming(String type, String executeType, String commandString) {
+            rootBuilder.customTiming(type, executeType, commandString);
+            return this;
+        }
+
+        /**
+         * Adds a custom link to the expected profiler.
+         *
+         * @param text the display text for the link
+         * @param url  the URL the link points to
+         * @return this builder
+         */
+        public ProfilerBuilder customLink(String text, String url) {
+            customLinks.put(text, url);
+            return this;
+        }
+
+        ExpectedProfiler build() {
+            Map<String, String> links = customLinks.isEmpty() ? null : new LinkedHashMap<>(customLinks);
+            return new ExpectedProfiler(rootBuilder.name, rootBuilder.build(), links);
         }
     }
 }

--- a/test/src/test/groovy/io/jdev/miniprofiler/test/ProfilerComparatorSpec.groovy
+++ b/test/src/test/groovy/io/jdev/miniprofiler/test/ProfilerComparatorSpec.groovy
@@ -1,0 +1,113 @@
+/*
+ * Copyright 2026 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.jdev.miniprofiler.test
+
+import io.jdev.miniprofiler.ProfileLevel
+import io.jdev.miniprofiler.internal.ProfilerImpl
+import spock.lang.Specification
+
+class ProfilerComparatorSpec extends Specification {
+
+    def provider = new TestProfilerProvider()
+
+    void "verify passes when custom links match"() {
+        given:
+        def profiler = new ProfilerImpl("test", ProfileLevel.Info, provider)
+        profiler.addCustomLink('AppStats', 'http://example.com/appstats')
+        profiler.addCustomLink('Tracing', 'http://example.com/tracing')
+        profiler.stop()
+
+        def expected = ProfilerDsl.profiler('test') { p ->
+            p.customLink('AppStats', 'http://example.com/appstats')
+            p.customLink('Tracing', 'http://example.com/tracing')
+        }
+
+        when:
+        ProfilerComparator.verify(profiler, expected)
+
+        then:
+        noExceptionThrown()
+    }
+
+    void "verify passes when both have no custom links"() {
+        given:
+        def profiler = new ProfilerImpl("test", ProfileLevel.Info, provider)
+        profiler.stop()
+
+        def expected = ProfilerDsl.profiler('test')
+
+        when:
+        ProfilerComparator.verify(profiler, expected)
+
+        then:
+        noExceptionThrown()
+    }
+
+    void "verify fails when custom link URL differs"() {
+        given:
+        def profiler = new ProfilerImpl("test", ProfileLevel.Info, provider)
+        profiler.addCustomLink('AppStats', 'http://example.com/wrong')
+        profiler.stop()
+
+        def expected = ProfilerDsl.profiler('test') { p ->
+            p.customLink('AppStats', 'http://example.com/appstats')
+        }
+
+        when:
+        ProfilerComparator.verify(profiler, expected)
+
+        then:
+        def e = thrown(AssertionError)
+        e.message.contains("custom link URL for 'AppStats'")
+    }
+
+    void "verify fails when custom link count differs"() {
+        given:
+        def profiler = new ProfilerImpl("test", ProfileLevel.Info, provider)
+        profiler.addCustomLink('AppStats', 'http://example.com/appstats')
+        profiler.addCustomLink('Tracing', 'http://example.com/tracing')
+        profiler.stop()
+
+        def expected = ProfilerDsl.profiler('test') { p ->
+            p.customLink('AppStats', 'http://example.com/appstats')
+        }
+
+        when:
+        ProfilerComparator.verify(profiler, expected)
+
+        then:
+        def e = thrown(AssertionError)
+        e.message.contains("custom link count")
+    }
+
+    void "verify fails when expected link is missing from actual"() {
+        given:
+        def profiler = new ProfilerImpl("test", ProfileLevel.Info, provider)
+        profiler.stop()
+
+        def expected = ProfilerDsl.profiler('test') { p ->
+            p.customLink('AppStats', 'http://example.com/appstats')
+        }
+
+        when:
+        ProfilerComparator.verify(profiler, expected)
+
+        then:
+        def e = thrown(AssertionError)
+        e.message.contains("custom link count")
+    }
+}

--- a/testlib-browser/src/main/groovy/io/jdev/miniprofiler/browsertest/AbstractMiniProfilerHandlerBrowserSpec.groovy
+++ b/testlib-browser/src/main/groovy/io/jdev/miniprofiler/browsertest/AbstractMiniProfilerHandlerBrowserSpec.groovy
@@ -98,6 +98,19 @@ abstract class AbstractMiniProfilerHandlerBrowserSpec extends GebReportingSpec {
         return p.id
     }
 
+    /**
+     * Injects a profile with a custom link directly into storage. Returns the saved profile's UUID.
+     */
+    protected UUID injectProfileWithCustomLinks(String name = '/test-request') {
+        def p = new ProfilerImpl(name, ProfileLevel.Info, server.profilerProvider)
+        def child = p.step('child step')
+        child.stop()
+        p.stop(true)
+        p.addCustomLink('AppStats', 'http://example.com/appstats')
+        server.addProfile(p)
+        return p.id
+    }
+
     void 'results page renders an injected profile'() {
         given:
         UUID id = injectProfile()
@@ -240,6 +253,23 @@ abstract class AbstractMiniProfilerHandlerBrowserSpec extends GebReportingSpec {
         def rowTexts = resultRows*.text()
         rowTexts.any { it.contains('/request-alpha') }
         rowTexts.any { it.contains('/request-beta') }
+    }
+
+    void 'results page popup shows custom links'() {
+        given:
+        UUID id = injectProfileWithCustomLinks()
+
+        when:
+        go "miniprofiler/results?id=${id}"
+
+        then:
+        at MiniProfilerSingleResultPage
+        waitFor { page.items.size() >= 1 }
+        def popup = page.items[0] as MiniProfilerPopupModule
+        popup.customLinks.size() == 1
+        popup.customLinks[0].text() == 'AppStats'
+        popup.customLinks[0].@href == 'http://example.com/appstats'
+        popup.customLinks[0].@target == '_blank'
     }
 
     @Requires({ instance.server.profiledPagePath })


### PR DESCRIPTION
## Summary

- Add `addCustomLink`/`getCustomLinks` API to `Profiler` interface with `ProfilerImpl` implementation (DCL lazy init, null by default like `clientTimings`/`customTimings`)
- Serialize `CustomLinks` field in `toJson()`/`fromJson()`, matching the .NET wire format the bundled JS UI already renders
- Extend test utilities: `ExpectedProfiler` gains a `customLinks` field, `ProfilerDsl` gains a `ProfilerBuilder` wrapper with `customLink()`, `ProfilerComparator` verifies links
- Add Geb `customLinks` content to `MiniProfilerPopupModule`, verification in `ProfilerUiComparator`, and browser tests confirming links render with correct text, href, and `target="_blank"`