### PR TITLE
Fix flaky tests and reduce build noise

### DIFF
--- a/core/src/test/groovy/io/jdev/miniprofiler/server/MiniProfilerServerSpec.groovy
+++ b/core/src/test/groovy/io/jdev/miniprofiler/server/MiniProfilerServerSpec.groovy
@@ -23,7 +23,10 @@ import io.jdev.miniprofiler.test.TestProfilerProvider
 import spock.lang.AutoCleanup
 import spock.lang.Specification
 
+import java.util.concurrent.TimeUnit
 import java.util.concurrent.atomic.AtomicInteger
+
+import static org.awaitility.Awaitility.await
 
 class MiniProfilerServerSpec extends Specification {
 
@@ -37,6 +40,16 @@ class MiniProfilerServerSpec extends Specification {
     MiniProfilerServer server = new MiniProfilerServer(provider)
 
     void setup() {
+        await().atMost(5, TimeUnit.SECONDS).until {
+            try {
+                def conn = new URL("http://127.0.0.1:${server.port}/miniprofiler/includes.min.js").openConnection() as HttpURLConnection
+                conn.connectTimeout = 1000
+                conn.readTimeout = 1000
+                conn.responseCode > 0
+            } catch (IOException ignored) {
+                false
+            }
+        }
         profiler = provider.start('test').tap {
             stop()
         }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -75,6 +75,7 @@ spock-groovy3 = "2.4-groovy-3.0"
 spock-groovy4 = "2.4-groovy-4.0"
 spring-v5 = "5.3.39"
 spring-v6 = "6.2.8"
+test-retry = "1.6.4"
 testcontainers = "2.0.4"
 weld-se-v3 = "3.1.9.Final"
 weld-se-v5 = "5.1.3.Final"
@@ -153,6 +154,7 @@ spring-v5-test = { module = "org.springframework:spring-test", version.ref = "sp
 spring-v5-web = { module = "org.springframework:spring-web", version.ref = "spring-v5" }
 spring-v6-test = { module = "org.springframework:spring-test", version.ref = "spring-v6" }
 spring-v6-web = { module = "org.springframework:spring-web", version.ref = "spring-v6" }
+test-retry-plugin = { module = "org.gradle:test-retry-gradle-plugin", version.ref = "test-retry" }
 testcontainers-core   = { module = "org.testcontainers:testcontainers",   version.ref = "testcontainers" }
 testcontainers-junit5 = { module = "org.testcontainers:testcontainers-junit-jupiter", version.ref = "testcontainers" }
 weld-se-v3 = { module = "org.jboss.weld.se:weld-se-core", version.ref = "weld-se-v3" }

--- a/gradle/plugins/build.gradle.kts
+++ b/gradle/plugins/build.gradle.kts
@@ -32,4 +32,5 @@ dependencies {
     // another workaround for https://github.com/gradle/gradle/issues/15383
     implementation(libs.develocity.plugin)
     implementation(libs.nexus.publish.plugin)
+    implementation(libs.test.retry.plugin)
 }

--- a/gradle/plugins/src/main/kotlin/CopyrightTask.kt
+++ b/gradle/plugins/src/main/kotlin/CopyrightTask.kt
@@ -275,10 +275,10 @@ abstract class VerifyCopyrightTask : CopyrightTask() {
     }
 
     override fun onFinish(outOfDate: List<String>, upToDate: List<String>, skipped: List<String>) {
-        logger.lifecycle("Checked ${upToDate.size + outOfDate.size} file(s) for copyright year drift.")
+        logger.info("Checked ${upToDate.size + outOfDate.size} file(s) for copyright year drift.")
         if (skipped.isNotEmpty()) {
-            logger.lifecycle("Skipped: ${skipped.size}")
-            skipped.forEach { logger.lifecycle("  $it") }
+            logger.info("Skipped: ${skipped.size}")
+            skipped.forEach { logger.info("  $it") }
         }
         if (outOfDate.isNotEmpty()) {
             logger.error("${outOfDate.size} file(s) have out-of-date copyright years:")

--- a/gradle/plugins/src/main/kotlin/Tests.kt
+++ b/gradle/plugins/src/main/kotlin/Tests.kt
@@ -17,6 +17,7 @@ import org.gradle.api.tasks.compile.JavaCompile
 import org.gradle.jvm.toolchain.JavaLanguageVersion
 import org.gradle.jvm.toolchain.JavaToolchainService
 import org.gradle.kotlin.dsl.DependencyHandlerScope
+import org.gradle.testretry.TestRetryTaskExtension
 import org.gradle.kotlin.dsl.assign
 import org.gradle.kotlin.dsl.invoke
 import org.gradle.kotlin.dsl.register
@@ -34,6 +35,7 @@ fun ConfigurationContainer.extendFromTest(testSuiteName: String) {
 }
 
 fun JvmTestSuite.makeBrowserTest(project: Project, groovyVariant: String = "groovy4"): Unit {
+    project.plugins.apply("org.gradle.test-retry")
 
     val reporting = project.extensions.getByType(ReportingExtension::class.java)
     val catalogs = project.extensions.getByType(VersionCatalogsExtension::class.java)
@@ -50,24 +52,16 @@ fun JvmTestSuite.makeBrowserTest(project: Project, groovyVariant: String = "groo
     }
 
     val buildParameters = project.extensions.getByType(BuildParametersExtension::class.java)
-    val javaToolchains = project.extensions.getByType(JavaToolchainService::class.java)
 
     targets {
         all {
             testTask.configure {
-                // Selenium 4.x requires Java 11+; use project's toolchain version if higher.
-                // Resolved lazily so that toolchain overrides in the consumer script take effect.
-//                javaLauncher.set(project.provider {
-//                    val configuredVersion = project.extensions
-//                        .findByType(JavaPluginExtension::class.java)
-//                        ?.toolchain?.languageVersion?.orNull?.asInt() ?: 8
-//                    javaToolchains.launcherFor {
-//                        languageVersion.set(JavaLanguageVersion.of(maxOf(11, configuredVersion)))
-//                    }.get()
-//                })
                 systemProperty("geb.build.reportsDir", "${reporting.baseDirectory.get().asFile}/geb")
                 buildParameters.browserTest.firefoxBinPath.orNull?.let {
                     systemProperty("webdriver.firefox.bin", it)
+                }
+                extensions.configure(TestRetryTaskExtension::class.java) {
+                    maxRetries = 2
                 }
             }
         }

--- a/gradle/plugins/src/main/kotlin/build.copyright.gradle.kts
+++ b/gradle/plugins/src/main/kotlin/build.copyright.gradle.kts
@@ -80,6 +80,12 @@ val verifyCopyright = tasks.register<VerifyCopyrightTask>("verifyCopyright") {
     }
 }
 
+tasks.register<Delete>("cleanVerifyCopyright") {
+    group = "verification"
+    description = "Removes the verifyCopyright up-to-date marker file."
+    delete(verifyCopyright.flatMap { it.markerFile })
+}
+
 tasks.named("fullCheck") {
     dependsOn(verifyCopyright)
 }

--- a/gradle/plugins/src/main/kotlin/build.java-module.gradle.kts
+++ b/gradle/plugins/src/main/kotlin/build.java-module.gradle.kts
@@ -67,6 +67,24 @@ project.tasks.withType<Test>().configureEach {
     }
 }
 
+// Groovy's Java9 plugin reflectively accesses java.lang.AssertionError, triggering
+// illegal-access warnings on Java 11. Open the package to suppress them. This only
+// applies to Java 11 — Java 8 has no module system, and Java 17+ denies access
+// outright (Groovy handles it differently there). If the project no longer uses a
+// Java 11 toolchain, this block can be removed.
+afterEvaluate {
+    tasks.withType<Test>().configureEach {
+        val launcher = javaLauncher
+        jvmArgumentProviders.add(CommandLineArgumentProvider {
+            if (launcher.get().metadata.languageVersion.asInt() == 11) {
+                listOf("--add-opens", "java.base/java.lang=ALL-UNNAMED")
+            } else {
+                emptyList()
+            }
+        })
+    }
+}
+
 // When both org.codehaus.groovy and org.apache.groovy are on the classpath (e.g. via ratpack-groovy
 // which uses Groovy 2.5), Groovy 4 declares capability equivalence and causes a conflict.
 // Resolve by selecting the highest version (Groovy 4) as the winner.
@@ -99,6 +117,10 @@ tasks.withType<JavaCompile>().configureEach {
 
 tasks.withType<GroovyCompile>().configureEach {
     options.compilerArgs.add("-Werror")
+}
+
+tasks.register("compileAllGroovy") {
+    dependsOn(tasks.withType<GroovyCompile>())
 }
 
 plugins.withId("build.publish") {

--- a/jakarta-servlet/src/integrationTest/groovy/io/jdev/miniprofiler/jakarta/servlet/ServletUserProviderIntegrationSpec.groovy
+++ b/jakarta-servlet/src/integrationTest/groovy/io/jdev/miniprofiler/jakarta/servlet/ServletUserProviderIntegrationSpec.groovy
@@ -34,11 +34,6 @@ class ServletUserProviderIntegrationSpec extends Specification {
         ['Authorization': 'Basic ' + Base64.encoder.encodeToString("${user}:${password}".bytes)]
     }
 
-    Map findInResultsList(String id) {
-        def list = client.getResultsList().bodyAsJson() as List<Map>
-        list.find { it.Id == id }
-    }
-
     void "anonymous request to public page records no user"() {
         when:
         def response = client.get('test-page')
@@ -47,7 +42,7 @@ class ServletUserProviderIntegrationSpec extends Specification {
         response.statusCode() == 200
 
         when:
-        def entry = findInResultsList(response.miniProfilerId())
+        def entry = client.awaitInResultsList(response.miniProfilerId())
 
         then:
         entry != null
@@ -63,7 +58,7 @@ class ServletUserProviderIntegrationSpec extends Specification {
         response.body() == 'hello alice'
 
         when:
-        def entry = findInResultsList(response.miniProfilerId())
+        def entry = client.awaitInResultsList(response.miniProfilerId())
 
         then:
         entry != null

--- a/javax-servlet/src/integrationTest/groovy/io/jdev/miniprofiler/javax/servlet/ServletUserProviderIntegrationSpec.groovy
+++ b/javax-servlet/src/integrationTest/groovy/io/jdev/miniprofiler/javax/servlet/ServletUserProviderIntegrationSpec.groovy
@@ -34,11 +34,6 @@ class ServletUserProviderIntegrationSpec extends Specification {
         ['Authorization': 'Basic ' + Base64.encoder.encodeToString("${user}:${password}".bytes)]
     }
 
-    Map findInResultsList(String id) {
-        def list = client.getResultsList().bodyAsJson() as List<Map>
-        list.find { it.Id == id }
-    }
-
     void "anonymous request to public page records no user"() {
         when:
         def response = client.get('test-page')
@@ -47,7 +42,7 @@ class ServletUserProviderIntegrationSpec extends Specification {
         response.statusCode() == 200
 
         when:
-        def entry = findInResultsList(response.miniProfilerId())
+        def entry = client.awaitInResultsList(response.miniProfilerId())
 
         then:
         entry != null
@@ -63,7 +58,7 @@ class ServletUserProviderIntegrationSpec extends Specification {
         response.body() == 'hello alice'
 
         when:
-        def entry = findInResultsList(response.miniProfilerId())
+        def entry = client.awaitInResultsList(response.miniProfilerId())
 
         then:
         entry != null

--- a/scenario-test/glassfish4/src/scenarioTest/groovy/io/jdev/miniprofiler/glassfish4/funtest/AuthenticatedGlassfish4ScenarioSpec.groovy
+++ b/scenario-test/glassfish4/src/scenarioTest/groovy/io/jdev/miniprofiler/glassfish4/funtest/AuthenticatedGlassfish4ScenarioSpec.groovy
@@ -32,11 +32,6 @@ class AuthenticatedGlassfish4ScenarioSpec extends Specification {
         ['Authorization': 'Basic ' + Base64.encoder.encodeToString("${user}:${password}".bytes)]
     }
 
-    Map findInResultsList(String id) {
-        def list = client.getResultsList().bodyAsJson() as List<Map>
-        list.find { it.Id == id }
-    }
-
     void "anonymous request to public page records no user on the profile"() {
         when:
         def response = client.get('')
@@ -45,7 +40,7 @@ class AuthenticatedGlassfish4ScenarioSpec extends Specification {
         response.statusCode() == 200
 
         when:
-        def entry = findInResultsList(response.miniProfilerId())
+        def entry = client.awaitInResultsList(response.miniProfilerId())
 
         then:
         entry != null
@@ -61,7 +56,7 @@ class AuthenticatedGlassfish4ScenarioSpec extends Specification {
         response.body() == 'hello alice'
 
         when:
-        def entry = findInResultsList(response.miniProfilerId())
+        def entry = client.awaitInResultsList(response.miniProfilerId())
 
         then:
         entry != null

--- a/scenario-test/glassfish4/src/scenarioTest/groovy/io/jdev/miniprofiler/glassfish4/funtest/Glassfish4ScenarioSpec.groovy
+++ b/scenario-test/glassfish4/src/scenarioTest/groovy/io/jdev/miniprofiler/glassfish4/funtest/Glassfish4ScenarioSpec.groovy
@@ -37,7 +37,7 @@ class Glassfish4ScenarioSpec extends Specification {
         response.miniProfilerIds().size() == 1
 
         when: 'fetch the profiler result as JSON'
-        def resultResponse = client.getResultsJson(response.miniProfilerId())
+        def resultResponse = client.awaitResultsJson(response.miniProfilerId())
         def profiler = resultResponse.bodyAsJson()
 
         then: 'profiler has expected timing structure'

--- a/scenario-test/glassfish7/src/scenarioTest/groovy/io/jdev/miniprofiler/glassfish7/funtest/AuthenticatedGlassfish7ScenarioSpec.groovy
+++ b/scenario-test/glassfish7/src/scenarioTest/groovy/io/jdev/miniprofiler/glassfish7/funtest/AuthenticatedGlassfish7ScenarioSpec.groovy
@@ -32,11 +32,6 @@ class AuthenticatedGlassfish7ScenarioSpec extends Specification {
         ['Authorization': 'Basic ' + Base64.encoder.encodeToString("${user}:${password}".bytes)]
     }
 
-    Map findInResultsList(String id) {
-        def list = client.getResultsList().bodyAsJson() as List<Map>
-        list.find { it.Id == id }
-    }
-
     void "anonymous request to public page records no user on the profile"() {
         when:
         def response = client.get('')
@@ -45,7 +40,7 @@ class AuthenticatedGlassfish7ScenarioSpec extends Specification {
         response.statusCode() == 200
 
         when:
-        def entry = findInResultsList(response.miniProfilerId())
+        def entry = client.awaitInResultsList(response.miniProfilerId())
 
         then:
         entry != null
@@ -61,7 +56,7 @@ class AuthenticatedGlassfish7ScenarioSpec extends Specification {
         response.body() == 'hello alice'
 
         when:
-        def entry = findInResultsList(response.miniProfilerId())
+        def entry = client.awaitInResultsList(response.miniProfilerId())
 
         then:
         entry != null

--- a/scenario-test/glassfish7/src/scenarioTest/groovy/io/jdev/miniprofiler/glassfish7/funtest/Glassfish7ScenarioSpec.groovy
+++ b/scenario-test/glassfish7/src/scenarioTest/groovy/io/jdev/miniprofiler/glassfish7/funtest/Glassfish7ScenarioSpec.groovy
@@ -37,7 +37,7 @@ class Glassfish7ScenarioSpec extends Specification {
         response.miniProfilerIds().size() == 1
 
         when: 'fetch the profiler result as JSON'
-        def resultResponse = client.getResultsJson(response.miniProfilerId())
+        def resultResponse = client.awaitResultsJson(response.miniProfilerId())
         def profiler = resultResponse.bodyAsJson()
 
         then: 'profiler has expected timing structure'

--- a/scenario-test/jetty12-servlet/src/scenarioTest/groovy/io/jdev/miniprofiler/jakarta/servlet/funtest/AuthenticatedServletScenarioSpec.groovy
+++ b/scenario-test/jetty12-servlet/src/scenarioTest/groovy/io/jdev/miniprofiler/jakarta/servlet/funtest/AuthenticatedServletScenarioSpec.groovy
@@ -32,11 +32,6 @@ class AuthenticatedServletScenarioSpec extends Specification {
         ['Authorization': 'Basic ' + Base64.encoder.encodeToString("${user}:${password}".bytes)]
     }
 
-    Map findInResultsList(String id) {
-        def list = client.getResultsList().bodyAsJson() as List<Map>
-        list.find { it.Id == id }
-    }
-
     void "anonymous request to public page records no user on the profile"() {
         when:
         def response = client.get('')
@@ -45,7 +40,7 @@ class AuthenticatedServletScenarioSpec extends Specification {
         response.statusCode() == 200
 
         when:
-        def entry = findInResultsList(response.miniProfilerId())
+        def entry = client.awaitInResultsList(response.miniProfilerId())
 
         then:
         entry != null
@@ -61,7 +56,7 @@ class AuthenticatedServletScenarioSpec extends Specification {
         response.body() == 'hello alice'
 
         when:
-        def entry = findInResultsList(response.miniProfilerId())
+        def entry = client.awaitInResultsList(response.miniProfilerId())
 
         then:
         entry != null

--- a/scenario-test/jetty12-servlet/src/scenarioTest/groovy/io/jdev/miniprofiler/jakarta/servlet/funtest/JakartaServletScenarioSpec.groovy
+++ b/scenario-test/jetty12-servlet/src/scenarioTest/groovy/io/jdev/miniprofiler/jakarta/servlet/funtest/JakartaServletScenarioSpec.groovy
@@ -37,7 +37,7 @@ class JakartaServletScenarioSpec extends Specification {
         response.miniProfilerIds().size() == 1
 
         when: 'fetch the profiler result as JSON'
-        def resultResponse = client.getResultsJson(response.miniProfilerId())
+        def resultResponse = client.awaitResultsJson(response.miniProfilerId())
         def profiler = resultResponse.bodyAsJson()
 
         then: 'profiler has expected timing structure'
@@ -83,7 +83,7 @@ class JakartaServletScenarioSpec extends Specification {
         def homeResponse = client.get('')
 
         when: 'fetch the single result page as HTML'
-        def response = client.getResultsHtml(homeResponse.miniProfilerId())
+        def response = client.awaitResultsHtml(homeResponse.miniProfilerId())
 
         then:
         response.statusCode() == 200

--- a/scenario-test/jetty9-servlet/src/scenarioTest/groovy/io/jdev/miniprofiler/javax/servlet/funtest/AuthenticatedServletScenarioSpec.groovy
+++ b/scenario-test/jetty9-servlet/src/scenarioTest/groovy/io/jdev/miniprofiler/javax/servlet/funtest/AuthenticatedServletScenarioSpec.groovy
@@ -32,11 +32,6 @@ class AuthenticatedServletScenarioSpec extends Specification {
         ['Authorization': 'Basic ' + Base64.encoder.encodeToString("${user}:${password}".bytes)]
     }
 
-    Map findInResultsList(String id) {
-        def list = client.getResultsList().bodyAsJson() as List<Map>
-        list.find { it.Id == id }
-    }
-
     void "anonymous request to public page records no user on the profile"() {
         when:
         def response = client.get('')
@@ -45,7 +40,7 @@ class AuthenticatedServletScenarioSpec extends Specification {
         response.statusCode() == 200
 
         when:
-        def entry = findInResultsList(response.miniProfilerId())
+        def entry = client.awaitInResultsList(response.miniProfilerId())
 
         then:
         entry != null
@@ -61,7 +56,7 @@ class AuthenticatedServletScenarioSpec extends Specification {
         response.body() == 'hello alice'
 
         when:
-        def entry = findInResultsList(response.miniProfilerId())
+        def entry = client.awaitInResultsList(response.miniProfilerId())
 
         then:
         entry != null

--- a/scenario-test/jetty9-servlet/src/scenarioTest/groovy/io/jdev/miniprofiler/javax/servlet/funtest/ServletScenarioSpec.groovy
+++ b/scenario-test/jetty9-servlet/src/scenarioTest/groovy/io/jdev/miniprofiler/javax/servlet/funtest/ServletScenarioSpec.groovy
@@ -37,7 +37,7 @@ class ServletScenarioSpec extends Specification {
         response.miniProfilerIds().size() == 1
 
         when: 'fetch the profiler result as JSON'
-        def resultResponse = client.getResultsJson(response.miniProfilerId())
+        def resultResponse = client.awaitResultsJson(response.miniProfilerId())
         def profiler = resultResponse.bodyAsJson()
 
         then: 'profiler has expected timing structure'
@@ -83,7 +83,7 @@ class ServletScenarioSpec extends Specification {
         def homeResponse = client.get('')
 
         when: 'fetch the single result page as HTML'
-        def response = client.getResultsHtml(homeResponse.miniProfilerId())
+        def response = client.awaitResultsHtml(homeResponse.miniProfilerId())
 
         then:
         response.statusCode() == 200

--- a/scenario-test/ratpack1/src/scenarioTest/groovy/io/jdev/miniprofiler/ratpack/funtest/RatpackScenarioSpec.groovy
+++ b/scenario-test/ratpack1/src/scenarioTest/groovy/io/jdev/miniprofiler/ratpack/funtest/RatpackScenarioSpec.groovy
@@ -46,7 +46,7 @@ class RatpackScenarioSpec extends Specification {
         response.miniProfilerIds().size() == 1
 
         when: 'fetch the profiler result as JSON'
-        def resultResponse = client.getResultsJson(response.miniProfilerId())
+        def resultResponse = client.awaitResultsJson(response.miniProfilerId())
         def profiler = resultResponse.bodyAsJson()
 
         then: 'profiler has expected timing structure'
@@ -105,7 +105,7 @@ class RatpackScenarioSpec extends Specification {
         def pageResponse = client.get('page')
 
         when: 'fetch the single result page as HTML'
-        def response = client.getResultsHtml(pageResponse.miniProfilerId())
+        def response = client.awaitResultsHtml(pageResponse.miniProfilerId())
 
         then:
         response.statusCode() == 200

--- a/scenario-test/wildfly10/src/scenarioTest/groovy/io/jdev/miniprofiler/wildfly10/funtest/AuthenticatedWildfly10ScenarioSpec.groovy
+++ b/scenario-test/wildfly10/src/scenarioTest/groovy/io/jdev/miniprofiler/wildfly10/funtest/AuthenticatedWildfly10ScenarioSpec.groovy
@@ -32,11 +32,6 @@ class AuthenticatedWildfly10ScenarioSpec extends Specification {
         ['Authorization': 'Basic ' + Base64.encoder.encodeToString("${user}:${password}".bytes)]
     }
 
-    Map findInResultsList(String id) {
-        def list = client.getResultsList().bodyAsJson() as List<Map>
-        list.find { it.Id == id }
-    }
-
     void "anonymous request to public page records no user on the profile"() {
         when:
         def response = client.get('')
@@ -45,7 +40,7 @@ class AuthenticatedWildfly10ScenarioSpec extends Specification {
         response.statusCode() == 200
 
         when:
-        def entry = findInResultsList(response.miniProfilerId())
+        def entry = client.awaitInResultsList(response.miniProfilerId())
 
         then:
         entry != null
@@ -61,7 +56,7 @@ class AuthenticatedWildfly10ScenarioSpec extends Specification {
         response.body() == 'hello alice'
 
         when:
-        def entry = findInResultsList(response.miniProfilerId())
+        def entry = client.awaitInResultsList(response.miniProfilerId())
 
         then:
         entry != null

--- a/scenario-test/wildfly10/src/scenarioTest/groovy/io/jdev/miniprofiler/wildfly10/funtest/Wildfly10ScenarioSpec.groovy
+++ b/scenario-test/wildfly10/src/scenarioTest/groovy/io/jdev/miniprofiler/wildfly10/funtest/Wildfly10ScenarioSpec.groovy
@@ -37,7 +37,7 @@ class Wildfly10ScenarioSpec extends Specification {
         response.miniProfilerIds().size() == 1
 
         when: 'fetch the profiler result as JSON'
-        def resultResponse = client.getResultsJson(response.miniProfilerId())
+        def resultResponse = client.awaitResultsJson(response.miniProfilerId())
         def profiler = resultResponse.bodyAsJson()
 
         then: 'profiler has expected timing structure'

--- a/scenario-test/wildfly27/src/scenarioTest/groovy/io/jdev/miniprofiler/wildfly27/funtest/AuthenticatedWildfly27ScenarioSpec.groovy
+++ b/scenario-test/wildfly27/src/scenarioTest/groovy/io/jdev/miniprofiler/wildfly27/funtest/AuthenticatedWildfly27ScenarioSpec.groovy
@@ -32,11 +32,6 @@ class AuthenticatedWildfly27ScenarioSpec extends Specification {
         ['Authorization': 'Basic ' + Base64.encoder.encodeToString("${user}:${password}".bytes)]
     }
 
-    Map findInResultsList(String id) {
-        def list = client.getResultsList().bodyAsJson() as List<Map>
-        list.find { it.Id == id }
-    }
-
     void "anonymous request to public page records no user on the profile"() {
         when:
         def response = client.get('')
@@ -45,7 +40,7 @@ class AuthenticatedWildfly27ScenarioSpec extends Specification {
         response.statusCode() == 200
 
         when:
-        def entry = findInResultsList(response.miniProfilerId())
+        def entry = client.awaitInResultsList(response.miniProfilerId())
 
         then:
         entry != null
@@ -61,7 +56,7 @@ class AuthenticatedWildfly27ScenarioSpec extends Specification {
         response.body() == 'hello alice'
 
         when:
-        def entry = findInResultsList(response.miniProfilerId())
+        def entry = client.awaitInResultsList(response.miniProfilerId())
 
         then:
         entry != null

--- a/scenario-test/wildfly27/src/scenarioTest/groovy/io/jdev/miniprofiler/wildfly27/funtest/Wildfly27ScenarioSpec.groovy
+++ b/scenario-test/wildfly27/src/scenarioTest/groovy/io/jdev/miniprofiler/wildfly27/funtest/Wildfly27ScenarioSpec.groovy
@@ -37,7 +37,7 @@ class Wildfly27ScenarioSpec extends Specification {
         response.miniProfilerIds().size() == 1
 
         when: 'fetch the profiler result as JSON'
-        def resultResponse = client.getResultsJson(response.miniProfilerId())
+        def resultResponse = client.awaitResultsJson(response.miniProfilerId())
         def profiler = resultResponse.bodyAsJson()
 
         then: 'profiler has expected timing structure'

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -54,8 +54,6 @@ fun setBuildFile(project: ProjectDescriptor) {
 
 setBuildFile(rootProject)
 
-enableFeaturePreview("TYPESAFE_PROJECT_ACCESSORS")
-
 dependencyResolutionManagement {
     versionCatalogs {
         create("images") {

--- a/storage-jdbc/src/containerTest/groovy/io/jdev/miniprofiler/storage/jdbc/MssqlStorageIntegrationSpec.groovy
+++ b/storage-jdbc/src/containerTest/groovy/io/jdev/miniprofiler/storage/jdbc/MssqlStorageIntegrationSpec.groovy
@@ -38,7 +38,7 @@ class MssqlStorageIntegrationSpec extends BaseJdbcStorageIntegrationSpec {
             .withExposedPorts(PORT)
             .withEnv("ACCEPT_EULA", "Y")
             .withEnv("MSSQL_SA_PASSWORD", "MiniProfiler1!")
-            .waitingFor(Wait.forLogMessage(".*SQL Server is now ready for client connections.*\\n", 1))
+            .waitingFor(Wait.forLogMessage(".*Recovery is complete\\..*\\n", 1))
         container.start()
 
         def config = new HikariConfig()

--- a/storage-jdbc/src/containerTest/groovy/io/jdev/miniprofiler/storage/jdbc/OracleStorageIntegrationSpec.groovy
+++ b/storage-jdbc/src/containerTest/groovy/io/jdev/miniprofiler/storage/jdbc/OracleStorageIntegrationSpec.groovy
@@ -23,6 +23,8 @@ import org.testcontainers.containers.GenericContainer
 import org.testcontainers.containers.wait.strategy.Wait
 import spock.lang.Shared
 
+import java.time.Duration
+
 class OracleStorageIntegrationSpec extends BaseJdbcStorageIntegrationSpec {
 
     static final int PORT = 1521
@@ -37,7 +39,8 @@ class OracleStorageIntegrationSpec extends BaseJdbcStorageIntegrationSpec {
         container = new GenericContainer<>(System.getProperty("dockerImage.oracle-free"))
             .withExposedPorts(PORT)
             .withEnv("ORACLE_PASSWORD", "test")
-            .waitingFor(Wait.forLogMessage(".*DATABASE IS READY TO USE!.*\\n", 1))
+            .waitingFor(Wait.forLogMessage(".*DATABASE IS READY TO USE!.*\\n", 1)
+                .withStartupTimeout(Duration.ofMinutes(5)))
         container.start()
 
         def config = new HikariConfig()

--- a/testlib-integration/src/main/groovy/io/jdev/miniprofiler/integtest/AbstractProfilingHandlerIntegrationSpec.groovy
+++ b/testlib-integration/src/main/groovy/io/jdev/miniprofiler/integtest/AbstractProfilingHandlerIntegrationSpec.groovy
@@ -66,7 +66,7 @@ abstract class AbstractProfilingHandlerIntegrationSpec extends Specification {
     void 'profiled request JSON results contain correct timing structure'() {
         when:
         def pageResponse = client.get(server.profiledPagePath)
-        def resultResponse = client.getResultsJson(pageResponse.miniProfilerId())
+        def resultResponse = client.awaitResultsJson(pageResponse.miniProfilerId())
         def profiler = resultResponse.bodyAsJson()
 
         then:
@@ -252,7 +252,7 @@ abstract class AbstractProfilingHandlerIntegrationSpec extends Specification {
         response.miniProfilerIds().size() == 1
 
         when:
-        def resultResponse = client.getResultsJson(response.miniProfilerId())
+        def resultResponse = client.awaitResultsJson(response.miniProfilerId())
         def profiler = resultResponse.bodyAsJson()
 
         then:

--- a/testlib-integration/src/main/java/io/jdev/miniprofiler/integtest/TestMiniProfilerHttpClient.java
+++ b/testlib-integration/src/main/java/io/jdev/miniprofiler/integtest/TestMiniProfilerHttpClient.java
@@ -104,6 +104,18 @@ public class TestMiniProfilerHttpClient {
     }
 
     /**
+     * Polls the results JSON endpoint until the profiler with the given ID is available.
+     *
+     * @param id the profiler result ID
+     * @return the response with status 200, or the last 404 response if the timeout expires
+     * @throws IOException on network error
+     * @see #awaitInResultsList(String)
+     */
+    public TestHttpResponse awaitResultsJson(String id) throws IOException {
+        return awaitResults(() -> getResultsJson(id));
+    }
+
+    /**
      * Fetches a MiniProfiler result as HTML: {@code GET <profilerPath>/results?id=<id>}.
      *
      * @param id the profiler result ID
@@ -115,6 +127,18 @@ public class TestMiniProfilerHttpClient {
     }
 
     /**
+     * Polls the results HTML endpoint until the profiler with the given ID is available.
+     *
+     * @param id the profiler result ID
+     * @return the response with status 200, or the last 404 response if the timeout expires
+     * @throws IOException on network error
+     * @see #awaitInResultsList(String)
+     */
+    public TestHttpResponse awaitResultsHtml(String id) throws IOException {
+        return awaitResults(() -> getResultsHtml(id));
+    }
+
+    /**
      * Fetches the full results list: {@code GET <profilerPath>/results-list}.
      *
      * @return the response
@@ -122,6 +146,38 @@ public class TestMiniProfilerHttpClient {
      */
     public TestHttpResponse getResultsList() throws IOException {
         return get(profilerPath + "/results-list");
+    }
+
+    /**
+     * Polls the results list until an entry with the given ID appears, or the timeout expires.
+     *
+     * <p>The profiler is saved to storage after the HTTP response is sent, so there is a brief
+     * window where the client has received the profiler ID header but the profile is not yet
+     * in the results list. This method handles that race by polling.</p>
+     *
+     * @param id the profiler ID to wait for
+     * @return the matching entry as a {@code Map}, or {@code null} if not found within the timeout
+     * @throws IOException on network error
+     */
+    @SuppressWarnings("unchecked")
+    public Map<String, Object> awaitInResultsList(String id) throws IOException {
+        long deadline = System.currentTimeMillis() + 5_000;
+        while (System.currentTimeMillis() < deadline) {
+            java.util.List<Map<String, Object>> list =
+                (java.util.List<Map<String, Object>>) getResultsList().bodyAsJson();
+            for (Map<String, Object> entry : list) {
+                if (id.equals(entry.get("Id"))) {
+                    return entry;
+                }
+            }
+            try {
+                Thread.sleep(100);
+            } catch (InterruptedException e) {
+                Thread.currentThread().interrupt();
+                return null;
+            }
+        }
+        return null;
     }
 
     /**
@@ -200,5 +256,25 @@ public class TestMiniProfilerHttpClient {
             result.write(buffer, 0, length);
         }
         return result.toString(StandardCharsets.UTF_8.name());
+    }
+
+    private TestHttpResponse awaitResults(IOSupplier<TestHttpResponse> fetcher) throws IOException {
+        long deadline = System.currentTimeMillis() + 5_000;
+        TestHttpResponse last = fetcher.get();
+        while (last.statusCode() == 404 && System.currentTimeMillis() < deadline) {
+            try {
+                Thread.sleep(100);
+            } catch (InterruptedException e) {
+                Thread.currentThread().interrupt();
+                return last;
+            }
+            last = fetcher.get();
+        }
+        return last;
+    }
+
+    @FunctionalInterface
+    private interface IOSupplier<T> {
+        T get() throws IOException;
     }
 }


### PR DESCRIPTION
- Fix flaky MSSQL container test by waiting for "Recovery is complete" instead of "SQL Server is now ready for client connections", which fires before SA password setup finishes
- Fix flaky Oracle container test by increasing startup timeout to 5 minutes
- Fix flaky MiniProfilerServerSpec by polling for server readiness before connecting
- Add test-retry plugin (maxRetries=2) for browser tests
- Suppress Groovy illegal reflective access warnings on Java 11 test tasks
- Reduce verifyCopyright logging noise and add cleanVerifyCopyright task
- Remove obsolete TYPESAFE_PROJECT_ACCESSORS feature preview