### PR TITLE
Verify published modules match release workflow and tidy verification lifecycle

### DIFF
--- a/.github/workflows/gradle-build.yml
+++ b/.github/workflows/gradle-build.yml
@@ -37,7 +37,7 @@ jobs:
       - name: Build and run fast tests
         env:
           CI_BRANCH: ${{ github.head_ref || github.ref_name }}
-        run: ./gradlew assemble sanityCheck check --continue
+        run: ./gradlew assemble check --continue
 
       - name: Run slow tests
         uses: GabrielBB/xvfb-action@v1.7

--- a/.github/workflows/gradle-release.yml
+++ b/.github/workflows/gradle-release.yml
@@ -57,7 +57,7 @@ jobs:
       - name: Run checks
         env:
           CI: true
-        run: ./gradlew sanityCheck check verifyCopyright
+        run: ./gradlew check verifyCopyright
 
       - name: Commit release version
         run: |

--- a/.github/workflows/gradle-release.yml
+++ b/.github/workflows/gradle-release.yml
@@ -57,7 +57,7 @@ jobs:
       - name: Run checks
         env:
           CI: true
-        run: ./gradlew check verifyCopyright
+        run: ./gradlew preRelease
 
       - name: Commit release version
         run: |

--- a/.github/workflows/gradle-validate-release-artifacts.yml
+++ b/.github/workflows/gradle-validate-release-artifacts.yml
@@ -30,9 +30,12 @@ jobs:
             miniprofiler-jakarta-servlet
             miniprofiler-javax-ee
             miniprofiler-javax-servlet
+            miniprofiler-jdbc
             miniprofiler-jooq
             miniprofiler-manual
             miniprofiler-ratpack
+            miniprofiler-storage-jdbc
+            miniprofiler-storage-objectstorage
             miniprofiler-test
             miniprofiler-test-geb-groovy3
             miniprofiler-test-geb-groovy4

--- a/gradle/plugins/src/main/kotlin/CheckPublishedModulesTask.kt
+++ b/gradle/plugins/src/main/kotlin/CheckPublishedModulesTask.kt
@@ -1,0 +1,71 @@
+/*
+ * Copyright 2026 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import org.gradle.api.DefaultTask
+import org.gradle.api.GradleException
+import org.gradle.api.file.RegularFileProperty
+import org.gradle.api.provider.ListProperty
+import org.gradle.api.tasks.Input
+import org.gradle.api.tasks.InputFile
+import org.gradle.api.tasks.OutputFile
+import org.gradle.api.tasks.PathSensitive
+import org.gradle.api.tasks.PathSensitivity
+import org.gradle.api.tasks.TaskAction
+
+abstract class CheckPublishedModulesTask : DefaultTask() {
+
+    @get:InputFile
+    @get:PathSensitive(PathSensitivity.RELATIVE)
+    abstract val workflowFile: RegularFileProperty
+
+    @get:Input
+    abstract val publishedArtifactIds: ListProperty<String>
+
+    @get:OutputFile
+    abstract val resultFile: RegularFileProperty
+
+    @TaskAction
+    fun check() {
+        val workflowContent = workflowFile.asFile.get().readText()
+        val published = publishedArtifactIds.get().toSet()
+        val workflowArtifacts = Regex("""^\s+(\S+)\s*$""", RegexOption.MULTILINE)
+            .findAll(
+                workflowContent.substringAfter("ARTIFACTS=(").substringBefore(")")
+            )
+            .map { it.groupValues[1] }
+            .toSet()
+
+        val notInWorkflow = published - workflowArtifacts
+        val notPublished = workflowArtifacts - published
+
+        val errors = buildList {
+            if (notInWorkflow.isNotEmpty()) {
+                add("Published modules not listed in ${workflowFile.asFile.get().name}: $notInWorkflow")
+            }
+            if (notPublished.isNotEmpty()) {
+                add("Modules listed in ${workflowFile.asFile.get().name} but not published: $notPublished")
+            }
+        }
+        if (errors.isNotEmpty()) {
+            throw GradleException(errors.joinToString("\n"))
+        }
+
+        resultFile.asFile.get().apply {
+            parentFile.mkdirs()
+            writeText("OK\n")
+        }
+    }
+}

--- a/gradle/plugins/src/main/kotlin/build.base.gradle.kts
+++ b/gradle/plugins/src/main/kotlin/build.base.gradle.kts
@@ -14,9 +14,17 @@
  * limitations under the License.
  */
 
