### PR TITLE
Fix child-profiler self-save and harden Ratpack profile persistence

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,12 @@
 Changelog
 =========
 
+0.12.2
+---
+- Fix child profilers being saved as independent sessions when stopped (regression from 0.12.1),
+  which caused "this execution has completed" errors in Ratpack forked executions. Child profilers
+  now resolve their command formatter via the parent profiler rather than owning a provider.
+
 0.12.0
 ---
 - Add Jakarta EE support: new jakarta-ee and jakarta-servlet modules

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ Changelog
 - Fix child profilers being saved as independent sessions when stopped (regression from 0.12.1),
   which caused "this execution has completed" errors in Ratpack forked executions. Child profilers
   now resolve their command formatter via the parent profiler rather than owning a provider.
+- Ratpack: persist profiles reliably when a profiler is stopped without a usable execution &mdash; on a
+  plain (non-Ratpack) thread, or from an execution's completion handler after it has finished.
+  `RatpackContextProfilerProvider` now forks a fresh execution to run the save in those cases; it takes
+  an `ExecController` (injected by `MiniProfilerModule`).
 
 0.12.0
 ---

--- a/core/src/main/java/io/jdev/miniprofiler/internal/ProfilerImpl.java
+++ b/core/src/main/java/io/jdev/miniprofiler/internal/ProfilerImpl.java
@@ -60,9 +60,15 @@ public class ProfilerImpl implements Profiler, Serializable, Jsonable {
     private List<ClientTiming> clientTimings;
     private volatile Map<String, String> customLinks;
     private final ProfilerProvider profilerProvider;
+    // Set for child profilers (created via TimingImpl.addChildProfiler) so that command formatting
+    // can resolve the provider without the child owning a lifecycle provider of its own. Null for roots.
+    private final ProfilerImpl parentProfiler;
 
     ProfilerProvider getProfilerProvider() {
-        return profilerProvider;
+        if (profilerProvider != null) {
+            return profilerProvider;
+        }
+        return parentProfiler != null ? parentProfiler.getProfilerProvider() : null;
     }
 
     /**
@@ -109,7 +115,8 @@ public class ProfilerImpl implements Profiler, Serializable, Jsonable {
     }
 
     private ProfilerImpl(UUID id, String name, long started, String machineName, ProfileLevel level,
-                         TimingImpl root, TimingInternal head, boolean stopped, ProfilerProvider profilerProvider) {
+                         TimingImpl root, TimingInternal head, boolean stopped, ProfilerProvider profilerProvider,
+                         ProfilerImpl parentProfiler) {
         this.id = id;
         this.name = name;
         this.started = started;
@@ -119,6 +126,7 @@ public class ProfilerImpl implements Profiler, Serializable, Jsonable {
         this.head = head;
         this.stopped = stopped;
         this.profilerProvider = profilerProvider;
+        this.parentProfiler = parentProfiler;
     }
 
     /**
@@ -141,23 +149,25 @@ public class ProfilerImpl implements Profiler, Serializable, Jsonable {
      * @param profilerProvider the profiler provider constructing the
      */
     public ProfilerImpl(UUID id, String name, String rootName, ProfileLevel level, ProfilerProvider profilerProvider) {
-        this(id != null ? id : UUID.randomUUID(), name, System.currentTimeMillis(), null, level, null, null, false, profilerProvider);
+        this(id != null ? id : UUID.randomUUID(), name, System.currentTimeMillis(), null, level, null, null, false, profilerProvider, null);
         root = new TimingImpl(this, null, rootName);
         head = root;
     }
 
     /**
-     * Used to add a child profiler.
+     * Used to add a child profiler. The child does not own a lifecycle provider (so stopping it does not
+     * notify or save to any provider); it keeps a reference to the parent profiler purely so that command
+     * formatting can resolve a {@link io.jdev.miniprofiler.format.CommandFormatter} via {@link #getProfilerProvider()}.
      */
-    ProfilerImpl(String rootName, ProfileLevel level, long started, ProfilerProvider profilerProvider) {
-        this(null, rootName, started, null, level, null, null, false, profilerProvider);
+    ProfilerImpl(String rootName, ProfileLevel level, long started, ProfilerImpl parentProfiler) {
+        this(null, rootName, started, null, level, null, null, false, null, parentProfiler);
         root = new TimingImpl(this, null, rootName);
         head = root;
     }
 
     // Deserialization constructor — does not create a root timing or set head
     ProfilerImpl(UUID id, String name, long started, String machineName, ProfileLevel level) {
-        this(id, name, started, machineName, level, null, null, true, null);
+        this(id, name, started, machineName, level, null, null, true, null, null);
     }
 
     /**

--- a/core/src/main/java/io/jdev/miniprofiler/internal/TimingImpl.java
+++ b/core/src/main/java/io/jdev/miniprofiler/internal/TimingImpl.java
@@ -262,7 +262,7 @@ public class TimingImpl implements TimingInternal, Serializable, Jsonable {
         if (childProfilers == null) {
             childProfilers = new ArrayList<Profiler>();
         }
-        ProfilerImpl child = new ProfilerImpl("\u2443 " + name, profiler.getLevel(), profiler.getStarted(), profiler.getProfilerProvider());
+        ProfilerImpl child = new ProfilerImpl("\u2443 " + name, profiler.getLevel(), profiler.getStarted(), profiler);
         childProfilers.add(child);
         return child;
     }

--- a/core/src/test/groovy/io/jdev/miniprofiler/internal/ProfilerImplSpec.groovy
+++ b/core/src/test/groovy/io/jdev/miniprofiler/internal/ProfilerImplSpec.groovy
@@ -18,6 +18,7 @@ package io.jdev.miniprofiler.internal
 
 import com.fasterxml.jackson.databind.ObjectMapper
 import io.jdev.miniprofiler.ProfileLevel
+import io.jdev.miniprofiler.ProfilerProvider
 import io.jdev.miniprofiler.test.TestProfilerProvider
 import spock.lang.Specification
 
@@ -230,12 +231,37 @@ class ProfilerImplSpec extends Specification {
         !parsed.has('Root')
     }
 
-    void "child profiler inherits parent's profiler provider"() {
+    void "child profiler resolves the parent's provider for command formatting"() {
         when:
         def child = profiler.addChild('child') as ProfilerImpl
 
+        then: 'the child can reach a provider (so custom-timing formatting does not NPE)'
+        child.getProfilerProvider() == profiler.getProfilerProvider()
+    }
+
+    void "stopping a child profiler does not notify or save to the provider"() {
+        given:
+        def provider = Mock(ProfilerProvider)
+        def root = new ProfilerImpl('root', ProfileLevel.Info, provider)
+        def child = root.addChild('child')
+
+        when:
+        child.stop()
+
+        then: 'child profilers are part of their parent and must never trigger a session save'
+        0 * provider.stopSession(_, _)
+    }
+
+    void "stopping the root profiler notifies the provider"() {
+        given:
+        def provider = Mock(ProfilerProvider)
+        def root = new ProfilerImpl('root', ProfileLevel.Info, provider)
+
+        when:
+        root.stop()
+
         then:
-        child.profilerProvider == profiler.profilerProvider
+        1 * provider.stopSession(root, false)
     }
 
     void "asUiJson on parent succeeds when child profiler has custom timings"() {

--- a/ratpack/src/main/java/io/jdev/miniprofiler/ratpack/MiniProfilerModule.java
+++ b/ratpack/src/main/java/io/jdev/miniprofiler/ratpack/MiniProfilerModule.java
@@ -25,6 +25,7 @@ import com.google.inject.multibindings.ProvidesIntoSet;
 import io.jdev.miniprofiler.MiniProfiler;
 import io.jdev.miniprofiler.ProfilerProvider;
 import io.jdev.miniprofiler.ProfilerUiConfig;
+import ratpack.exec.ExecController;
 import ratpack.exec.ExecInitializer;
 import ratpack.guice.ConfigurableModule;
 
@@ -152,15 +153,17 @@ public class MiniProfilerModule extends ConfigurableModule<MiniProfilerModule.Co
 
     private static class ProviderProvider implements Provider<RatpackContextProfilerProvider> {
         private final Config config;
+        private final ExecController execController;
 
         @Inject
-        private ProviderProvider(Config config) {
+        private ProviderProvider(Config config, ExecController execController) {
             this.config = config;
+            this.execController = execController;
         }
 
         @Override
         public RatpackContextProfilerProvider get() {
-            RatpackContextProfilerProvider provider = new RatpackContextProfilerProvider();
+            RatpackContextProfilerProvider provider = new RatpackContextProfilerProvider(execController);
             provider.setUiConfig(config.uiConfig);
             return provider;
         }

--- a/ratpack/src/main/java/io/jdev/miniprofiler/ratpack/RatpackContextProfilerProvider.java
+++ b/ratpack/src/main/java/io/jdev/miniprofiler/ratpack/RatpackContextProfilerProvider.java
@@ -19,9 +19,12 @@ package io.jdev.miniprofiler.ratpack;
 import io.jdev.miniprofiler.BaseProfilerProvider;
 import io.jdev.miniprofiler.Profiler;
 import io.jdev.miniprofiler.internal.ProfilerImpl;
+import ratpack.exec.ExecController;
 import ratpack.exec.Execution;
+import ratpack.exec.ExecutionException;
 import ratpack.exec.Operation;
 
+import java.util.Objects;
 import java.util.Optional;
 
 /**
@@ -31,8 +34,21 @@ import java.util.Optional;
  */
 public class RatpackContextProfilerProvider extends BaseProfilerProvider {
 
-    /** Default constructor. */
-    public RatpackContextProfilerProvider() {}
+    private final ExecController execController;
+
+    /**
+     * Constructs the provider with the {@link ExecController} used to persist profiles.
+     *
+     * <p>The controller is used to fork a fresh {@link Execution} for the (asynchronous) save when a profiler
+     * is stopped outside of a managed Ratpack execution &mdash; for example on a plain thread-pool thread or in
+     * an execution's completion handler. A Ratpack application always has an {@code ExecController} available;
+     * inject it (e.g. via Guice) and pass it here.</p>
+     *
+     * @param execController the exec controller to fork a save execution from when needed; must not be null
+     */
+    public RatpackContextProfilerProvider(ExecController execController) {
+        this.execController = Objects.requireNonNull(execController, "execController");
+    }
 
     /**
      * Adds the given rofiler to the current {@link Execution}.
@@ -58,15 +74,31 @@ public class RatpackContextProfilerProvider extends BaseProfilerProvider {
 
     @Override
     protected void saveProfiler(ProfilerImpl currentProfiler) {
+        if (Execution.isManagedThread()) {
+            try {
+                // On a live execution: bind the save to it, so it is persisted in order with the rest of
+                // the execution (e.g. before the request finishes and the UI fetches the result).
+                saveOperation(currentProfiler).then();
+                return;
+            } catch (ExecutionException e) {
+                // Managed thread, but the current execution has already completed (e.g. we are being
+                // called from its completion handler) and can no longer accept a promise. Fall through
+                // to fork a fresh execution below.
+            }
+        }
+        // Either not on a managed thread at all, or the current execution has completed. Fork a fresh
+        // execution to run the save, otherwise it would be silently lost.
+        execController.fork().start(execution -> saveOperation(currentProfiler).then());
+    }
+
+    private Operation saveOperation(ProfilerImpl currentProfiler) {
         String user = currentProfiler.getUser();
         AsyncStorage asyncStorage = AsyncStorage.adapt(getStorage());
         if (user != null) {
-            asyncStorage.saveAsync(currentProfiler)
-                .next(asyncStorage.setUnviewedAsync(user, currentProfiler.getId()))
-                .then();
-        } else {
-            asyncStorage.saveAsync(currentProfiler).then();
+            return asyncStorage.saveAsync(currentProfiler)
+                .next(asyncStorage.setUnviewedAsync(user, currentProfiler.getId()));
         }
+        return asyncStorage.saveAsync(currentProfiler);
     }
 
     /**

--- a/ratpack/src/test/groovy/io/jdev/miniprofiler/ratpack/MiniProfilerModuleShutdownSpec.groovy
+++ b/ratpack/src/test/groovy/io/jdev/miniprofiler/ratpack/MiniProfilerModuleShutdownSpec.groovy
@@ -20,6 +20,7 @@ import com.google.inject.Provides
 import com.google.inject.Singleton
 import io.jdev.miniprofiler.ProfilerProvider
 import io.jdev.miniprofiler.storage.MapStorage
+import ratpack.exec.ExecController
 import ratpack.groovy.test.embed.GroovyEmbeddedApp
 import ratpack.guice.Guice
 import spock.lang.Specification
@@ -68,8 +69,8 @@ class MiniProfilerModuleShutdownSpec extends Specification {
 
         @Provides
         @Singleton
-        RatpackContextProfilerProvider ratpackProvider() {
-            def provider = new RatpackContextProfilerProvider()
+        RatpackContextProfilerProvider ratpackProvider(ExecController execController) {
+            def provider = new RatpackContextProfilerProvider(execController)
             provider.storage = trackingStorage
             return provider
         }

--- a/ratpack/src/test/groovy/io/jdev/miniprofiler/ratpack/MiniProfilerRatpackUtilSpec.groovy
+++ b/ratpack/src/test/groovy/io/jdev/miniprofiler/ratpack/MiniProfilerRatpackUtilSpec.groovy
@@ -23,6 +23,7 @@ import io.jdev.miniprofiler.internal.NullProfiler
 import io.jdev.miniprofiler.internal.ProfilerImpl
 import io.jdev.miniprofiler.test.TestProfilerProvider
 import ratpack.exec.Blocking
+import ratpack.exec.ExecController
 import ratpack.exec.ExecInitializer
 import ratpack.exec.Execution
 import ratpack.exec.Promise
@@ -41,6 +42,9 @@ class MiniProfilerRatpackUtilSpec extends Specification {
     def polling = new PollingConditions()
 
     def provider = new TestProfilerProvider()
+
+    @AutoCleanup
+    ExecController execController = ExecController.builder().build()
 
     @AutoCleanup
     ApplicationUnderTest app
@@ -106,7 +110,7 @@ class MiniProfilerRatpackUtilSpec extends Specification {
 
     void "can attach child profilers on fork"() {
         given:
-        def provider = new RatpackContextProfilerProvider()
+        def provider = new RatpackContextProfilerProvider(execController)
 
         and: "handler with initializer on handler which forks execution"
         def profiler
@@ -157,7 +161,7 @@ class MiniProfilerRatpackUtilSpec extends Specification {
 
     void "can attach child profilers on fork with composed exec starter"() {
         given:
-        def provider = new RatpackContextProfilerProvider()
+        def provider = new RatpackContextProfilerProvider(execController)
 
         and: "handler with initializer on handler which forks execution"
         def profiler
@@ -214,7 +218,7 @@ class MiniProfilerRatpackUtilSpec extends Specification {
     void "forked child profilers are not saved to the provider on completion"() {
         given: 'a provider that records which profilers it is asked to save'
         def savedNames = new CopyOnWriteArrayList<String>()
-        def provider = new RatpackContextProfilerProvider() {
+        def provider = new RatpackContextProfilerProvider(execController) {
             @Override
             protected void saveProfiler(ProfilerImpl currentProfiler) {
                 savedNames << currentProfiler.name

--- a/ratpack/src/test/groovy/io/jdev/miniprofiler/ratpack/MiniProfilerRatpackUtilSpec.groovy
+++ b/ratpack/src/test/groovy/io/jdev/miniprofiler/ratpack/MiniProfilerRatpackUtilSpec.groovy
@@ -34,6 +34,8 @@ import spock.lang.AutoCleanup
 import spock.lang.Specification
 import spock.util.concurrent.PollingConditions
 
+import java.util.concurrent.CopyOnWriteArrayList
+
 class MiniProfilerRatpackUtilSpec extends Specification {
 
     def polling = new PollingConditions()
@@ -207,5 +209,59 @@ class MiniProfilerRatpackUtilSpec extends Specification {
 
         and: 'composed onStart called'
         composedOnStartCalled
+    }
+
+    void "forked child profilers are not saved to the provider on completion"() {
+        given: 'a provider that records which profilers it is asked to save'
+        def savedNames = new CopyOnWriteArrayList<String>()
+        def provider = new RatpackContextProfilerProvider() {
+            @Override
+            protected void saveProfiler(ProfilerImpl currentProfiler) {
+                savedNames << currentProfiler.name
+                super.saveProfiler(currentProfiler)
+            }
+        }
+
+        and: "a handler which forks an execution with a child profiler"
+        def profiler
+        app = GroovyEmbeddedApp.of {
+            registryOf {
+                add(ProfilerProvider, provider)
+                add(ExecInitializer, new MiniProfilerExecInitializer(provider))
+            }
+            handlers {
+                all(new MiniProfilerStartProfilingHandler(provider))
+                get { ctx ->
+                    profiler = provider.current
+                    provider.current.step('handler') {
+                        MiniProfilerRatpackUtil.forkChildProfiler(Execution.fork(), "forked execution").start { execution ->
+                            provider.current.step('forked') {
+                            }
+                        }
+                    }
+                    Blocking.op {
+                        // give some time for the forked exec to finish (and, pre-fix, to try to save its child)
+                        Thread.sleep(100)
+                    }.then {
+                        ctx.render("ok")
+                    }
+                }
+            }
+        }
+
+        when:
+        def response = app.httpClient.get()
+
+        then:
+        response.status.'2xx'
+        polling.eventually {
+            profiler.stopped
+        }
+
+        and: 'the request root profiler is saved, but the forked (context-less) child profiler never is'
+        polling.eventually {
+            !savedNames.isEmpty()
+        }
+        savedNames.every { !it.startsWith('⑃') }
     }
 }

--- a/ratpack/src/test/groovy/io/jdev/miniprofiler/ratpack/RatpackContextProfilerProviderSpec.groovy
+++ b/ratpack/src/test/groovy/io/jdev/miniprofiler/ratpack/RatpackContextProfilerProviderSpec.groovy
@@ -1,0 +1,81 @@
+/*
+ * Copyright 2026 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.jdev.miniprofiler.ratpack
+
+import io.jdev.miniprofiler.ProfileLevel
+import io.jdev.miniprofiler.internal.ProfilerImpl
+import io.jdev.miniprofiler.storage.MapStorage
+import ratpack.exec.ExecController
+import ratpack.test.exec.ExecHarness
+import spock.lang.AutoCleanup
+import spock.lang.Specification
+import spock.util.concurrent.PollingConditions
+
+class RatpackContextProfilerProviderSpec extends Specification {
+
+    @AutoCleanup
+    ExecController execController = ExecController.builder().build()
+
+    def polling = new PollingConditions(timeout: 5)
+
+    void "constructor requires an ExecController"() {
+        when:
+        new RatpackContextProfilerProvider(null)
+
+        then:
+        thrown(NullPointerException)
+    }
+
+    void "profiler stopped outside of an execution is still saved, via a forked execution"() {
+        given:
+        def storage = new MapStorage()
+        def provider = new RatpackContextProfilerProvider(execController)
+        provider.storage = storage
+
+        and: 'a profiler bound to the provider'
+        def id = UUID.randomUUID()
+        def profiler = new ProfilerImpl(id, 'root', 'root', ProfileLevel.Info, provider)
+
+        when: 'stopped on the test thread, i.e. not on a managed Ratpack execution'
+        profiler.stop()
+
+        then: 'the async save still runs (the provider forked an execution to do it)'
+        polling.eventually {
+            storage.load(id) != null
+        }
+    }
+
+    void "profiler stopped when its execution has already completed is still saved"() {
+        given:
+        def storage = new MapStorage()
+        def provider = new RatpackContextProfilerProvider(execController)
+        provider.storage = storage
+
+        and: 'the initializer stops the profiler in the execution completion, where the execution can no longer take promises'
+        UUID id = null
+
+        when: 'a context-less execution with a bound profiler completes'
+        ExecHarness.runSingle({ it.add(new MiniProfilerExecInitializer(provider)) }) { execution ->
+            id = (provider.start('root') as ProfilerImpl).id
+        }
+
+        then: 'the save is recovered onto a forked execution rather than lost to "this execution has completed"'
+        polling.eventually {
+            storage.load(id) != null
+        }
+    }
+}

--- a/ratpack/src/test/groovy/io/jdev/miniprofiler/ratpack/RatpackIntegSpec.groovy
+++ b/ratpack/src/test/groovy/io/jdev/miniprofiler/ratpack/RatpackIntegSpec.groovy
@@ -21,17 +21,22 @@ import io.jdev.miniprofiler.Profiler
 import io.jdev.miniprofiler.ProfilerProvider
 import io.jdev.miniprofiler.internal.ProfilerImpl
 import ratpack.exec.Blocking
+import ratpack.exec.ExecController
 import ratpack.func.Action
 import ratpack.handling.Chain
 import ratpack.handling.Context
 import ratpack.handling.Handler
 import ratpack.handling.RequestId
+import spock.lang.AutoCleanup
 import spock.lang.Ignore
 import spock.lang.Specification
 
 import static ratpack.groovy.test.handling.GroovyRequestFixture.handle
 
 class RatpackIntegSpec extends Specification {
+
+    @AutoCleanup
+    ExecController execController = ExecController.builder().build()
 
     void cleanup() {
         MiniProfiler.setProfilerProvider(null)
@@ -40,7 +45,7 @@ class RatpackIntegSpec extends Specification {
     @Ignore("See https://github.com/ratpack/ratpack/issues/1110 - relying on integ-test/ratpack in the meantime")
     void "profiler is bound to current execution context and is available statically"() {
         given: 'provider and interceptor'
-        RatpackContextProfilerProvider provider = new RatpackContextProfilerProvider()
+        RatpackContextProfilerProvider provider = new RatpackContextProfilerProvider(execController)
         MiniProfilerExecInitializer interceptor = new MiniProfilerExecInitializer(provider)
         MiniProfiler.setProfilerProvider(provider)
 
@@ -76,7 +81,7 @@ class RatpackIntegSpec extends Specification {
 
     void "profiler id can be a uuid-formatted request id"() {
         given: 'provider and interceptor'
-        RatpackContextProfilerProvider provider = new RatpackContextProfilerProvider()
+        RatpackContextProfilerProvider provider = new RatpackContextProfilerProvider(execController)
         MiniProfiler.setProfilerProvider(provider)
         def id = UUID.randomUUID()
 

--- a/ratpack/src/test/groovy/io/jdev/miniprofiler/ratpack/RatpackIntegSpec.groovy
+++ b/ratpack/src/test/groovy/io/jdev/miniprofiler/ratpack/RatpackIntegSpec.groovy
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015-2018 the original author or authors.
+ * Copyright 2015-2026 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.


### PR DESCRIPTION
Fixes #201.

Two related fixes to how the Ratpack integration persists profiles, both about `saveProfiler` running without a usable execution.

## 1. Child profilers no longer self-save on stop (the #201 regression)

Since 0.12.1, `TimingImpl.addChildProfiler` propagated the parent's `ProfilerProvider` into child profilers (to fix an NPE resolving a `CommandFormatter` for child custom timings). But `ProfilerImpl.stop()` only skips `stopSession()`/`saveProfiler()` when the provider is `null` — so children began saving themselves as independent top-level sessions. In Ratpack this failed on every forked (context-less) execution with `ExecutionException: this execution has completed`, once per profiled execution.

Fix: child profilers keep a reference to their **parent profiler** instead of owning a provider. `getProfilerProvider()` resolves up the parent chain (keeping the formatter NPE fixed), while `stop()` sees a `null` provider on the child and no longer saves it.

## 2. `saveProfiler` recovers when there is no live execution

`RatpackContextProfilerProvider.saveProfiler` binds an async operation to the current execution (`...saveAsync(...).then()`), which silently loses the save whenever a profiler is stopped without a usable execution:

- on a plain, non-Ratpack thread → `UnmanagedThreadException`
- from an execution's completion handler after it has finished → `ExecutionException` (this runs on a managed compute thread, so an `isManagedThread()` check alone does not catch it — confirmed empirically)

Fix: `saveProfiler` runs the save on the current execution when it can, and otherwise forks a fresh execution from an injected `ExecController` to run it. The controller is now required — the sole constructor takes it (`Objects.requireNonNull`) and `MiniProfilerModule` injects it.

This is a safety net independent of fix #1: with the `ExecutionException` catch, the completion-handler path is recovered even for a root profiler.

## Compatibility note

`RatpackContextProfilerProvider`'s no-arg constructor is removed in favour of a single `ExecController` constructor. Subclasses/wirings that constructed it directly (e.g. a custom provider) must pass an `ExecController` — always available in a Ratpack application.
