### PR TITLE
Exclude upstream Gradle wrapper files from copyright checks

### DIFF
--- a/gradle/plugins/src/main/kotlin/CopyrightTask.kt
+++ b/gradle/plugins/src/main/kotlin/CopyrightTask.kt
@@ -60,6 +60,13 @@ abstract class CopyrightTask : DefaultTask() {
     @get:Internal
     abstract val excludedDirectories: ListProperty<File>
 
+    /** Repo-relative (forward-slash) paths to leave untouched even when they carry a matching
+     *  header. An entry matches a file that equals it or lies under it, so both individual files
+     *  (`gradlew.bat`) and whole directories (`gradle/wrapper`) work. Used to keep upstream-owned
+     *  files such as the Gradle wrapper scripts pristine. */
+    @get:Internal
+    abstract val excludedPaths: ListProperty<String>
+
     /** When true, only the end (last) year is checked: a file is treated as out of date solely
      *  when its declared end year is behind the latest substantive commit. The start year is
      *  preserved as written. Intended for shallow CI clones where the file's true first commit
@@ -82,7 +89,8 @@ abstract class CopyrightTask : DefaultTask() {
     fun run() {
         val repoRoot = repositoryRoot.get().asFile
         val scanPrefix = repoRoot.relativeRepoPath(scanDirectory.get().asFile)
-        val excludedPrefixes = excludedDirectories.get().map { repoRoot.relativeRepoPath(it) }
+        val excludedPrefixes = excludedDirectories.get().map { repoRoot.relativeRepoPath(it) } +
+            excludedPaths.get()
 
         val tracked = CopyrightGit.run(repoRoot, listOf("ls-files"))
             .lineSequence()

--- a/gradle/plugins/src/main/kotlin/build.copyright.gradle.kts
+++ b/gradle/plugins/src/main/kotlin/build.copyright.gradle.kts
@@ -41,12 +41,18 @@ val descendantProjectDirs = provider {
         .toList()
 }
 
+// Upstream-owned files that must stay byte-for-byte identical to what Gradle ships. They happen to
+// carry the "the original author or authors" header the scanner keys on, but their years belong to
+// Gradle, not this project, so they must never be rewritten or flagged.
+val upstreamWrapperPaths = listOf("gradlew", "gradlew.bat", "gradle/wrapper")
+
 tasks.register<UpdateCopyrightTask>("updateCopyright") {
     group = "documentation"
     description = "Updates file-header copyright years from git history for this project's directory."
     repositoryRoot.set(rootProject.layout.projectDirectory)
     scanDirectory.set(layout.projectDirectory)
     excludedDirectories.set(descendantProjectDirs)
+    excludedPaths.set(upstreamWrapperPaths)
     notCompatibleWithConfigurationCache("Shells out to git during execution.")
 }
 
@@ -56,6 +62,7 @@ val verifyCopyright = tasks.register<VerifyCopyrightTask>("verifyCopyright") {
     repositoryRoot.set(rootProject.layout.projectDirectory)
     scanDirectory.set(layout.projectDirectory)
     excludedDirectories.set(descendantProjectDirs)
+    excludedPaths.set(upstreamWrapperPaths)
     notCompatibleWithConfigurationCache("Shells out to git during execution.")
 
     val repoRoot = rootProject.projectDir

--- a/gradlew.bat
+++ b/gradlew.bat
@@ -1,5 +1,5 @@
 @rem
-@rem Copyright 2013-2026 the original author or authors.
+@rem Copyright 2015 the original author or authors.
 @rem
 @rem Licensed under the Apache License, Version 2.0 (the "License");
 @rem you may not use this file except in compliance with the License.


### PR DESCRIPTION
## Problem

The `verifyCopyright` task scans every git-tracked file for the `Copyright YYYY the original author or authors` header and bumps the year from git history. Gradle's own `gradlew.bat` ships with exactly that header (`Copyright 2015 the original author or authors`), so it gets picked up by the scanner.

This surfaced on the `renovate/gradle-9.x` PR: Renovate's wrapper update touched `gradlew.bat`, and CI failed with:

```
> Task :verifyCopyright FAILED
1 file(s) have out-of-date copyright years:
  gradlew.bat: Copyright 2015 the original author or authors -> Copyright 2013-2026 the original author or authors
```

The flip side of the same bug: `updateCopyright` had already rewritten the upstream header to `2013-2026` on `main`, leaving the wrapper file non-pristine.

## Fix

- Add an `excludedPaths` property to `CopyrightTask`. Entries are repo-relative and matched with the existing `isUnder` logic, so both individual files (`gradlew.bat`) and directory prefixes (`gradle/wrapper`) work.
- Configure both `updateCopyright` and `verifyCopyright` to exclude the upstream-owned wrapper paths: `gradlew`, `gradlew.bat`, `gradle/wrapper`.
- Restore `gradlew.bat`'s pristine `Copyright 2015` header.

## Verification

- `:verifyCopyright` passes with the pristine `Copyright 2015` header in place (its real substantive range is 2013–2026, so it would be flagged without the exclusion).
- Full `check` passes: 636 tests passed, 0 failed.