-tasks.register("sanityCheck") {
+plugins {
+    id("base")
+}
+
+val sanityCheck = tasks.register("sanityCheck") {
     group = "verification"
     description = "Lifecycle task: compiles all code, runs quality checks and generates documentation"
+}
+
+tasks.named("check") {
+    dependsOn(sanityCheck)
 }
 
 tasks.register("fullCheck") {

--- a/gradle/plugins/src/main/kotlin/build.base.gradle.kts
+++ b/gradle/plugins/src/main/kotlin/build.base.gradle.kts
@@ -27,7 +27,14 @@ tasks.named("check") {
     dependsOn(sanityCheck)
 }
 
-tasks.register("fullCheck") {
+val fullCheck = tasks.register("fullCheck") {
     group = "verification"
     description = "Lifecycle task: runs check and all additional test suites (e.g. browserTest)"
+    dependsOn(tasks.named("check"))
+}
+
+tasks.register("preRelease") {
+    group = "verification"
+    description = "Lifecycle task: runs all checks required before a release"
+    dependsOn(fullCheck)
 }

--- a/gradle/plugins/src/main/kotlin/build.java-module.gradle.kts
+++ b/gradle/plugins/src/main/kotlin/build.java-module.gradle.kts
@@ -148,6 +148,3 @@ afterEvaluate {
     }
 }
 
-tasks.named("fullCheck") {
-    dependsOn(tasks.named("check"))
-}

--- a/gradle/plugins/src/main/kotlin/build.publish.gradle.kts
+++ b/gradle/plugins/src/main/kotlin/build.publish.gradle.kts
@@ -92,6 +92,10 @@ tasks.withType<Jar>().configureEach {
     }
 }
 
+tasks.named("preRelease") {
+    dependsOn(tasks.named("assemble"))
+}
+
 tasks.register("publishSnapshots") {
     if (isSnapshot) {
         dependsOn(tasks.named("publishToSonatype"))

--- a/miniprofiler-jvm.gradle.kts
+++ b/miniprofiler-jvm.gradle.kts
@@ -25,3 +25,20 @@ allprojects {
 
     apply(plugin = "build.copyright")
 }
+
+val checkPublishedModulesMatchWorkflow by tasks.registering(CheckPublishedModulesTask::class) {
+    group = "verification"
+    description = "Verifies published modules and the release artifact validation workflow are in sync"
+    workflowFile = file(".github/workflows/gradle-validate-release-artifacts.yml")
+    publishedArtifactIds = provider {
+        subprojects
+            .filter { it.plugins.hasPlugin("build.publish") }
+            .map { "miniprofiler-${it.name}" }
+            .sorted()
+    }
+    resultFile = layout.buildDirectory.file("${name}/result.txt")
+}
+
+tasks.named("fullCheck") {
+    dependsOn(checkPublishedModulesMatchWorkflow)
+}


### PR DESCRIPTION
- Add a `CheckPublishedModulesTask` that bidirectionally verifies modules applying `build.publish` match the ARTIFACTS list in the release validation workflow. Catches both missing and stale entries. Wired to `fullCheck`.
- Fix the three modules missing from the workflow: `miniprofiler-jdbc`, `miniprofiler-storage-jdbc`, `miniprofiler-storage-objectstorage`.
- Apply the `base` plugin in `build.base` and wire the verification lifecycle:
  `preRelease` → `fullCheck` + `assemble` → `check` → `sanityCheck`.
- Simplify CI workflows to use these lifecycle tasks instead of invoking individual tasks.