### PR TITLE
Make HikariCP optional and exercise JDBC storage in EE scenarios

### DIFF
--- a/core/src/main/java/io/jdev/miniprofiler/internal/ProfilerImpl.java
+++ b/core/src/main/java/io/jdev/miniprofiler/internal/ProfilerImpl.java
@@ -174,6 +174,7 @@ public class ProfilerImpl implements Profiler, Serializable, Jsonable {
         ProfileLevel level = ProfileLevel.Verbose;
 
         ProfilerImpl profiler = new ProfilerImpl(id, name, started, machineName, level);
+        profiler.user = (String) obj.get("User");
         TimingImpl root = TimingImpl.fromJson(profiler, null, (JSONObject) obj.get("Root"));
         profiler.root = root;
 
@@ -320,6 +321,7 @@ public class ProfilerImpl implements Profiler, Serializable, Jsonable {
         map.put("Started", Instant.ofEpochMilli(started).atOffset(ZoneOffset.UTC).toString());
         map.put("DurationMilliseconds", getDurationMilliseconds());
         map.put("MachineName", machineName);
+        map.put("User", user);
         map.put("Root", root);
         if (clientTimings != null) {
             Map<String, Object> ct = new LinkedHashMap<>();

--- a/core/src/test/groovy/io/jdev/miniprofiler/internal/ProfilerImplSpec.groovy
+++ b/core/src/test/groovy/io/jdev/miniprofiler/internal/ProfilerImplSpec.groovy
@@ -175,10 +175,34 @@ class ProfilerImplSpec extends Specification {
             'Started',
             'DurationMilliseconds',
             'MachineName',
+            'User',
             'Root',
             'ClientTimings',
             'CustomLinks'
         ]
+    }
+
+    void "User round-trips through toJson/fromJson"() {
+        given:
+        profiler.setUser('alice')
+        profiler.stop()
+
+        when:
+        def restored = ProfilerImpl.fromJson(profiler.asUiJson())
+
+        then:
+        restored.user == 'alice'
+    }
+
+    void "User is null on fromJson when absent from JSON"() {
+        given:
+        profiler.stop()
+
+        when:
+        def restored = ProfilerImpl.fromJson(profiler.asUiJson())
+
+        then:
+        restored.user == null
     }
 
     void "list json contains expected fields in order"() {

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -35,7 +35,10 @@ google-cloud-storage = "2.67.0"
 groovy-v3 = "3.0.25"
 groovy-v4 = "4.0.31"
 h2 = "1.4.200"
-hikaricp = "4.0.3"
+hikaricp-v4 = "4.0.3"   # Compile target: minimum supported version (Java 8)
+hikaricp-v5 = "5.1.0"   # Java 11
+hikaricp-v6 = "6.3.3"   # Java 11
+hikaricp-v7 = "7.0.2"   # Java 17
 hibernate-v5 = "5.6.15.Final"
 hibernate-v6 = "6.6.15.Final"
 hibernate-v7 = "7.0.10.Final"
@@ -104,7 +107,10 @@ google-cloud-storage  = { module = "com.google.cloud:google-cloud-storage",     
 groovy-v3 = { module = "org.codehaus.groovy:groovy-all", version.ref = "groovy-v3" }
 groovy-v4 = { module = "org.apache.groovy:groovy-all", version.ref = "groovy-v4" }
 h2 = { module = "com.h2database:h2", version.ref = "h2" }
-hikaricp = { module = "com.zaxxer:HikariCP", version.ref = "hikaricp" }
+hikaricp-v4 = { module = "com.zaxxer:HikariCP", version.ref = "hikaricp-v4" }
+hikaricp-v5 = { module = "com.zaxxer:HikariCP", version.ref = "hikaricp-v5" }
+hikaricp-v6 = { module = "com.zaxxer:HikariCP", version.ref = "hikaricp-v6" }
+hikaricp-v7 = { module = "com.zaxxer:HikariCP", version.ref = "hikaricp-v7" }
 hibernate-v5 = { module = "org.hibernate:hibernate-core",     version.ref = "hibernate-v5" }
 hibernate-v6 = { module = "org.hibernate.orm:hibernate-core", version.ref = "hibernate-v6" }
 hibernate-v7 = { module = "org.hibernate.orm:hibernate-core", version.ref = "hibernate-v7" }

--- a/renovate.json
+++ b/renovate.json
@@ -80,10 +80,28 @@
       "allowedVersions": "<6"
     },
     {
-      "description": "HikariCP — pin to 4.x; 5.0+ is compiled for Java 11 and we still target Java 8",
+      "description": "HikariCP v4 — compile target; pinned for Java 8 compatibility",
       "matchPackageNames": ["com.zaxxer:HikariCP"],
       "matchCurrentValue": "/^4\\./",
       "allowedVersions": "<5"
+    },
+    {
+      "description": "HikariCP v5",
+      "matchPackageNames": ["com.zaxxer:HikariCP"],
+      "matchCurrentValue": "/^5\\./",
+      "allowedVersions": "<6"
+    },
+    {
+      "description": "HikariCP v6",
+      "matchPackageNames": ["com.zaxxer:HikariCP"],
+      "matchCurrentValue": "/^6\\./",
+      "allowedVersions": "<7"
+    },
+    {
+      "description": "HikariCP v7",
+      "matchPackageNames": ["com.zaxxer:HikariCP"],
+      "matchCurrentValue": "/^7\\./",
+      "allowedVersions": "<8"
     },
     {
       "description": "Jetty 9",
@@ -102,6 +120,7 @@
       "matchPackageNames": [
         "com.h2database:*",
         "com.puppycrawl.tools:checkstyle",
+        "com.zaxxer:HikariCP",
         "io.ratpack:*",
         "jakarta.*:*",
         "javax:javaee-api",

--- a/scenario-test/glassfish4/glassfish4.gradle.kts
+++ b/scenario-test/glassfish4/glassfish4.gradle.kts
@@ -27,6 +27,9 @@ dependencies {
     implementation(projects.javaxServlet)
     implementation(projects.eclipselink)
 
+    // Exercise the JDBC storage locator via the container's JNDI DataSource.
+    runtimeOnly(projects.storageJdbc)
+
     scenarioTestImplementation(projects.testlibIntegration)
     scenarioTestRuntimeOnly(scenarioTestFixtures(projects.javaxEe))
 }

--- a/scenario-test/glassfish4/src/main/resources/miniprofiler.properties
+++ b/scenario-test/glassfish4/src/main/resources/miniprofiler.properties
@@ -1,0 +1,22 @@
+#
+# Copyright 2026 the original author or authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+# Point the JDBC storage locator at the JNDI DataSource that the test
+# container creates via asadmin before the WAR is deployed. This makes the
+# scenario test implicitly exercise the full JDBC storage path.
+storage.jdbc.jndiName=jdbc/DataSource
+storage.jdbc.dialect=h2
+storage.jdbc.table.create=true

--- a/scenario-test/glassfish7/glassfish7.gradle.kts
+++ b/scenario-test/glassfish7/glassfish7.gradle.kts
@@ -32,6 +32,9 @@ dependencies {
     implementation(projects.jakartaServlet)
     implementation(projects.eclipselink)
 
+    // Exercise the JDBC storage locator via the container's JNDI DataSource.
+    runtimeOnly(projects.storageJdbc)
+
     scenarioTestImplementation(projects.testlibIntegration)
     scenarioTestRuntimeOnly(scenarioTestFixtures(projects.jakartaEe))
 }

--- a/scenario-test/glassfish7/src/main/resources/miniprofiler.properties
+++ b/scenario-test/glassfish7/src/main/resources/miniprofiler.properties
@@ -1,0 +1,22 @@
+#
+# Copyright 2026 the original author or authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+# Point the JDBC storage locator at the JNDI DataSource that the test
+# container creates via asadmin before the WAR is deployed. This makes the
+# scenario test implicitly exercise the full JDBC storage path.
+storage.jdbc.jndiName=jdbc/DataSource
+storage.jdbc.dialect=h2
+storage.jdbc.table.create=true

--- a/scenario-test/wildfly10/src/main/resources/miniprofiler.properties
+++ b/scenario-test/wildfly10/src/main/resources/miniprofiler.properties
@@ -1,0 +1,21 @@
+#
+# Copyright 2026 the original author or authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+# Point the JDBC storage locator at WildFly's built-in ExampleDS. This makes
+# the scenario test implicitly exercise the full JDBC storage path.
+storage.jdbc.jndiName=java:jboss/datasources/ExampleDS
+storage.jdbc.dialect=h2
+storage.jdbc.table.create=true

--- a/scenario-test/wildfly10/wildfly10.gradle.kts
+++ b/scenario-test/wildfly10/wildfly10.gradle.kts
@@ -26,6 +26,9 @@ dependencies {
     implementation(projects.javaxServlet)
     implementation(projects.hibernate)
 
+    // Exercise the JDBC storage locator via the container's JNDI DataSource.
+    runtimeOnly(projects.storageJdbc)
+
     scenarioTestImplementation(projects.testlibIntegration)
     scenarioTestRuntimeOnly(scenarioTestFixtures(projects.javaxEe))
 }

--- a/scenario-test/wildfly27/src/main/resources/miniprofiler.properties
+++ b/scenario-test/wildfly27/src/main/resources/miniprofiler.properties
@@ -1,0 +1,21 @@
+#
+# Copyright 2026 the original author or authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+# Point the JDBC storage locator at WildFly's built-in ExampleDS. This makes
+# the scenario test implicitly exercise the full JDBC storage path.
+storage.jdbc.jndiName=java:jboss/datasources/ExampleDS
+storage.jdbc.dialect=h2
+storage.jdbc.table.create=true

--- a/scenario-test/wildfly27/wildfly27.gradle.kts
+++ b/scenario-test/wildfly27/wildfly27.gradle.kts
@@ -32,6 +32,9 @@ dependencies {
     implementation(projects.jakartaServlet)
     implementation(projects.hibernate)
 
+    // Exercise the JDBC storage locator via the container's JNDI DataSource.
+    runtimeOnly(projects.storageJdbc)
+
     scenarioTestImplementation(projects.testlibIntegration)
     scenarioTestRuntimeOnly(scenarioTestFixtures(projects.jakartaEe))
 }

--- a/storage-jdbc/src/crossVersionTest/groovy/io/jdev/miniprofiler/storage/jdbc/JdbcStorageLocatorHikariCrossVersionSpec.groovy
+++ b/storage-jdbc/src/crossVersionTest/groovy/io/jdev/miniprofiler/storage/jdbc/JdbcStorageLocatorHikariCrossVersionSpec.groovy
@@ -1,0 +1,78 @@
+/*
+ * Copyright 2026 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.jdev.miniprofiler.storage.jdbc
+
+import spock.lang.Specification
+
+import java.sql.SQLException
+
+/**
+ * Runs against every HikariCP major supported by the locator. Verifies that
+ * {@link JdbcStorageLocator} discovers the URL-configured storage, that the internal
+ * DataSource is a HikariCP pool, and that closing the storage closes the pool.
+ */
+class JdbcStorageLocatorHikariCrossVersionSpec extends Specification {
+
+    def "locator produces a Hikari-backed storage"() {
+        given:
+        def url = "jdbc:h2:mem:xvtest-${UUID.randomUUID()};DB_CLOSE_DELAY=-1"
+        System.setProperty("miniprofiler.storage.jdbc.url", url)
+
+        when:
+        def result = new JdbcStorageLocator().locate()
+
+        then:
+        result.present
+
+        when:
+        def storage = (JdbcStorage) result.get()
+        def dataSource = storage.dataSource
+
+        then:
+        dataSource.getClass().getName() == "com.zaxxer.hikari.HikariDataSource"
+
+        when: "the storage is usable against a live database"
+        storage.createTable()
+        def conn = dataSource.getConnection()
+
+        then:
+        conn != null
+
+        cleanup:
+        conn?.close()
+        storage?.close()
+        System.clearProperty("miniprofiler.storage.jdbc.url")
+    }
+
+    def "closing the storage shuts the pool down"() {
+        given:
+        def url = "jdbc:h2:mem:xvtest-close-${UUID.randomUUID()};DB_CLOSE_DELAY=-1"
+        System.setProperty("miniprofiler.storage.jdbc.url", url)
+        def storage = (JdbcStorage) new JdbcStorageLocator().locate().get()
+        def dataSource = storage.dataSource
+
+        when:
+        storage.close()
+        dataSource.getConnection()
+
+        then:
+        thrown(SQLException)
+
+        cleanup:
+        System.clearProperty("miniprofiler.storage.jdbc.url")
+    }
+}

--- a/storage-jdbc/src/main/java/io/jdev/miniprofiler/storage/jdbc/DriverManagerDataSource.java
+++ b/storage-jdbc/src/main/java/io/jdev/miniprofiler/storage/jdbc/DriverManagerDataSource.java
@@ -1,0 +1,95 @@
+/*
+ * Copyright 2026 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.jdev.miniprofiler.storage.jdbc;
+
+import javax.sql.DataSource;
+import java.io.PrintWriter;
+import java.sql.Connection;
+import java.sql.DriverManager;
+import java.sql.SQLException;
+import java.sql.SQLFeatureNotSupportedException;
+import java.util.logging.Logger;
+
+/**
+ * Minimal unpooled {@link DataSource} adapter over {@link DriverManager}. Used as the
+ * fallback when HikariCP is not on the classpath and {@link JdbcStorageLocator} has a
+ * JDBC URL to work with. Not intended for production use where pooling is desired —
+ * users should supply their own pooled {@link DataSource} in that case.
+ */
+final class DriverManagerDataSource implements DataSource {
+
+    private final String url;
+    private final String username;
+    private final String password;
+
+    DriverManagerDataSource(String url, String username, String password) {
+        this.url = url;
+        this.username = username;
+        this.password = password;
+    }
+
+    @Override
+    public Connection getConnection() throws SQLException {
+        if (username == null && password == null) {
+            return DriverManager.getConnection(url);
+        }
+        return DriverManager.getConnection(url, username, password);
+    }
+
+    @Override
+    public Connection getConnection(String user, String pass) throws SQLException {
+        return DriverManager.getConnection(url, user, pass);
+    }
+
+    @Override
+    public PrintWriter getLogWriter() {
+        return DriverManager.getLogWriter();
+    }
+
+    @Override
+    public void setLogWriter(PrintWriter out) {
+        DriverManager.setLogWriter(out);
+    }
+
+    @Override
+    public void setLoginTimeout(int seconds) {
+        DriverManager.setLoginTimeout(seconds);
+    }
+
+    @Override
+    public int getLoginTimeout() {
+        return DriverManager.getLoginTimeout();
+    }
+
+    @Override
+    public Logger getParentLogger() throws SQLFeatureNotSupportedException {
+        throw new SQLFeatureNotSupportedException();
+    }
+
+    @Override
+    public <T> T unwrap(Class<T> iface) throws SQLException {
+        if (iface.isInstance(this)) {
+            return iface.cast(this);
+        }
+        throw new SQLException("Cannot unwrap to " + iface.getName());
+    }
+
+    @Override
+    public boolean isWrapperFor(Class<?> iface) {
+        return iface.isInstance(this);
+    }
+}

--- a/storage-jdbc/src/main/java/io/jdev/miniprofiler/storage/jdbc/JdbcStorage.java
+++ b/storage-jdbc/src/main/java/io/jdev/miniprofiler/storage/jdbc/JdbcStorage.java
@@ -43,8 +43,10 @@ import java.util.UUID;
  *   <li><strong>DI/programmatic:</strong> pass a {@link DataSource} (and optionally a
  *       {@link DatabaseDialect} and table name). The storage does <em>not</em> own or
  *       close the data source.</li>
- *   <li><strong>Auto-configured via {@link JdbcStorageLocator}:</strong> a HikariCP pool
- *       is created internally. The storage owns and closes the pool.</li>
+ *   <li><strong>Auto-configured via {@link JdbcStorageLocator}:</strong> a
+ *       {@link DataSource} is created internally (HikariCP when available, otherwise an
+ *       unpooled {@link java.sql.DriverManager}-backed adapter). The storage owns and
+ *       closes it.</li>
  * </ul>
  */
 public class JdbcStorage extends BaseStorage {
@@ -258,6 +260,10 @@ public class JdbcStorage extends BaseStorage {
         } catch (SQLException e) {
             throw new RuntimeException("Failed to create table " + tableName, e);
         }
+    }
+
+    DataSource getDataSource() {
+        return dataSource;
     }
 
     private static DatabaseDialect detectDialect(DataSource dataSource) {

--- a/storage-jdbc/src/main/java/io/jdev/miniprofiler/storage/jdbc/JdbcStorageConfig.java
+++ b/storage-jdbc/src/main/java/io/jdev/miniprofiler/storage/jdbc/JdbcStorageConfig.java
@@ -35,6 +35,9 @@ import java.util.Properties;
  *   <li>{@code storage.jdbc.username} — database username</li>
  *   <li>{@code storage.jdbc.password} — database password</li>
  *   <li>{@code storage.jdbc.table} — table name override</li>
+ *   <li>{@code storage.jdbc.table.create} — when {@code true}, the locator calls
+ *       {@link JdbcStorage#createTable()} after constructing the storage; defaults to
+ *       {@code false}</li>
  *   <li>{@code storage.jdbc.dialect} — explicit dialect: h2, postgresql, mysql, mssql, oracle</li>
  * </ul>
  *
@@ -49,24 +52,29 @@ public class JdbcStorageConfig {
     private final String table;
     private final String dialect;
     private final String jndiName;
+    private final boolean tableCreate;
 
     /**
      * Creates a new instance with explicit values.
      *
-     * @param url      the JDBC URL; may be {@code null}
-     * @param username the database username; may be {@code null}
-     * @param password the database password; may be {@code null}
-     * @param table    the table name override; may be {@code null}
-     * @param dialect  the dialect name override; may be {@code null}
-     * @param jndiName the JNDI name of a container-managed DataSource; may be {@code null}
+     * @param url         the JDBC URL; may be {@code null}
+     * @param username    the database username; may be {@code null}
+     * @param password    the database password; may be {@code null}
+     * @param table       the table name override; may be {@code null}
+     * @param dialect     the dialect name override; may be {@code null}
+     * @param jndiName    the JNDI name of a container-managed DataSource; may be {@code null}
+     * @param tableCreate whether the locator should call {@link JdbcStorage#createTable()} after
+     *                    constructing the storage
      */
-    public JdbcStorageConfig(String url, String username, String password, String table, String dialect, String jndiName) {
+    public JdbcStorageConfig(String url, String username, String password, String table, String dialect,
+                             String jndiName, boolean tableCreate) {
         this.url = url;
         this.username = username;
         this.password = password;
         this.table = table;
         this.dialect = dialect;
         this.jndiName = jndiName;
+        this.tableCreate = tableCreate;
     }
 
     /**
@@ -84,13 +92,14 @@ public class JdbcStorageConfig {
     }
 
     static JdbcStorageConfig create(MiniProfilerConfig props) {
-        String url      = props.getProperty("storage.jdbc.url",      (String) null);
-        String username = props.getProperty("storage.jdbc.username", (String) null);
-        String password = props.getProperty("storage.jdbc.password", (String) null);
-        String table    = props.getProperty("storage.jdbc.table",    (String) null);
-        String dialect  = props.getProperty("storage.jdbc.dialect",  (String) null);
-        String jndiName = props.getProperty("storage.jdbc.jndiName", (String) null);
-        return new JdbcStorageConfig(url, username, password, table, dialect, jndiName);
+        String url          = props.getProperty("storage.jdbc.url",          (String) null);
+        String username     = props.getProperty("storage.jdbc.username",     (String) null);
+        String password     = props.getProperty("storage.jdbc.password",     (String) null);
+        String table        = props.getProperty("storage.jdbc.table",        (String) null);
+        String dialect      = props.getProperty("storage.jdbc.dialect",      (String) null);
+        String jndiName     = props.getProperty("storage.jdbc.jndiName",     (String) null);
+        boolean tableCreate = props.getProperty("storage.jdbc.table.create", false);
+        return new JdbcStorageConfig(url, username, password, table, dialect, jndiName, tableCreate);
     }
 
     /**
@@ -155,5 +164,15 @@ public class JdbcStorageConfig {
      */
     public String getJndiName() {
         return jndiName;
+    }
+
+    /**
+     * Returns whether the locator should auto-create the storage table after constructing the
+     * storage. Defaults to {@code false}.
+     *
+     * @return {@code true} if {@code storage.jdbc.table.create} is set to {@code true}
+     */
+    public boolean isTableCreate() {
+        return tableCreate;
     }
 }

--- a/storage-jdbc/src/main/java/io/jdev/miniprofiler/storage/jdbc/JdbcStorageConfig.java
+++ b/storage-jdbc/src/main/java/io/jdev/miniprofiler/storage/jdbc/JdbcStorageConfig.java
@@ -29,12 +29,17 @@ import java.util.Properties;
  *
  * <p>Supported keys:</p>
  * <ul>
+ *   <li>{@code storage.jdbc.jndiName} — JNDI name of a container-managed {@code DataSource};
+ *       takes precedence over the URL path when set</li>
  *   <li>{@code storage.jdbc.url} — JDBC URL; presence triggers auto-configuration</li>
  *   <li>{@code storage.jdbc.username} — database username</li>
  *   <li>{@code storage.jdbc.password} — database password</li>
  *   <li>{@code storage.jdbc.table} — table name override</li>
  *   <li>{@code storage.jdbc.dialect} — explicit dialect: h2, postgresql, mysql, mssql, oracle</li>
  * </ul>
+ *
+ * <p>Either {@code jndiName} or {@code url} must be set for {@link #isConfigured()} to return
+ * {@code true}.</p>
  */
 public class JdbcStorageConfig {
 
@@ -43,6 +48,7 @@ public class JdbcStorageConfig {
     private final String password;
     private final String table;
     private final String dialect;
+    private final String jndiName;
 
     /**
      * Creates a new instance with explicit values.
@@ -52,13 +58,15 @@ public class JdbcStorageConfig {
      * @param password the database password; may be {@code null}
      * @param table    the table name override; may be {@code null}
      * @param dialect  the dialect name override; may be {@code null}
+     * @param jndiName the JNDI name of a container-managed DataSource; may be {@code null}
      */
-    public JdbcStorageConfig(String url, String username, String password, String table, String dialect) {
+    public JdbcStorageConfig(String url, String username, String password, String table, String dialect, String jndiName) {
         this.url = url;
         this.username = username;
         this.password = password;
         this.table = table;
         this.dialect = dialect;
+        this.jndiName = jndiName;
     }
 
     /**
@@ -81,16 +89,18 @@ public class JdbcStorageConfig {
         String password = props.getProperty("storage.jdbc.password", (String) null);
         String table    = props.getProperty("storage.jdbc.table",    (String) null);
         String dialect  = props.getProperty("storage.jdbc.dialect",  (String) null);
-        return new JdbcStorageConfig(url, username, password, table, dialect);
+        String jndiName = props.getProperty("storage.jdbc.jndiName", (String) null);
+        return new JdbcStorageConfig(url, username, password, table, dialect, jndiName);
     }
 
     /**
-     * Returns whether the JDBC URL is set, indicating auto-configuration should proceed.
+     * Returns whether either a JNDI name or JDBC URL is set, indicating auto-configuration
+     * should proceed.
      *
-     * @return {@code true} if the JDBC URL is non-null
+     * @return {@code true} if either {@code jndiName} or {@code url} is non-null
      */
     public boolean isConfigured() {
-        return url != null;
+        return jndiName != null || url != null;
     }
 
     /**
@@ -136,5 +146,14 @@ public class JdbcStorageConfig {
      */
     public String getDialect() {
         return dialect;
+    }
+
+    /**
+     * Returns the JNDI name of the {@code DataSource} to look up, or {@code null} if not set.
+     *
+     * @return the JNDI name
+     */
+    public String getJndiName() {
+        return jndiName;
     }
 }

--- a/storage-jdbc/src/main/java/io/jdev/miniprofiler/storage/jdbc/JdbcStorageLocator.java
+++ b/storage-jdbc/src/main/java/io/jdev/miniprofiler/storage/jdbc/JdbcStorageLocator.java
@@ -22,6 +22,7 @@ import io.jdev.miniprofiler.storage.Storage;
 import io.jdev.miniprofiler.storage.StorageLocator;
 import io.jdev.miniprofiler.storage.jdbc.dialect.DatabaseDialect;
 
+import javax.sql.DataSource;
 import java.util.Optional;
 
 /**
@@ -29,8 +30,16 @@ import java.util.Optional;
  * {@code miniprofiler.storage.jdbc.url} property is not set, making auto-discovery
  * safe in environments without JDBC storage configuration.
  *
- * <p>When configured, creates a HikariCP connection pool that is owned by the
- * resulting {@link JdbcStorage} instance and closed when the storage is closed.</p>
+ * <p>When configured, a {@link DataSource} is obtained as follows:</p>
+ * <ol>
+ *   <li>If HikariCP is on the classpath, a {@link HikariDataSource} is created.</li>
+ *   <li>Otherwise, an unpooled {@link DriverManagerDataSource} is created. Users who
+ *       want pooling should either add HikariCP to their classpath or construct
+ *       {@link JdbcStorage} directly with their own {@link DataSource}.</li>
+ * </ol>
+ *
+ * <p>The resulting {@link DataSource} is owned by the {@link JdbcStorage} instance and
+ * closed when the storage is closed.</p>
  */
 public class JdbcStorageLocator implements StorageLocator {
 
@@ -50,7 +59,59 @@ public class JdbcStorageLocator implements StorageLocator {
             if (!config.isConfigured()) {
                 return Optional.empty();
             }
+            DataSourceResult result = createDataSource(config);
+            if (result == null) {
+                return Optional.empty();
+            }
+            DatabaseDialect dialect = resolveDialect(config, result.dataSource);
+            String tableName = config.getTable() != null
+                ? config.getTable()
+                : JdbcStorage.DEFAULT_TABLE_NAME;
+            return Optional.of(new JdbcStorage(result.dataSource, dialect, tableName, result.ownsDataSource));
+        } catch (Exception | NoClassDefFoundError e) {
+            return Optional.empty();
+        }
+    }
 
+    private static final class DataSourceResult {
+        final DataSource dataSource;
+        final boolean ownsDataSource;
+
+        DataSourceResult(DataSource dataSource, boolean ownsDataSource) {
+            this.dataSource = dataSource;
+            this.ownsDataSource = ownsDataSource;
+        }
+    }
+
+    private static DataSourceResult createDataSource(JdbcStorageConfig config) {
+        if (config.getUrl() != null) {
+            DataSource ds = isHikariAvailable()
+                ? HikariFactory.create(config)
+                : new DriverManagerDataSource(config.getUrl(), config.getUsername(), config.getPassword());
+            return new DataSourceResult(ds, true);
+        }
+        return null;
+    }
+
+    private static boolean isHikariAvailable() {
+        try {
+            Class.forName("com.zaxxer.hikari.HikariDataSource", false,
+                JdbcStorageLocator.class.getClassLoader());
+            return true;
+        } catch (ClassNotFoundException e) {
+            return false;
+        }
+    }
+
+    private static DatabaseDialect resolveDialect(JdbcStorageConfig config, DataSource dataSource) {
+        if (config.getDialect() != null) {
+            return DatabaseDialect.forName(config.getDialect());
+        }
+        return DatabaseDialect.detect(config.getUrl());
+    }
+
+    private static final class HikariFactory {
+        static DataSource create(JdbcStorageConfig config) {
             HikariConfig hikariConfig = new HikariConfig();
             hikariConfig.setJdbcUrl(config.getUrl());
             if (config.getUsername() != null) {
@@ -59,18 +120,7 @@ public class JdbcStorageLocator implements StorageLocator {
             if (config.getPassword() != null) {
                 hikariConfig.setPassword(config.getPassword());
             }
-            HikariDataSource dataSource = new HikariDataSource(hikariConfig);
-
-            DatabaseDialect dialect = config.getDialect() != null
-                ? DatabaseDialect.forName(config.getDialect())
-                : DatabaseDialect.detect(config.getUrl());
-            String tableName = config.getTable() != null
-                ? config.getTable()
-                : JdbcStorage.DEFAULT_TABLE_NAME;
-
-            return Optional.of(new JdbcStorage(dataSource, dialect, tableName, true));
-        } catch (Exception | NoClassDefFoundError e) {
-            return Optional.empty();
+            return new HikariDataSource(hikariConfig);
         }
     }
 }

--- a/storage-jdbc/src/main/java/io/jdev/miniprofiler/storage/jdbc/JdbcStorageLocator.java
+++ b/storage-jdbc/src/main/java/io/jdev/miniprofiler/storage/jdbc/JdbcStorageLocator.java
@@ -22,24 +22,31 @@ import io.jdev.miniprofiler.storage.Storage;
 import io.jdev.miniprofiler.storage.StorageLocator;
 import io.jdev.miniprofiler.storage.jdbc.dialect.DatabaseDialect;
 
+import javax.naming.InitialContext;
+import javax.naming.NamingException;
 import javax.sql.DataSource;
+import java.sql.Connection;
+import java.sql.SQLException;
 import java.util.Optional;
 
 /**
- * {@link StorageLocator} for JDBC storage. Returns an empty {@link Optional} when the
- * {@code miniprofiler.storage.jdbc.url} property is not set, making auto-discovery
- * safe in environments without JDBC storage configuration.
+ * {@link StorageLocator} for JDBC storage. Returns an empty {@link Optional} when neither
+ * {@code miniprofiler.storage.jdbc.jndiName} nor {@code miniprofiler.storage.jdbc.url} is
+ * set, making auto-discovery safe in environments without JDBC storage configuration.
  *
- * <p>When configured, a {@link DataSource} is obtained as follows:</p>
+ * <p>When configured, a {@link DataSource} is obtained in this order:</p>
  * <ol>
- *   <li>If HikariCP is on the classpath, a {@link HikariDataSource} is created.</li>
- *   <li>Otherwise, an unpooled {@link DriverManagerDataSource} is created. Users who
- *       want pooling should either add HikariCP to their classpath or construct
- *       {@link JdbcStorage} directly with their own {@link DataSource}.</li>
+ *   <li>If {@code jndiName} is set and resolves to a {@link DataSource} via JNDI, that
+ *       container-managed source is used and is <em>not</em> owned by the storage.</li>
+ *   <li>Otherwise, if {@code url} is set:
+ *       <ul>
+ *         <li>If HikariCP is on the classpath, a {@link HikariDataSource} is created.</li>
+ *         <li>Otherwise, an unpooled {@link DriverManagerDataSource} is created. Users who
+ *             want pooling should either add HikariCP to their classpath or construct
+ *             {@link JdbcStorage} directly with their own {@link DataSource}.</li>
+ *       </ul>
+ *       These URL-path data sources are owned by the storage and closed when it closes.</li>
  * </ol>
- *
- * <p>The resulting {@link DataSource} is owned by the {@link JdbcStorage} instance and
- * closed when the storage is closed.</p>
  */
 public class JdbcStorageLocator implements StorageLocator {
 
@@ -84,6 +91,13 @@ public class JdbcStorageLocator implements StorageLocator {
     }
 
     private static DataSourceResult createDataSource(JdbcStorageConfig config) {
+        if (config.getJndiName() != null) {
+            DataSource ds = lookupJndi(config.getJndiName());
+            if (ds != null) {
+                return new DataSourceResult(ds, false);
+            }
+            // Fall through to URL path if one is configured.
+        }
         if (config.getUrl() != null) {
             DataSource ds = isHikariAvailable()
                 ? HikariFactory.create(config)
@@ -91,6 +105,15 @@ public class JdbcStorageLocator implements StorageLocator {
             return new DataSourceResult(ds, true);
         }
         return null;
+    }
+
+    private static DataSource lookupJndi(String name) {
+        try {
+            Object obj = new InitialContext().lookup(name);
+            return obj instanceof DataSource ? (DataSource) obj : null;
+        } catch (NamingException e) {
+            return null;
+        }
     }
 
     private static boolean isHikariAvailable() {
@@ -107,7 +130,15 @@ public class JdbcStorageLocator implements StorageLocator {
         if (config.getDialect() != null) {
             return DatabaseDialect.forName(config.getDialect());
         }
-        return DatabaseDialect.detect(config.getUrl());
+        if (config.getUrl() != null) {
+            return DatabaseDialect.detect(config.getUrl());
+        }
+        // JNDI path with no explicit dialect — detect from a live connection.
+        try (Connection c = dataSource.getConnection()) {
+            return DatabaseDialect.detect(c.getMetaData().getURL());
+        } catch (SQLException e) {
+            throw new RuntimeException("Failed to detect dialect from JNDI DataSource", e);
+        }
     }
 
     private static final class HikariFactory {

--- a/storage-jdbc/src/main/java/io/jdev/miniprofiler/storage/jdbc/JdbcStorageLocator.java
+++ b/storage-jdbc/src/main/java/io/jdev/miniprofiler/storage/jdbc/JdbcStorageLocator.java
@@ -47,6 +47,10 @@ import java.util.Optional;
  *       </ul>
  *       These URL-path data sources are owned by the storage and closed when it closes.</li>
  * </ol>
+ *
+ * <p>When {@code miniprofiler.storage.jdbc.table.create} is set to {@code true} the locator
+ * invokes {@link JdbcStorage#createTable()} on the resulting storage, so a fresh database
+ * starts with the {@code mini_profiler_sessions} table ready. The DDL is idempotent.</p>
  */
 public class JdbcStorageLocator implements StorageLocator {
 
@@ -74,7 +78,11 @@ public class JdbcStorageLocator implements StorageLocator {
             String tableName = config.getTable() != null
                 ? config.getTable()
                 : JdbcStorage.DEFAULT_TABLE_NAME;
-            return Optional.of(new JdbcStorage(result.dataSource, dialect, tableName, result.ownsDataSource));
+            JdbcStorage storage = new JdbcStorage(result.dataSource, dialect, tableName, result.ownsDataSource);
+            if (config.isTableCreate()) {
+                storage.createTable();
+            }
+            return Optional.of(storage);
         } catch (Exception | NoClassDefFoundError e) {
             return Optional.empty();
         }

--- a/storage-jdbc/src/test/groovy/io/jdev/miniprofiler/storage/jdbc/JdbcStorageConfigSpec.groovy
+++ b/storage-jdbc/src/test/groovy/io/jdev/miniprofiler/storage/jdbc/JdbcStorageConfigSpec.groovy
@@ -29,6 +29,7 @@ class JdbcStorageConfigSpec extends Specification {
         sysprops["miniprofiler.storage.jdbc.table"]     = "my_table"
         sysprops["miniprofiler.storage.jdbc.dialect"]   = "h2"
         sysprops["miniprofiler.storage.jdbc.jndiName"]  = "java:comp/env/jdbc/profiler"
+        sysprops["miniprofiler.storage.jdbc.table.create"] = "true"
 
         when:
         def config = JdbcStorageConfig.create(sysprops, null)
@@ -41,6 +42,7 @@ class JdbcStorageConfigSpec extends Specification {
             table == "my_table"
             dialect == "h2"
             jndiName == "java:comp/env/jdbc/profiler"
+            tableCreate
             configured
         }
     }
@@ -114,6 +116,15 @@ class JdbcStorageConfigSpec extends Specification {
             table == null
             dialect == null
             jndiName == null
+            !tableCreate
         }
+    }
+
+    def "tableCreate defaults to false"() {
+        when:
+        def config = JdbcStorageConfig.create(new Properties(), null)
+
+        then:
+        !config.tableCreate
     }
 }

--- a/storage-jdbc/src/test/groovy/io/jdev/miniprofiler/storage/jdbc/JdbcStorageConfigSpec.groovy
+++ b/storage-jdbc/src/test/groovy/io/jdev/miniprofiler/storage/jdbc/JdbcStorageConfigSpec.groovy
@@ -28,17 +28,21 @@ class JdbcStorageConfigSpec extends Specification {
         sysprops["miniprofiler.storage.jdbc.password"]  = "secret"
         sysprops["miniprofiler.storage.jdbc.table"]     = "my_table"
         sysprops["miniprofiler.storage.jdbc.dialect"]   = "h2"
+        sysprops["miniprofiler.storage.jdbc.jndiName"]  = "java:comp/env/jdbc/profiler"
 
         when:
         def config = JdbcStorageConfig.create(sysprops, null)
 
         then:
-        config.url == "jdbc:h2:mem:test"
-        config.username == "sa"
-        config.password == "secret"
-        config.table == "my_table"
-        config.dialect == "h2"
-        config.configured
+        verifyAll(config) {
+            url == "jdbc:h2:mem:test"
+            username == "sa"
+            password == "secret"
+            table == "my_table"
+            dialect == "h2"
+            jndiName == "java:comp/env/jdbc/profiler"
+            configured
+        }
     }
 
     def "reads properties from file properties"() {
@@ -70,12 +74,27 @@ class JdbcStorageConfigSpec extends Specification {
         config.url == "jdbc:h2:mem:sys"
     }
 
-    def "returns unconfigured when no url is set"() {
+    def "returns unconfigured when neither url or jndiName is set"() {
         when:
         def config = JdbcStorageConfig.create(new Properties(), null)
 
         then:
         !config.configured
+        config.url == null
+        config.jndiName == null
+    }
+
+    def "is configured when only jndiName is set"() {
+        given:
+        def sysprops = new Properties()
+        sysprops["miniprofiler.storage.jdbc.jndiName"] = "java:comp/env/jdbc/ds"
+
+        when:
+        def config = JdbcStorageConfig.create(sysprops, null)
+
+        then:
+        config.configured
+        config.jndiName == "java:comp/env/jdbc/ds"
         config.url == null
     }
 
@@ -88,10 +107,13 @@ class JdbcStorageConfigSpec extends Specification {
         def config = JdbcStorageConfig.create(sysprops, null)
 
         then:
-        config.url == "jdbc:h2:mem:test"
-        config.username == null
-        config.password == null
-        config.table == null
-        config.dialect == null
+        verifyAll(config) {
+            url == "jdbc:h2:mem:test"
+            username == null
+            password == null
+            table == null
+            dialect == null
+            jndiName == null
+        }
     }
 }

--- a/storage-jdbc/src/test/groovy/io/jdev/miniprofiler/storage/jdbc/JdbcStorageLocatorDriverManagerSpec.groovy
+++ b/storage-jdbc/src/test/groovy/io/jdev/miniprofiler/storage/jdbc/JdbcStorageLocatorDriverManagerSpec.groovy
@@ -1,0 +1,96 @@
+/*
+ * Copyright 2026 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.jdev.miniprofiler.storage.jdbc
+
+import spock.lang.Specification
+
+/**
+ * Exercises the Hikari-absent path of {@link JdbcStorageLocator} without physically removing
+ * Hikari from the test classpath. A filtering classloader redefines the storage-jdbc classes
+ * so their {@code Class.forName("com.zaxxer.hikari...")} probes resolve against the filtered
+ * loader and report Hikari as missing.
+ */
+class JdbcStorageLocatorDriverManagerSpec extends Specification {
+
+    static class HikariHidingClassLoader extends ClassLoader {
+        HikariHidingClassLoader(ClassLoader parent) {
+            super(parent)
+        }
+
+        @Override
+        protected Class<?> loadClass(String name, boolean resolve) throws ClassNotFoundException {
+            if (name.startsWith('com.zaxxer.hikari.')) {
+                throw new ClassNotFoundException(name)
+            }
+            // Re-define storage-jdbc classes in THIS classloader so Class.forName
+            // inside them uses the filtered loader. Delegate everything else.
+            if (name.startsWith('io.jdev.miniprofiler.storage.jdbc.')) {
+                Class<?> c = findLoadedClass(name)
+                if (c == null) {
+                    def resource = getParent().getResource(name.replace('.', '/') + '.class')
+                    if (resource == null) {
+                        throw new ClassNotFoundException(name)
+                    }
+                    byte[] bytes = resource.bytes
+                    c = defineClass(name, bytes, 0, bytes.length)
+                }
+                if (resolve) {
+                    resolveClass(c)
+                }
+                return c
+            }
+            return super.loadClass(name, resolve)
+        }
+    }
+
+    def "locate falls back to DriverManagerDataSource when Hikari is absent"() {
+        given:
+        def url = "jdbc:h2:mem:dmtest-${UUID.randomUUID()};DB_CLOSE_DELAY=-1"
+        System.setProperty("miniprofiler.storage.jdbc.url", url)
+
+        and:
+        def loader = new HikariHidingClassLoader(getClass().getClassLoader())
+        def locatorClass = loader.loadClass("io.jdev.miniprofiler.storage.jdbc.JdbcStorageLocator")
+        def locator = locatorClass.getDeclaredConstructor().newInstance()
+
+        when:
+        def result = locator.locate()
+
+        then:
+        result.present
+
+        when:
+        def storage = result.get()
+        def dataSource = storage.dataSource
+
+        then:
+        // Classes differ across classloaders — compare names as strings.
+        dataSource.getClass().getName() == "io.jdev.miniprofiler.storage.jdbc.DriverManagerDataSource"
+
+        when: "the fallback yields a usable storage"
+        storage.createTable()
+        def conn = dataSource.getConnection()
+
+        then:
+        conn != null
+
+        cleanup:
+        conn?.close()
+        storage?.close()
+        System.clearProperty("miniprofiler.storage.jdbc.url")
+    }
+}

--- a/storage-jdbc/src/test/groovy/io/jdev/miniprofiler/storage/jdbc/JdbcStorageLocatorJndiSpec.groovy
+++ b/storage-jdbc/src/test/groovy/io/jdev/miniprofiler/storage/jdbc/JdbcStorageLocatorJndiSpec.groovy
@@ -53,6 +53,7 @@ class JdbcStorageLocatorJndiSpec extends Specification {
         System.clearProperty("miniprofiler.storage.jdbc.jndiName")
         System.clearProperty("miniprofiler.storage.jdbc.url")
         System.clearProperty("miniprofiler.storage.jdbc.dialect")
+        System.clearProperty("miniprofiler.storage.jdbc.table.create")
     }
 
     def "locate uses a DataSource bound in JNDI and does not own it"() {
@@ -116,6 +117,57 @@ class JdbcStorageLocatorJndiSpec extends Specification {
 
         expect:
         !new JdbcStorageLocator().locate().present
+    }
+
+    def "locate auto-creates the storage table when table.create is true"() {
+        given:
+        def h2 = new JdbcDataSource()
+        h2.URL = "jdbc:h2:mem:tablecreate-${UUID.randomUUID()};DB_CLOSE_DELAY=-1"
+        BINDINGS["java:comp/env/jdbc/profiler"] = h2
+
+        and:
+        System.setProperty("miniprofiler.storage.jdbc.jndiName", "java:comp/env/jdbc/profiler")
+        System.setProperty("miniprofiler.storage.jdbc.dialect", "h2")
+        System.setProperty("miniprofiler.storage.jdbc.table.create", "true")
+
+        when:
+        def result = new JdbcStorageLocator().locate()
+
+        then:
+        result.present
+        tableExists(h2, JdbcStorage.DEFAULT_TABLE_NAME)
+
+        cleanup:
+        ((JdbcStorage) result?.orElse(null))?.close()
+    }
+
+    def "locate does not create the storage table by default"() {
+        given:
+        def h2 = new JdbcDataSource()
+        h2.URL = "jdbc:h2:mem:notablecreate-${UUID.randomUUID()};DB_CLOSE_DELAY=-1"
+        BINDINGS["java:comp/env/jdbc/profiler"] = h2
+
+        and:
+        System.setProperty("miniprofiler.storage.jdbc.jndiName", "java:comp/env/jdbc/profiler")
+        System.setProperty("miniprofiler.storage.jdbc.dialect", "h2")
+
+        when:
+        def result = new JdbcStorageLocator().locate()
+
+        then:
+        result.present
+        !tableExists(h2, JdbcStorage.DEFAULT_TABLE_NAME)
+
+        cleanup:
+        ((JdbcStorage) result?.orElse(null))?.close()
+    }
+
+    private static boolean tableExists(JdbcDataSource ds, String tableName) {
+        ds.connection.withCloseable { conn ->
+            conn.metaData.getTables(null, null, tableName.toUpperCase(), null).withCloseable { rs ->
+                return rs.next()
+            }
+        }
     }
 
     private static class MapBackedContext implements Context {

--- a/storage-jdbc/src/test/groovy/io/jdev/miniprofiler/storage/jdbc/JdbcStorageLocatorJndiSpec.groovy
+++ b/storage-jdbc/src/test/groovy/io/jdev/miniprofiler/storage/jdbc/JdbcStorageLocatorJndiSpec.groovy
@@ -1,0 +1,167 @@
+/*
+ * Copyright 2026 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.jdev.miniprofiler.storage.jdbc
+
+import com.zaxxer.hikari.HikariDataSource
+import org.h2.jdbcx.JdbcDataSource
+import spock.lang.Specification
+
+import javax.naming.Context
+import javax.naming.Name
+import javax.naming.NameNotFoundException
+import javax.naming.spi.InitialContextFactory
+import javax.naming.spi.InitialContextFactoryBuilder
+import javax.naming.spi.NamingManager
+
+import java.util.concurrent.ConcurrentHashMap
+
+class JdbcStorageLocatorJndiSpec extends Specification {
+
+    private static final Map<String, Object> BINDINGS = new ConcurrentHashMap<>()
+
+    static {
+        try {
+            NamingManager.setInitialContextFactoryBuilder({ env ->
+                { e -> new MapBackedContext(BINDINGS) } as InitialContextFactory
+            } as InitialContextFactoryBuilder)
+        } catch (IllegalStateException ignored) {
+            // Another test or runtime already installed a builder — acceptable
+            // since this spec is the only test that uses JNDI in this module.
+        }
+    }
+
+    def setup() {
+        BINDINGS.clear()
+    }
+
+    def cleanup() {
+        BINDINGS.clear()
+        System.clearProperty("miniprofiler.storage.jdbc.jndiName")
+        System.clearProperty("miniprofiler.storage.jdbc.url")
+        System.clearProperty("miniprofiler.storage.jdbc.dialect")
+    }
+
+    def "locate uses a DataSource bound in JNDI and does not own it"() {
+        given:
+        def h2 = new JdbcDataSource()
+        h2.URL = "jdbc:h2:mem:jnditest-${UUID.randomUUID()};DB_CLOSE_DELAY=-1"
+        BINDINGS["java:comp/env/jdbc/profiler"] = h2
+
+        and:
+        System.setProperty("miniprofiler.storage.jdbc.jndiName", "java:comp/env/jdbc/profiler")
+        System.setProperty("miniprofiler.storage.jdbc.dialect", "h2")
+
+        when:
+        def result = new JdbcStorageLocator().locate()
+
+        then:
+        result.present
+        def storage = (JdbcStorage) result.get()
+        storage.dataSource.is(h2)
+
+        when: "the storage is closed it must not close the container-managed DataSource"
+        storage.close()
+        def conn = h2.connection
+
+        then:
+        conn != null
+
+        cleanup:
+        conn?.close()
+    }
+
+    def "locate falls through from a missing JNDI binding to the URL path"() {
+        given:
+        System.setProperty("miniprofiler.storage.jdbc.jndiName", "java:comp/env/jdbc/missing")
+        System.setProperty("miniprofiler.storage.jdbc.url", "jdbc:h2:mem:fallthrough-${UUID.randomUUID()};DB_CLOSE_DELAY=-1")
+
+        when:
+        def result = new JdbcStorageLocator().locate()
+
+        then:
+        result.present
+        def storage = (JdbcStorage) result.get()
+        storage.dataSource instanceof HikariDataSource
+
+        cleanup:
+        storage?.close()
+    }
+
+    def "locate returns empty when JNDI lookup fails and no URL is configured"() {
+        given:
+        System.setProperty("miniprofiler.storage.jdbc.jndiName", "java:comp/env/jdbc/missing")
+
+        expect:
+        !new JdbcStorageLocator().locate().present
+    }
+
+    def "locate returns empty when JNDI binding is not a DataSource and no URL is configured"() {
+        given:
+        BINDINGS["java:comp/env/jdbc/profiler"] = "not a data source"
+        System.setProperty("miniprofiler.storage.jdbc.jndiName", "java:comp/env/jdbc/profiler")
+
+        expect:
+        !new JdbcStorageLocator().locate().present
+    }
+
+    private static class MapBackedContext implements Context {
+
+        private final Map<String, Object> bindings
+
+        MapBackedContext(Map<String, Object> bindings) {
+            this.bindings = bindings
+        }
+
+        @Override
+        Object lookup(String name) throws javax.naming.NamingException {
+            Object value = bindings.get(name)
+            if (value == null) {
+                throw new NameNotFoundException(name)
+            }
+            return value
+        }
+
+        @Override Object lookup(Name name) throws javax.naming.NamingException { lookup(name.toString()) }
+        @Override Hashtable<?, ?> getEnvironment() { new Hashtable<>() }
+        @Override void close() {}
+        @Override void bind(Name name, Object obj) { bindings.put(name.toString(), obj) }
+        @Override void bind(String name, Object obj) { bindings.put(name, obj) }
+        @Override void rebind(Name name, Object obj) { bindings.put(name.toString(), obj) }
+        @Override void rebind(String name, Object obj) { bindings.put(name, obj) }
+        @Override void unbind(Name name) { bindings.remove(name.toString()) }
+        @Override void unbind(String name) { bindings.remove(name) }
+        @Override void rename(Name a, Name b) { throw new UnsupportedOperationException() }
+        @Override void rename(String a, String b) { throw new UnsupportedOperationException() }
+        @Override javax.naming.NamingEnumeration<javax.naming.NameClassPair> list(Name n) { throw new UnsupportedOperationException() }
+        @Override javax.naming.NamingEnumeration<javax.naming.NameClassPair> list(String n) { throw new UnsupportedOperationException() }
+        @Override javax.naming.NamingEnumeration<javax.naming.Binding> listBindings(Name n) { throw new UnsupportedOperationException() }
+        @Override javax.naming.NamingEnumeration<javax.naming.Binding> listBindings(String n) { throw new UnsupportedOperationException() }
+        @Override void destroySubcontext(Name n) { throw new UnsupportedOperationException() }
+        @Override void destroySubcontext(String n) { throw new UnsupportedOperationException() }
+        @Override Context createSubcontext(Name n) { throw new UnsupportedOperationException() }
+        @Override Context createSubcontext(String n) { throw new UnsupportedOperationException() }
+        @Override Object lookupLink(Name n) { lookup(n) }
+        @Override Object lookupLink(String n) { lookup(n) }
+        @Override javax.naming.NameParser getNameParser(Name n) { throw new UnsupportedOperationException() }
+        @Override javax.naming.NameParser getNameParser(String n) { throw new UnsupportedOperationException() }
+        @Override Name composeName(Name n, Name p) { throw new UnsupportedOperationException() }
+        @Override String composeName(String n, String p) { throw new UnsupportedOperationException() }
+        @Override Object addToEnvironment(String k, Object v) { null }
+        @Override Object removeFromEnvironment(String k) { null }
+        @Override String getNameInNamespace() { "" }
+    }
+}

--- a/storage-jdbc/src/test/groovy/io/jdev/miniprofiler/storage/jdbc/JdbcStorageLocatorSpec.groovy
+++ b/storage-jdbc/src/test/groovy/io/jdev/miniprofiler/storage/jdbc/JdbcStorageLocatorSpec.groovy
@@ -16,6 +16,7 @@
 
 package io.jdev.miniprofiler.storage.jdbc
 
+import com.zaxxer.hikari.HikariDataSource
 import spock.lang.Specification
 
 class JdbcStorageLocatorSpec extends Specification {
@@ -40,5 +41,22 @@ class JdbcStorageLocatorSpec extends Specification {
         if (saved != null) {
             System.setProperty("miniprofiler.storage.jdbc.url", saved)
         }
+    }
+
+    def "locate returns a Hikari-backed storage when HikariCP is on the classpath"() {
+        given:
+        System.setProperty("miniprofiler.storage.jdbc.url", "jdbc:h2:mem:locator-hikari;DB_CLOSE_DELAY=-1")
+
+        when:
+        def result = new JdbcStorageLocator().locate()
+
+        then:
+        result.present
+        def storage = (JdbcStorage) result.get()
+        storage.dataSource instanceof HikariDataSource
+
+        cleanup:
+        storage?.close()
+        System.clearProperty("miniprofiler.storage.jdbc.url")
     }
 }

--- a/storage-jdbc/storage-jdbc.gradle.kts
+++ b/storage-jdbc/storage-jdbc.gradle.kts
@@ -24,7 +24,10 @@ plugins {
 dependencies {
     api(projects.core)
 
-    implementation(libs.hikaricp.v4)
+    // HikariCP is optional — users who supply their own DataSource don't need it.
+    // The auto-discovery path in JdbcStorageLocator prefers Hikari when available
+    // and falls back to a DriverManager-backed DataSource when it is not.
+    compileOnly(libs.hikaricp.v4)
 
     // JDBC drivers declared compileOnly — users bring their own versions.
     compileOnly(libs.h2)
@@ -35,6 +38,8 @@ dependencies {
 
     // H2 is used in unit tests for the fast check path.
     testImplementation(libs.h2)
+    // Default test suite exercises the Hikari-preferred happy path.
+    testImplementation(libs.hikaricp.v4)
 
     // testFixtures holds the base integration spec — it needs Spock/Groovy.
     testFixturesImplementation(libs.h2)
@@ -45,6 +50,7 @@ dependencies {
     // compileOnly deps are not inherited by containerTest suite — re-declare them.
     containerTestImplementation(testFixtures(project))
     containerTestImplementation(libs.h2)
+    containerTestImplementation(libs.hikaricp.v4)
     containerTestImplementation(libs.postgresql)
     containerTestImplementation(libs.mysql.connector)
     containerTestImplementation(libs.mssql.jdbc)

--- a/storage-jdbc/storage-jdbc.gradle.kts
+++ b/storage-jdbc/storage-jdbc.gradle.kts
@@ -24,7 +24,7 @@ plugins {
 dependencies {
     api(projects.core)
 
-    implementation(libs.hikaricp)
+    implementation(libs.hikaricp.v4)
 
     // JDBC drivers declared compileOnly — users bring their own versions.
     compileOnly(libs.h2)

--- a/storage-jdbc/storage-jdbc.gradle.kts
+++ b/storage-jdbc/storage-jdbc.gradle.kts
@@ -16,6 +16,7 @@
 
 plugins {
     id("build.java-module")
+    id("build.cross-version-test")
     id("build.container-test")
     id("build.publish")
     `java-test-fixtures`
@@ -63,6 +64,38 @@ tasks.named<Test>("containerTest").configure {
     systemProperty("dockerImage.mssql-server", images.versions.mssql.server.get())
     systemProperty("dockerImage.oracle-free", images.versions.oracle.free.get())
 }
+
+crossVersionTests {
+    configureEach {
+        implementation(libs.bundles.testing.groovy4)
+        runtimeOnly(libs.bundles.testing.runtime)
+        implementation(projects.core)
+        implementation(libs.h2)
+    }
+    register("crossVersionTestHikariV4") {
+        // HikariCP 4.0.3: compile target, minimum supported version (Java 8)
+        minJavaVersion = 8
+        implementation(libs.hikaricp.v4)
+    }
+    register("crossVersionTestHikariV5") {
+        // HikariCP 5.x: Java 11
+        minJavaVersion = 11
+        implementation(libs.hikaricp.v5)
+    }
+    register("crossVersionTestHikariV6") {
+        // HikariCP 6.x: Java 11
+        minJavaVersion = 11
+        implementation(libs.hikaricp.v6)
+    }
+    register("crossVersionTestHikariV7") {
+        // HikariCP 7.x: Java 17
+        minJavaVersion = 17
+        implementation(libs.hikaricp.v7)
+    }
+}
+
+// The v4 suite tests the minimum supported version and runs as part of regular check
+tasks.named("check") { dependsOn("crossVersionTestHikariV4") }
 
 publishing {
     publications.named<MavenPublication>("maven") {


### PR DESCRIPTION
## Summary

- **HikariCP is now optional.** `storage-jdbc` moves its HikariCP dependency
  from `implementation` to `compileOnly`, so users who supply their own
  `DataSource` — or use their own Hikari major internally — no longer inherit
  the coordinate transitively. A new `DriverManagerDataSource` adapter is used
  as the unpooled fallback when HikariCP is absent from the classpath.
- **JNDI discovery tier.** `JdbcStorageLocator` consults
  `miniprofiler.storage.jdbc.jndiName` ahead of the URL path. A bound
  `DataSource` is used container-managed (not closed on storage shutdown); an
  unbound name falls through to the URL path; a non-`DataSource` binding
  yields `Optional.empty()`.
- **`storage.jdbc.table.create` flag.** When `true`, the locator invokes
  `JdbcStorage.createTable()` after constructing the storage so the schema
  is in place on first save. Default is `false` — existing deployments are
  unaffected.
- **Cross-version test matrix.** Four `crossVersionTestHikariV*` suites run
  the locator against Hikari 4/5/6/7, each on its JDK floor (8/11/11/17).
  The v4 suite participates in `check`; v5/v6/v7 join via `crossVersionTest`
  / `fullCheck`, mirroring the existing jOOQ/Hibernate/EclipseLink pattern.
- **EE scenario tests now round-trip through JDBC.** Glassfish 4, Glassfish
  7, WildFly 10, and WildFly 27 WARs gain a runtime `storage-jdbc` dep and
  a `miniprofiler.properties` that points the locator at the JNDI
  `DataSource` each container already provides. Their existing HTTP-level
  assertions now implicitly prove JDBC save/load works end-to-end.
- **Pre-existing bug fix.** `ProfilerImpl.toJson` was omitting the `User`
  field, so `JdbcStorage` lost the authenticated principal on every
  round-trip. Fixed in-place so both `toJson` and `fromJson` handle `User`
  consistently with the list JSON.

## Notable details

- Renovate now has per-major pin rules for HikariCP v4/v5/v6/v7, and HikariCP
  joins the cross-version-blocked list so the v4 compile target stays on
  Java 8.
- The Hikari API used by the locator (`HikariConfig`, `setJdbcUrl`,
  `setUsername`, `setPassword`, `new HikariDataSource`) is stable across all
  four majors, confirmed by the cross-version suite.
- The generated `storage-jdbc` POM no longer lists `com.zaxxer:HikariCP` —
  verified on the `generatePomFileForMavenPublication` output.
- Dialect resolution now supports the JNDI-only case (no URL) by detecting
  from a live connection. Scenario tests set `storage.jdbc.dialect=h2`
  explicitly to skip that path, since the container's bound `DataSource` is
  known to be H2.