### PR TITLE
Speed up CI builds with local build cache

### DIFF
--- a/.github/workflows/gradle-build.yml
+++ b/.github/workflows/gradle-build.yml
@@ -35,9 +35,13 @@ jobs:
           geckodriver-version: 0.36.0
 
       - name: Build and run fast tests
+        env:
+          CI_BRANCH: ${{ github.head_ref || github.ref_name }}
         run: ./gradlew assemble sanityCheck check --continue
 
       - name: Run slow tests
         uses: GabrielBB/xvfb-action@v1.7
+        env:
+          CI_BRANCH: ${{ github.head_ref || github.ref_name }}
         with:
           run: ./gradlew fullCheck --continue

--- a/.gitignore
+++ b/.gitignore
@@ -13,4 +13,3 @@ bin/
 chromedriver.log
 .shelf/
 out/
-/gradle.properties

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,0 +1,2 @@
+org.gradle.parallel=true
+org.gradle.caching=true

--- a/gradle/plugins/build-parameters/build.gradle.kts
+++ b/gradle/plugins/build-parameters/build.gradle.kts
@@ -27,6 +27,11 @@ buildParameters {
         defaultValue = false
     }
 
+    string("ciBranch") {
+        fromEnvironment()
+        defaultValue = ""
+    }
+
     group("publishing") {
         bool("alwaysSign") {
             defaultValue = false

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -59,6 +59,7 @@ enableFeaturePreview("TYPESAFE_PROJECT_ACCESSORS")
 val buildParameters = the<BuildParametersExtension>()
 buildCache {
     local {
-        isEnabled = !buildParameters.ci
+        isEnabled = true
+        isPush = !buildParameters.ci || buildParameters.ciBranch == "main"
     }
 }


### PR DESCRIPTION
- Track `org.gradle.parallel` and `org.gradle.caching` in `gradle.properties` so CI and contributors get sensible defaults
- Enable the local build cache for all builds, with push enabled on local dev builds and CI main branch builds only (feature branch CI builds read but don't push)