### PR TITLE
Propagate ProfilerProvider to child profilers

### DIFF
--- a/core/src/main/java/io/jdev/miniprofiler/internal/ProfilerImpl.java
+++ b/core/src/main/java/io/jdev/miniprofiler/internal/ProfilerImpl.java
@@ -149,8 +149,8 @@ public class ProfilerImpl implements Profiler, Serializable, Jsonable {
     /**
      * Used to add a child profiler.
      */
-    ProfilerImpl(String rootName, ProfileLevel level, long started) {
-        this(null, rootName, started, null, level, null, null, false, null);
+    ProfilerImpl(String rootName, ProfileLevel level, long started, ProfilerProvider profilerProvider) {
+        this(null, rootName, started, null, level, null, null, false, profilerProvider);
         root = new TimingImpl(this, null, rootName);
         head = root;
     }

--- a/core/src/main/java/io/jdev/miniprofiler/internal/TimingImpl.java
+++ b/core/src/main/java/io/jdev/miniprofiler/internal/TimingImpl.java
@@ -262,7 +262,7 @@ public class TimingImpl implements TimingInternal, Serializable, Jsonable {
         if (childProfilers == null) {
             childProfilers = new ArrayList<Profiler>();
         }
-        ProfilerImpl child = new ProfilerImpl("\u2443 " + name, profiler.getLevel(), profiler.getStarted());
+        ProfilerImpl child = new ProfilerImpl("\u2443 " + name, profiler.getLevel(), profiler.getStarted(), profiler.getProfilerProvider());
         childProfilers.add(child);
         return child;
     }

--- a/core/src/test/groovy/io/jdev/miniprofiler/internal/ProfilerImplSpec.groovy
+++ b/core/src/test/groovy/io/jdev/miniprofiler/internal/ProfilerImplSpec.groovy
@@ -230,4 +230,34 @@ class ProfilerImplSpec extends Specification {
         !parsed.has('Root')
     }
 
+    void "child profiler inherits parent's profiler provider"() {
+        when:
+        def child = profiler.addChild('child') as ProfilerImpl
+
+        then:
+        child.profilerProvider == profiler.profilerProvider
+    }
+
+    void "asUiJson on parent succeeds when child profiler has custom timings"() {
+        given:
+        def childProfiler = profiler.addChild('child')
+        def childTiming = childProfiler.step('child step')
+        childTiming.addCustomTiming('sql', 'query', 'select * from foo', 5)
+        childTiming.stop()
+        childProfiler.stop()
+
+        when:
+        def parsed = new ObjectMapper().readTree(profiler.asUiJson())
+
+        then: 'child profiler is rendered as a child of the root timing'
+        def childJson = parsed.path('Root').path('Children').get(0)
+        childJson.path('Name').asText() == '⑃ child'
+
+        and: 'custom timing on the child step is rendered'
+        def childCustom = childJson.path('Children').get(0).path('CustomTimings').path('sql').get(0)
+        childCustom.path('CommandString').asText().contains('select')
+        childCustom.path('CommandString').asText().contains('foo')
+        childCustom.path('ExecuteType').asText() == 'query'
+    }
+
 }


### PR DESCRIPTION
## Summary

Calling `asUiJson()` (or any other code path that ends up invoking `CustomTimingImpl.toJson()`) on a profiler that has child profilers with custom timings throws a `NullPointerException` in 0.12.0.

## Reproduction

```java
ProfilerProvider provider = new TestProfilerProvider();
ProfilerImpl parent = new ProfilerImpl("root", ProfileLevel.Info, provider);
Profiler child = parent.addChild("child");
Timing childStep = child.step("step");
childStep.addCustomTiming("sql", "query", "select * from foo", 5);
childStep.stop();
child.stop();

parent.asUiJson(); // throws NPE
```

Stack trace:

```
java.lang.NullPointerException: Cannot invoke "io.jdev.miniprofiler.ProfilerProvider.getCommandFormatter(String)"
    because the return value of "io.jdev.miniprofiler.internal.ProfilerImpl.getProfilerProvider()" is null
    at io.jdev.miniprofiler.internal.CustomTimingImpl.formatCommandString(CustomTimingImpl.java:104)
    at io.jdev.miniprofiler.internal.CustomTimingImpl.toJson(CustomTimingImpl.java:91)
    ...
    at io.jdev.miniprofiler.internal.ProfilerImpl.asUiJson(ProfilerImpl.java:339)
```

`asPlainText()` is unaffected because it reads the raw command string directly without going through the formatter.

## Root cause

`TimingImpl.addChildProfiler` builds the child `ProfilerImpl` via the package-private three-arg constructor `(String rootName, ProfileLevel level, long started)`, which hardcodes `profilerProvider = null`:

```java
ProfilerImpl child = new ProfilerImpl("⑃ " + name, profiler.getLevel(), profiler.getStarted());
```

In 0.11.x this was harmless: `CustomTimingImpl.toJson()` formatted commands via the static `SqlFormatterFactory.getFormatter()`, so the per-profiler provider was never consulted.

0.12.0 replaced that global lookup with a per-provider one in `CustomTimingImpl.formatCommandString()`:

```java
return parentTiming.getProfiler().getProfilerProvider()
    .getCommandFormatter(type)
    .format(commandString);
```

Custom timings on a child profiler reach this code with `getProfilerProvider() == null` and crash. The `addChildProfiler` call site itself wasn't updated to thread the provider through, so the new SPI contract is silently violated for child profilers.

## Fix

`TimingImpl.addChildProfiler` now passes the parent profiler's provider to the child, and the child constructor accepts it (replacing the previous `null` hardcoding). The provider field is `private final` so this has to happen at construction time — there is no setter.

```diff
-ProfilerImpl(String rootName, ProfileLevel level, long started) {
-    this(null, rootName, started, null, level, null, null, false, null);
+ProfilerImpl(String rootName, ProfileLevel level, long started, ProfilerProvider profilerProvider) {
+    this(null, rootName, started, null, level, null, null, false, profilerProvider);
```

```diff
-ProfilerImpl child = new ProfilerImpl("⑃ " + name, profiler.getLevel(), profiler.getStarted());
+ProfilerImpl child = new ProfilerImpl("⑃ " + name, profiler.getLevel(), profiler.getStarted(), profiler.getProfilerProvider());
```

Both methods are package-private; no public API surface changes.

## Tests

Two new specs in `ProfilerImplSpec`:

1. `child profiler inherits parent's profiler provider` — direct invariant check on `addChild`.
2. `asUiJson on parent succeeds when child profiler has custom timings` — end-to-end repro of the bug scenario, asserts the rendered JSON contains the child profiler and its custom timing.

Both fail without the source change (one with provider mismatch, one with the exact NPE shown above) and pass with it. Full `./gradlew check` is green across the project.

## Test plan

- [x] New specs fail on unfixed code, pass with the fix
- [x] Existing `core` tests pass
- [x] Full `./gradlew check` passes (all modules including ratpack)