### PR TITLE
Publish Build Scans to community.develocity.cloud

### DIFF
--- a/.github/workflows/gradle-build-and-publish-snapshot.yml
+++ b/.github/workflows/gradle-build-and-publish-snapshot.yml
@@ -8,6 +8,7 @@ on:
 jobs:
   call-gradle-build:
     uses: tomdcc/miniprofiler-jvm/.github/workflows/gradle-build.yml@main
+    secrets: inherit
   call-publish-snapshots:
     needs: call-gradle-build
     uses: tomdcc/miniprofiler-jvm/.github/workflows/gradle-publish-snapshots.yml@main

--- a/.github/workflows/gradle-build-pr.yml
+++ b/.github/workflows/gradle-build-pr.yml
@@ -3,3 +3,4 @@ on: [ pull_request ]
 jobs:
   call-gradle-build:
     uses: tomdcc/miniprofiler-jvm/.github/workflows/gradle-build.yml@main
+    secrets: inherit

--- a/.github/workflows/gradle-build.yml
+++ b/.github/workflows/gradle-build.yml
@@ -3,6 +3,10 @@ on: [ workflow_call ]
 jobs:
   build:
     runs-on: ubuntu-latest
+    env:
+      # Authenticates Build Scan publishing to community.develocity.cloud.
+      # Absent on fork PRs, where publishing is skipped rather than failing.
+      DEVELOCITY_ACCESS_KEY: ${{ secrets.DEVELOCITY_ACCESS_KEY }}
     steps:
       - uses: actions/checkout@v6
         with:

--- a/.github/workflows/gradle-publish-snapshots.yml
+++ b/.github/workflows/gradle-publish-snapshots.yml
@@ -3,6 +3,9 @@ on: [ workflow_call ]
 jobs:
   build:
     runs-on: ubuntu-latest
+    env:
+      # Authenticates Build Scan publishing to community.develocity.cloud.
+      DEVELOCITY_ACCESS_KEY: ${{ secrets.DEVELOCITY_ACCESS_KEY }}
     steps:
       - uses: actions/checkout@v6
         with:

--- a/.github/workflows/gradle-release.yml
+++ b/.github/workflows/gradle-release.yml
@@ -13,6 +13,9 @@ permissions:
 jobs:
   release:
     runs-on: ubuntu-latest
+    env:
+      # Authenticates Build Scan publishing to community.develocity.cloud.
+      DEVELOCITY_ACCESS_KEY: ${{ secrets.DEVELOCITY_ACCESS_KEY }}
     steps:
       - uses: actions/checkout@v6
         with:

--- a/gradle/plugins/build-parameters/build.gradle.kts
+++ b/gradle/plugins/build-parameters/build.gradle.kts
@@ -42,9 +42,6 @@ buildParameters {
         bool("alwaysPublish") {
             defaultValue = false
         }
-        bool("scansGradleComTermsAgree") {
-            defaultValue = false
-        }
     }
 
     group("browserTest") {

--- a/gradle/plugins/src/main/kotlin/build.build-scan.gradle.kts
+++ b/gradle/plugins/src/main/kotlin/build.build-scan.gradle.kts
@@ -24,13 +24,13 @@ plugins {
 project.afterEvaluate {
     project.the<DevelocityConfiguration>().run {
         buildScan {
-            if (buildParameters.ci || buildParameters.buildScans.scansGradleComTermsAgree) {
-                termsOfUseUrl = "https://gradle.com/help/legal-terms-of-use"
-                termsOfUseAgree = "yes"
-            }
-
+            // Build Scans are published to community.develocity.cloud (server configured in
+            // settings.gradle.kts), which requires an authenticated connection. Publish on CI
+            // or when locally opted in via buildScans.alwaysPublish, but only when an access
+            // key is present, so unauthenticated builds (e.g. fork PRs) skip publishing
+            // cleanly rather than failing.
             publishing {
-                onlyIf { buildParameters.ci || buildParameters.buildScans.alwaysPublish }
+                onlyIf { it.isAuthenticated && (buildParameters.ci || buildParameters.buildScans.alwaysPublish) }
             }
             uploadInBackground = !buildParameters.ci
         }

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -11,6 +11,11 @@ plugins {
     id("org.gradle.toolchains.foojay-resolver-convention") version "1.0.0"
 }
 
+develocity {
+    server = "https://community.develocity.cloud"
+    projectId = "tomdcc"
+}
+
 includeBuild("gradle/plugins")
 
 include("core")


### PR DESCRIPTION
Switches Build Scan publishing from the default `scans.gradle.com` to the `community.develocity.cloud` Develocity instance, for both personal workstations and CI.

## Changes

- **`settings.gradle.kts`** — add a `develocity { }` block setting `server = "https://community.develocity.cloud"` and `projectId = "tomdcc"`. The community instance *requires* a projectId; publishing is rejected without one.
- **`build.build-scan.gradle.kts`** — remove the `termsOfUseUrl`/`termsOfUseAgree` agreement (only applies to the public scans.gradle.com service, not a Develocity server), and gate publishing on `isAuthenticated` in addition to the existing `ci`/`alwaysPublish` opt-in. The community instance rejects unauthenticated publishes, so this makes unauthenticated builds (e.g. fork PRs) skip publishing cleanly instead of failing.
- **`build-parameters/build.gradle.kts`** — drop the now-obsolete `scansGradleComTermsAgree` parameter (`alwaysPublish` is retained).
- **CI workflows** — provide `DEVELOCITY_ACCESS_KEY` to the build, snapshot-publish and release jobs, and `secrets: inherit` in the reusable build workflow's callers.

## Setup (out of band)

- `DEVELOCITY_ACCESS_KEY` repo secret added in GitHub.
- Access keys provisioned locally via `provisionDevelocityAccessKey`.

Verified locally: a build with `-Pbuild.buildScans.alwaysPublish=true` and a provisioned key publishes successfully to community.develocity.cloud, and `gain check` passes (636 tests).